### PR TITLE
Add missing `te` parameter to discard_tips (TR)

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -811,6 +811,7 @@ class STAR(HamiltonLiquidHandler):
         begin_tip_deposit_process=int((max_z + max_total_tip_length)*10),
         end_tip_deposit_process=int((max_z + max_tip_length)*10),
         minimum_traverse_height_at_beginning_of_a_command=2450,
+        z_position_at_end_of_a_command=2450,
         discarding_method=drop_method
       )
     except HamiltonFirmwareError as e:

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -2797,6 +2797,7 @@ class STAR(HamiltonLiquidHandler):
     begin_tip_deposit_process: int = 0,
     end_tip_deposit_process: int = 0,
     minimum_traverse_height_at_beginning_of_a_command: int = 3600,
+    z_position_at_end_of_a_command: int = 3600,
     discarding_method: TipDropMethod = TipDropMethod.DROP
   ):
     """ discard tip
@@ -2812,6 +2813,8 @@ class STAR(HamiltonLiquidHandler):
       minimum_traverse_height_at_beginning_of_a_command: Minimum traverse height at beginning of a
           command 0.1mm] (refers to all channels independent of tip pattern parameter 'tm'). Must
           be between 0 and 3600.
+      z-position_at_end_of_a_command: Z-Position at end of a command [0.1mm].
+          Must be between 0 and 3600.
       discarding_method: Pick up method Pick up method. 0 = auto selection (see command TT
           parameter tu) 1 = pick up out of rack. 2 = pick up out of wash liquid (slowly). Must be
           between 0 and 2.
@@ -2828,6 +2831,8 @@ class STAR(HamiltonLiquidHandler):
       "end_tip_deposit_process must be between 0 and 3600"
     assert 0 <= minimum_traverse_height_at_beginning_of_a_command <= 3600, \
       "minimum_traverse_height_at_beginning_of_a_command must be between 0 and 3600"
+    assert 0 <= z_position_at_end_of_a_command <= 3600, \
+      "z_position_at_end_of_a_command must be between 0 and 3600"
 
     return await self.send_command(
       module="C0",
@@ -2840,6 +2845,7 @@ class STAR(HamiltonLiquidHandler):
       tp=begin_tip_deposit_process,
       tz=end_tip_deposit_process,
       th=minimum_traverse_height_at_beginning_of_a_command,
+      te=z_position_at_end_of_a_command,
       ti=discarding_method.value,
     )
 


### PR DESCRIPTION
I ran into an issue with the robot hanging when running `LiquidHandler.return_tips` with channels other than the first few. Here is a simple example for reproducing that issue:

```python3
from pylabrobot.liquid_handling import LiquidHandler
from pylabrobot.liquid_handling.backends import STAR
from pylabrobot.resources.hamilton import STARDeck
from pylabrobot.resources import (
    TIP_CAR_480_A00,
    STF_L
)

backend = STAR()
lh = LiquidHandler(backend=backend, deck=STARDeck())

tip_car = TIP_CAR_480_A00(name='tip carrier')
tip_car[0] = STF_L(name='tips_01')
lh.deck.assign_child_resource(tip_car, rails=3)

tiprack = lh.get_resource("tips_01")
await lh.pick_up_tips(tiprack["A1":"D1"], use_channels=[3,4,5])
await lh.return_tips()
```

The last call to `return_tips` will result in the robot hanging and eventually timing out trying to read a response. On reinitialization, the robot sends an error message for the TR command (err01/31, faulty parameter). I think the issue is the the TR command should have a `te` parameter analogous to the `te` param in ` initialize_pipetting_channels`. When I add the param, the command works as expected.

Weirdly enough, `return_tips` works if I'm not specifying `use_channels`. Not sure why it does not require `te` when only using the first n channels.
