### PR TITLE
Fix error handling for asyncio

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -498,11 +498,15 @@ class HamiltonLiquidHandler(USBBackend, metaclass=ABCMeta):
 
       for id_, (loop, fut, cmd, fmt, timeout_time) in self._waiting_tasks.items():
         if "id" in parsed_response and f"{parsed_response['id']:04}" == id_:
-          parsed = self.parse_response(resp, fmt)
-          if fmt is not None and fmt != "":
-            loop.call_soon_threadsafe(fut.set_result, parsed)
+          try:
+            parsed = self.parse_response(resp, fmt)
+          except HamiltonFirmwareError as e:
+            loop.call_soon_threadsafe(fut.set_exception, e)
           else:
-            loop.call_soon_threadsafe(fut.set_result, resp)
+            if fmt is not None and fmt != "":
+              loop.call_soon_threadsafe(fut.set_result, parsed)
+            else:
+              loop.call_soon_threadsafe(fut.set_result, resp)
           del self._waiting_tasks[id_]
           break
 


### PR DESCRIPTION
Currently, if an HamiltonFirmwareError is raised by the `parse_response` in `_continuously_read` (e.g. when the robot fails to pick up tips), the caller hangs, since the future it is awaiting is never set (the handling thread crashes).

This PR updates the error handling in ` _continuously_read` to set the exception for the `fut` so that it is raised the awaiting caller.