### PR TITLE
Increase command timeout for STAR

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -309,7 +309,7 @@ class HamiltonLiquidHandler(LiquidHandlerBackend, metaclass=ABCMeta):
     self,
     module: str,
     command: str,
-    timeout: int = 16,
+    timeout: int = 100,
     fmt: typing.Optional[str]=None,
     wait = True,
     **kwargs


### PR DESCRIPTION
Testing on the latest commit, it seems like the timeout for the STAR commands is too small. Right now, it will timeout during setup for example, or any other long running command like serial aspirations. The increased value here is enough to allow `setup` to complete successfully, but there should probably be a better heuristic here for commands that might take even longer than 100 s (which is definitely a possibility with low flow rates, high volumes, multiple moves etc).