### PR TITLE
pylabrobot.resources.hamilton do not exist

### DIFF
--- a/docs/using-the-simulator.ipynb
+++ b/docs/using-the-simulator.ipynb
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pylabrobot.resources.hamilton import STARLetDeck"
+    "from pylabrobot.liquid_handling.resources.hamilton import STARLetDeck"
    ]
   },
   {


### PR DESCRIPTION
I was getting a error while trying to run this code, at it seems from the `pylabrobot` folder inside `site-packages` that pylabrobot only have two folder `utils` and `liquid_handling`.

From there I found a `resources` folder inside inside `liquid_handling`.

It's possible to reproduce this error by:

```
mkdir your_project
cd your_project
python -m virtualenv env
source env/bin/activate

pip install pylabrobot[all]
```

create a script using `from pylabrobot.resources.hamilton import STARLetDeck`

and it will generate a Module not found error.