### PR TITLE
Add self-assignment and multiple-parent checks to Resource.assign_child_resource

### DIFF
--- a/pylabrobot/resources/carrier.py
+++ b/pylabrobot/resources/carrier.py
@@ -20,7 +20,12 @@ class CarrierSite(Resource):
     self.resource: Optional[Resource] = None
     self.spot: int = spot
 
-  def assign_child_resource(self, resource: Resource, location: Optional[Coordinate]):
+  def assign_child_resource(
+    self,
+    resource: Resource,
+    location: Optional[Coordinate],
+    reassign: bool = True
+  ):
     self.resource = resource
     return super().assign_child_resource(resource, location=location)
 
@@ -90,12 +95,17 @@ class Carrier(Resource):
       site.name = f"carrier-{self.name}-spot-{site.spot}"
       self.assign_child_resource(site, location=site.location)
 
-  def assign_child_resource(self, resource: Resource, location: Optional[Coordinate]):
+  def assign_child_resource(
+    self,
+    resource: Resource,
+    location: Optional[Coordinate],
+    reassign: bool = True
+  ):
     """ Assign a resource to this carrier.
 
     For a carrier, the only valid resource is a :class:`CarrierSite`.
 
-    Also see :meth:`~Resource.assign_child_resource`
+    Also see :meth:`~Resource.assign_child_resource`.
 
     Raises:
       TypeError: If the resource is not a :class:`CarrierSite`.

--- a/pylabrobot/resources/hamilton/hamilton_decks.py
+++ b/pylabrobot/resources/hamilton/hamilton_decks.py
@@ -78,6 +78,7 @@ class HamiltonDeck(Deck):
     self,
     resource: Resource,
     location: Optional[Coordinate] = None,
+    reassign: bool = False,
     rails: Optional[int] = None,
     replace=False
   ):
@@ -94,13 +95,17 @@ class HamiltonDeck(Deck):
 
     Args:
       resource: A Resource to assign to this liquid handler.
-      rails: The left most real (inclusive) of the deck resource (between and 1-30 for STARLet,
-             max 55 for STAR.) Either rails or location must be None, but not both.
       location: The location of the resource relative to the liquid handler. Either rails or
-                location must be None, but not both.
+        location must be `None`, but not both.
+      reassign: If True, reassign the resource if it is already assigned. If False, raise a
+        `ValueError` if the resource is already assigned.
+      rails: The left most real (inclusive) of the deck resource (between and 1-30 for STARLet,
+        max 55 for STAR.) Either rails or location must be None, but not both.
+      location: The location of the resource relative to the liquid handler. Either rails or
+        location must be None, but not both.
       replace: Replace the resource with the same name that was previously assigned, if it exists.
-               If a resource is assigned with the same name and replace is False, a ValueError
-               will be raised.
+        If a resource is assigned with the same name and replace is False, a ValueError
+        will be raised.
 
     Raises:
       ValueError: If a resource is assigned with the same name and replace is `False`.

--- a/pylabrobot/resources/opentrons/deck.py
+++ b/pylabrobot/resources/opentrons/deck.py
@@ -63,7 +63,12 @@ class OTDeck(Deck):
     trash_container.assign_child_resource(actual_trash, location=Coordinate(x=82.84, y=53.56, z=5))
     self.assign_child_at_slot(trash_container, 12)
 
-  def assign_child_resource(self, resource: Resource, location: Optional[Coordinate]):
+  def assign_child_resource(
+    self,
+    resource: Resource,
+    location: Optional[Coordinate],
+    reassign: bool = True
+  ):
     """ Assign a resource to a slot.
 
     ..warning:: This method exists only for deserialization. You should use

--- a/pylabrobot/resources/plate.py
+++ b/pylabrobot/resources/plate.py
@@ -103,12 +103,17 @@ class Plate(ItemizedResource[Well]):
 
     return self._compute_volume_from_height(height)
 
-  def assign_child_resource(self, resource: Resource, location: Optional[Coordinate]):
+  def assign_child_resource(
+    self,
+    resource: Resource,
+    location: Optional[Coordinate],
+    reassign: bool = True
+  ):
     if isinstance(resource, Lid):
       if self.has_lid():
         raise ValueError(f"Plate '{self.name}' already has a lid.")
       self.lid = resource
-    return super().assign_child_resource(resource, location=location)
+    return super().assign_child_resource(resource, location=location, reassign=reassign)
 
   def unassign_child_resource(self, resource):
     if isinstance(resource, Lid) and self.has_lid():

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -128,7 +128,9 @@ class Resource:
     """ Get the size of this resource in the z-direction. """
     return self._size_z
 
-  def assign_child_resource(self, resource: Resource, location: Optional[Coordinate]):
+  def assign_child_resource(self,
+                            resource: Resource, location: Optional[Coordinate],
+                            reassign: bool = True):
     """ Assign a child resource to this resource.
 
     Will use :meth:`~Resource.resource_assigned_callback` to notify the parent of the assignment,
@@ -137,7 +139,7 @@ class Resource:
     """
 
     # Check for unsupported resource assignment operations
-    self.check_assignment(resource)
+    self.check_assignment(resource, reassign)
 
     resource.parent = self
     resource.location = location
@@ -151,7 +153,7 @@ class Resource:
 
     self.children.append(resource)
 
-  def check_assignment(self, resource: Resource):
+  def check_assignment(self, resource: Resource, reassign: bool = True):
     """Check if the resource assignment produces unsupported or dangerous conflicts.
     """
     msgs = []
@@ -160,8 +162,13 @@ class Resource:
     if resource is self:
       msgs.append(f"Will not assign resource '{self.name}' to itself.")
 
-    # Check for multiple parents
-    if resource.parent is not None:
+    # Check for reassignment to the same parent
+    if resource.parent is not None and (resource.parent is self):
+      msgs.append(f"Will not reassign resource '{resource.name}' " +
+                  f"to the same parent: '{resource.parent.name}'.")
+
+    # Check for pre-existing parent
+    if resource.parent is not None and not reassign:
       msgs.append(f"Will not assign resource '{resource.name}' " +
                   f"that already has a parent: '{resource.parent.name}'.")
 

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -156,7 +156,7 @@ class Resource:
       msgs.append(f"Will not assign resource '{self.name}' to itself.")
 
     # Check for multiple parents
-    if resource.parent:
+    if resource.parent is not None:
       msgs.append(f"Will not assign resource '{resource.name}' that already has a parent: '{resource.parent.name}'.")
 
     # TODO: write other checks, perhaps recursive or location checks.

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -128,7 +128,7 @@ class Resource:
     """ Get the size of this resource in the z-direction. """
     return self._size_z
 
-  def assign_child_resource(self, resource: Resource, location: Optional[Coordinate]):
+  def assign_child_resource(self, resource: Resource):
     """ Assign a child resource to this resource.
 
     Will use :meth:`~Resource.resource_assigned_callback` to notify the parent of the assignment,
@@ -147,8 +147,10 @@ class Resource:
       raise e
 
     self.children.append(resource)
-    
-  def check_assignment(self, resource: Resource, location: Optional[Coordinate]):
+  
+  def check_assignment(self, resource: Resource):
+    """Check if the resource assignment produces unsupported or dangerous conflicts.
+    """
     msgs = []
 
     # Check for self assignment
@@ -157,7 +159,8 @@ class Resource:
 
     # Check for multiple parents
     if resource.parent is not None:
-      msgs.append(f"Will not assign resource '{resource.name}' that already has a parent: '{resource.parent.name}'.")
+      msgs.append(f"Will not assign resource '{resource.name}' " +
+                  f"that already has a parent: '{resource.parent.name}'.")
 
     # TODO: write other checks, perhaps recursive or location checks.
 

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -135,7 +135,7 @@ class Resource:
     if parent is not `None`.  Note that the resource to be assigned may have child resources, in
     which case you will be responsible for handling any checking, if necessary.
     """
-    
+
     # Check for unsupported resource assignment operations
     self.check_assignment(resource)
 
@@ -150,7 +150,7 @@ class Resource:
       raise e
 
     self.children.append(resource)
-  
+
   def check_assignment(self, resource: Resource):
     """Check if the resource assignment produces unsupported or dangerous conflicts.
     """

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -136,9 +136,10 @@ class Resource:
     which case you will be responsible for handling any checking, if necessary.
     """
 
-    resource.parent = self
-    resource.location = location
     try:
+      self.check_assignment(resource, location)
+      resource.parent = self
+      resource.location = location
       self.resource_assigned_callback(resource) # call callbacks first.
     except Exception as e:
       resource.parent = None
@@ -146,6 +147,23 @@ class Resource:
       raise e
 
     self.children.append(resource)
+    
+  def check_assignment(self, resource: Resource, location: Optional[Coordinate]):
+    msgs = []
+
+    # Check for self assignment
+    if resource is self:
+      msgs.append(f"Will not assign resource '{self.name}' to itself.")
+
+    # Check for multiple parents
+    if resource.parent:
+      msgs.append(f"Will not assign resource '{self.name}' that already has a parent: '{self.parent.name}'. ")
+
+    # TODO: write other checks, perhaps recursive or location checks.
+
+    msg = " ".join(msgs)
+    if msg != "":
+      raise ValueError(msg)
 
   def unassign_child_resource(self, resource: Resource):
     """ Unassign a child resource from this resource.

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -135,11 +135,14 @@ class Resource:
     if parent is not `None`.  Note that the resource to be assigned may have child resources, in
     which case you will be responsible for handling any checking, if necessary.
     """
+    
+    # Check for unsupported resource assignment operations
+    self.check_assignment(resource)
+
+    resource.parent = self
+    resource.location = location
 
     try:
-      self.check_assignment(resource, location)
-      resource.parent = self
-      resource.location = location
       self.resource_assigned_callback(resource) # call callbacks first.
     except Exception as e:
       resource.parent = None

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -12,6 +12,8 @@ if sys.version_info >= (3, 11):
 else:
   from typing_extensions import Self
 
+import logging
+logger = logging.getLogger(__name__)
 
 class Resource:
   """ Base class for deck resources.
@@ -162,10 +164,15 @@ class Resource:
     if resource is self:
       msgs.append(f"Will not assign resource '{self.name}' to itself.")
 
-    # Check for reassignment to the same parent
-    if resource.parent is not None and (resource.parent is self):
-      msgs.append(f"Will not reassign resource '{resource.name}' " +
-                  f"to the same parent: '{resource.parent.name}'.")
+    # Check for reassignment to the same (non-null) parent
+    if (resource.parent is not None) and (resource.parent is self):
+      if reassign:
+        # Inform the user that this is redundant.
+        logger.info(f"Resource '{resource.name}' already assigned to '{resource.parent.name}'")
+      else:
+        # Else raise an error.
+        msgs.append(f"Will not reassign resource '{resource.name}' " +
+                    f"to the same parent: '{resource.parent.name}'.")
 
     # Check for pre-existing parent
     if resource.parent is not None and not reassign:

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -128,7 +128,7 @@ class Resource:
     """ Get the size of this resource in the z-direction. """
     return self._size_z
 
-  def assign_child_resource(self, resource: Resource):
+  def assign_child_resource(self, resource: Resource, location: Optional[Coordinate]):
     """ Assign a child resource to this resource.
 
     Will use :meth:`~Resource.resource_assigned_callback` to notify the parent of the assignment,

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -168,7 +168,7 @@ class Resource:
     if (resource.parent is not None) and (resource.parent is self):
       if reassign:
         # Inform the user that this is redundant.
-        logger.info(f"Resource '{resource.name}' already assigned to '{resource.parent.name}'")
+        logger.warning(f"Resource '{resource.name}' already assigned to '{resource.parent.name}'")
       else:
         # Else raise an error.
         msgs.append(f"Will not reassign resource '{resource.name}' " +

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -157,7 +157,7 @@ class Resource:
 
     # Check for multiple parents
     if resource.parent:
-      msgs.append(f"Will not assign resource '{self.name}' that already has a parent: '{self.parent.name}'. ")
+      msgs.append(f"Will not assign resource '{resource.name}' that already has a parent: '{resource.parent.name}'.")
 
     # TODO: write other checks, perhaps recursive or location checks.
 


### PR DESCRIPTION
Motivation: resources can be assigned to themseves and have multiple parents.

![image](https://user-images.githubusercontent.com/3259326/229376237-ad9909f3-bc94-4c19-8e42-85df93576e2b.png)

Which can be fixed by this PR.
