### PR TITLE
Always eject tips in trash during STAR setup

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -593,7 +593,7 @@ class STAR(HamiltonLiquidHandler):
       y_positions = [4050 - i * dy for i in range(self.num_channels)]
 
       await self.initialize_pipetting_channels(
-        x_positions=[8000],
+        x_positions=[extended_conf['xw']],  # Tip eject waste X position.
         y_positions=y_positions,
         begin_of_tip_deposit_process=2450,
         end_of_tip_deposit_process=1220,

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -593,7 +593,7 @@ class STAR(HamiltonLiquidHandler):
       y_positions = [4050 - i * dy for i in range(self.num_channels)]
 
       await self.initialize_pipetting_channels(
-        x_positions=[extended_conf['xw']],  # Tip eject waste X position.
+        x_positions=[extended_conf["xw"]],  # Tip eject waste X position.
         y_positions=y_positions,
         begin_of_tip_deposit_process=2450,
         end_of_tip_deposit_process=1220,


### PR DESCRIPTION
Currently, on `setup` the STAR will eject tips in the waste position for the STARlet (which is in the middle of the deck). This PR updates the setup to use the `xw` parameter from the extended machine configuration to avoid hard-coding the trash location. This will have the robot discard tips in the correct spot for both STAR and STARlet robots.