### PR TITLE
Add missing await to super setup for STAR

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -565,7 +565,7 @@ class STAR(HamiltonLiquidHandler):
     Creates a USB connection and finds read/write interfaces.
     """
 
-    super().setup()
+    await super().setup()
 
     tip_presences = await self.request_tip_presence()
     self._num_channels = len(tip_presences)


### PR DESCRIPTION
The asyncio refactor looks great!

There is a missing await in STAR.setup, which is preventing initialization. This PR fixes that.