### PR TITLE
Iswap state

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,7 +32,7 @@ dependencies. Also using pip:
 
 ```bash
 pip install pylabrobot[docs]
-pip install pylabrobot[tests]
+pip install pylabrobot[testing]
 ```
 
 There's a multitude of other optional dependencies that you can install. Replace `[docs]` with one of the following items to install the desired dependencies.

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
     extras_require={
         'testing': extras_testing,
         'docs': extras_docs,
+        'fw': extras_fw,
         'simulation': extras_simulation,
         'http': extras_http,
         'websockets': extras_websockets,


### PR DESCRIPTION
Hi there!
I discussed with Rick that we should keep track of the iSWAP state in the star class before calling methods that need the iSWAP to be parked.

A couple of questions/comments:
- I guess the `need_iswap_parked` wrapper should not be where it is, would it make sense to add it to STAR_helpers.py module?
- I wasn't sure if I should be using the `request_iswap_in_parking_position` or the `park_iswap function`.
- When setting up the environment on a Linux machine, it's not possible to install pywin==32, I think you would want a `platform_system` in setup.py?

Please let me know what you think, and thanks for setting this project up! I would love to be a part of it if necessary