### PR TITLE
Fix tip length for high volume no filter tips

### DIFF
--- a/pylabrobot/liquid_handling/resources/ml_star/tip_types.py
+++ b/pylabrobot/liquid_handling/resources/ml_star/tip_types.py
@@ -66,7 +66,7 @@ low_volume_tip_with_filter = TipType(
 #: High volume tip without a filter (`tt04` in venus)
 high_volume_tip_no_filter = TipType(
   has_filter=False,
-  total_tip_length=59.9,
+  total_tip_length=95.1,
   maximal_volume=1000,
   tip_type_id=TIP_TYPE_HIGH_VOLUME,
   pick_up_method=0


### PR DESCRIPTION
Hi all, thanks for this package! 

After testing, it seems like the current tip height for non-filtered high-volume tips was copied from the standard tips and is not correct, as it should be 95.1 (the same as the filtered high-volume tips). This PR updates the value to the correct length.