### PR TITLE
Change ABCMeta iterable to typing

### DIFF
--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1,13 +1,11 @@
 """ Defines LiquidHandler class, the coordinator for liquid handling operations. """
-
-from collections.abc import Iterable
 import functools
 import inspect
 import json
 import logging
 import numbers
 import time
-from typing import Union, Optional, List, Callable
+from typing import Union, Optional, List, Callable, Iterable
 
 import pylabrobot.utils.file_parsing as file_parser
 from pylabrobot.liquid_handling.resources.abstract import Deck


### PR DESCRIPTION
Currently, when I try to import the `LiquidHandler` class, I get the following error:

```bash
Traceback (most recent call last):
  File "simulate.py", line 1, in <module>
    from pylabrobot.liquid_handling import LiquidHandler
  File "/Users/Kobi/Documents/Research/phd_code/other/pylabrobot/pylabrobot/liquid_handling/__init__.py", line 4, in <module>
    from .liquid_handler import LiquidHandler
  File "/Users/Kobi/Documents/Research/phd_code/other/pylabrobot/pylabrobot/liquid_handling/liquid_handler.py", line 39, in <module>
    class LiquidHandler:
  File "/Users/Kobi/Documents/Research/phd_code/other/pylabrobot/pylabrobot/liquid_handling/liquid_handler.py", line 514, in LiquidHandler
    wells: Iterable[Well],
TypeError: 'ABCMeta' object is not subscriptable
```

This PR creates a fix by switching to the `Iterable` type from typing.