### PR TITLE
Powder Dispenser: Initial commit

### DIFF
--- a/pylabrobot/powder_dispensing/__init__.py
+++ b/pylabrobot/powder_dispensing/__init__.py
@@ -1,0 +1,1 @@
+from .powder_dispenser import PowderDispenser

--- a/pylabrobot/powder_dispensing/backend.py
+++ b/pylabrobot/powder_dispensing/backend.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+from abc import ABCMeta, abstractmethod
+from typing import List
+
+from pylabrobot.machine import MachineBackend
+from pylabrobot.resources import Resource, Powder
+from typing import Optional, Dict, Any
+
+
+class PowderDispenserBackend(MachineBackend, metaclass=ABCMeta):
+  """
+  An abstract class for a powder dispenser backend.
+  """
+
+  @abstractmethod
+  async def setup(self) -> None:
+
+    """Set up the powder dispenser."""
+
+  @abstractmethod
+  async def stop(self) -> None:
+    """Close all connections to the powder dispenser and make sure setup() can be called again."""
+
+  @abstractmethod
+  async def dispense(
+    self,
+    dispense_parameters: List[PowderDispense],
+    **backend_kwargs
+  ) -> List[DispenseResults]:
+    """Dispense powders with set of dispense parameters."""
+
+
+class PowderDispense:
+  """
+  A class for input parameters for powder dispensing.
+  """
+
+  def __init__(
+    self,
+    resource: Resource,
+    powder: Powder,
+    amount: float,
+    params: Optional[Dict[str, Any]] = None,
+    **kwargs
+  ) -> None:
+    self.resource = resource
+    self.powder = powder
+    self.amount = amount
+    self.params = params
+    self.kwargs = kwargs
+
+
+class DispenseResults(dict):
+  """
+  A class for results of powder dispensing, behaving like a dictionary
+  but ensuring the presence of 'actual_amount'.
+  """
+
+  def __init__(self, actual_amount: float, **kwargs):
+    super().__init__(actual_amount=actual_amount, **kwargs)

--- a/pylabrobot/powder_dispensing/backend.py
+++ b/pylabrobot/powder_dispensing/backend.py
@@ -4,7 +4,6 @@ from typing import List
 
 from pylabrobot.machine import MachineBackend
 from pylabrobot.resources import Resource, Powder
-from typing import Optional, Dict, Any
 
 
 class PowderDispenserBackend(MachineBackend, metaclass=ABCMeta):
@@ -40,13 +39,11 @@ class PowderDispense:
     resource: Resource,
     powder: Powder,
     amount: float,
-    params: Optional[Dict[str, Any]] = None,
     **kwargs
   ) -> None:
     self.resource = resource
     self.powder = powder
     self.amount = amount
-    self.params = params
     self.kwargs = kwargs
 
 

--- a/pylabrobot/powder_dispensing/chemspeed/crystal_powderdose.py
+++ b/pylabrobot/powder_dispensing/chemspeed/crystal_powderdose.py
@@ -1,0 +1,8 @@
+from pylabrobot.powder_dispensing.backend import PowderDispenserBackend
+
+class CrystalPowderdose(PowderDispenserBackend):
+  """ A powder dispenser backend for Chemspeed Crystal Powderdose. """
+
+  def __init__(self, arksuite_adress: str) -> None:
+    self.arksuite_adress = arksuite_adress
+

--- a/pylabrobot/powder_dispensing/powder_dispenser.py
+++ b/pylabrobot/powder_dispensing/powder_dispenser.py
@@ -1,0 +1,90 @@
+from typing import Any, Dict, Union, List, Sequence, cast, Optional
+from pylabrobot.machine import MachineFrontend, need_setup_finished
+from .backend import PowderDispenserBackend, PowderDispense
+from pylabrobot.resources import (
+  Deck,
+  Resource,
+  Powder
+)
+
+class PowderDispenser(MachineFrontend):
+  """
+  The front end for powder dispensers. Powder dispensers are devices that can dispense powder
+  into containers such as mtp's placed on a deck.
+
+  Here's an example of how to use this class:
+  >>> pd = PowderDispenser(backend=YourPowderDispenserBackend(), deck=Deck())
+  >>> pd.setup()
+  >>> result = pd.dispense_powder(plate["A1"], powders='NaCl', amount=0.005)
+  >>> print(result)
+  {'actual_amount': 0.005012, ...}
+  """
+
+  def __init__(self, backend: PowderDispenserBackend, deck: Deck) -> None:
+    MachineFrontend.__init__(self, backend=backend)
+    self.backend: PowderDispenserBackend = backend
+    self.deck = deck
+
+  @need_setup_finished
+  async def dispense(
+    self,
+    resources: Union[Resource, Sequence[Resource]],
+    powders: Union[Powder, Sequence[Powder]],
+    amounts: Union[float, Sequence[float]],
+    dispense_parameters: Optional[Union[Dict[str, Any], Sequence[Dict[str, Any]]]] = None,
+    **backend_kwargs
+  ) -> List[Dict[str, Any]]:
+    """
+    Dispense powders into containers with specified amounts and tolerances.
+
+    Args:
+      resources (Union[Resource, Sequence[Resource]]): The target resources
+        into which the dispenses should happen. Usually would be a well or a vial.
+      powders (Union[Powder, Sequence[Powder]]): The powders to dispense.
+      amounts (Union[float, Sequence[float]]): The amounts of powders to dispense. In kg, S.I.
+      dispense_parameters (Optional[Union[Dict[str, Any], Sequence[Dict[str, Any]]]], optional):
+        Additional parameters for the dispense. The parameters are optional and depend on the
+        backend. Defaults to None.
+      **backend_kwargs: Additional keyword arguments to be passed to the backend.
+
+    Returns:
+      List[Dict[str, Any]]: A list of dictionaries containing information about the dispensed
+        powders. Should always contain the key 'actual_amount' with the actual amount
+        that was dispensed.
+
+    Raises:
+      AssertionError: If the lengths of `amounts` and `powders` do not match.
+    """
+    if isinstance(resources, Resource):
+      resources = [resources]
+
+    if isinstance(powders, Powder):
+      powders = [powders]
+
+    if isinstance(amounts, float):
+      amounts = [amounts]
+
+    assert len(amounts) == len(powders)
+
+    if dispense_parameters is not None:
+      assert len(dispense_parameters) == len(powders)
+    else:
+      powder_dispenses = [
+        PowderDispense(resource=r, powder=p, amount=a, params=dp)
+        if dispense_parameters is not None
+        else PowderDispense(resource=r, powder=p, amount=a)
+        for r, p, a, dp in zip(
+          resources,
+          powders,
+          amounts,
+          dispense_parameters or [None] * len(resources)
+        )
+      ]
+
+    result = await self.backend.dispense(powder_dispenses, **backend_kwargs)
+
+    return cast(List[Dict[str, Any]], result)
+
+  async def setup(self):
+    """ Setup the powder dispenser. This method should be called before any dispensing actions. """
+    await super().setup()

--- a/pylabrobot/powder_dispensing/powder_dispenser.py
+++ b/pylabrobot/powder_dispensing/powder_dispenser.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Union, List, Sequence, cast, Optional
+from typing import Any, Dict, Union, List, Sequence, cast
 from pylabrobot.machine import MachineFrontend, need_setup_finished
 from .backend import PowderDispenserBackend, PowderDispense
 from pylabrobot.resources import (
@@ -31,7 +31,6 @@ class PowderDispenser(MachineFrontend):
     resources: Union[Resource, Sequence[Resource]],
     powders: Union[Powder, Sequence[Powder]],
     amounts: Union[float, Sequence[float]],
-    dispense_parameters: Optional[Union[Dict[str, Any], Sequence[Dict[str, Any]]]] = None,
     **backend_kwargs
   ) -> List[Dict[str, Any]]:
     """
@@ -41,10 +40,7 @@ class PowderDispenser(MachineFrontend):
       resources (Union[Resource, Sequence[Resource]]): The target resources
         into which the dispenses should happen. Usually would be a well or a vial.
       powders (Union[Powder, Sequence[Powder]]): The powders to dispense.
-      amounts (Union[float, Sequence[float]]): The amounts of powders to dispense. In kg, S.I.
-      dispense_parameters (Optional[Union[Dict[str, Any], Sequence[Dict[str, Any]]]], optional):
-        Additional parameters for the dispense. The parameters are optional and depend on the
-        backend. Defaults to None.
+      amounts (Union[float, Sequence[float]]): The amounts of powders to dispense. In mg, S.I.
       **backend_kwargs: Additional keyword arguments to be passed to the backend.
 
     Returns:
@@ -64,20 +60,14 @@ class PowderDispenser(MachineFrontend):
     if isinstance(amounts, float):
       amounts = [amounts]
 
-    assert len(amounts) == len(powders)
+    assert len(amounts) == len(powders) == len(resources)
 
-    if dispense_parameters is not None:
-      assert len(dispense_parameters) == len(powders)
-    else:
-      powder_dispenses = [
-        PowderDispense(resource=r, powder=p, amount=a, params=dp)
-        if dispense_parameters is not None
-        else PowderDispense(resource=r, powder=p, amount=a)
-        for r, p, a, dp in zip(
+    powder_dispenses = [
+        PowderDispense(resource=r, powder=p, amount=a)
+        for r, p, a in zip(
           resources,
           powders,
           amounts,
-          dispense_parameters or [None] * len(resources)
         )
       ]
 

--- a/pylabrobot/powder_dispensing/powder_dispenser_tests.py
+++ b/pylabrobot/powder_dispensing/powder_dispenser_tests.py
@@ -1,0 +1,79 @@
+import unittest
+from unittest.mock import AsyncMock
+from pylabrobot.powder_dispensing.powder_dispenser import PowderDispenser
+from pylabrobot.powder_dispensing.backend import PowderDispenserBackend, PowderDispense, DispenseResults
+from pylabrobot.resources import Deck, Powder, Cos_96_DW_1mL
+from typing import List
+
+class MockPowderDispenserBackend(PowderDispenserBackend):
+  """ A mock backend for testing. """
+  async def setup(self) -> None:
+    pass
+
+  async def stop(self) -> None:
+    pass
+
+  async def dispense(
+    self,
+    dispense_parameters: List[PowderDispense],
+    **backend_kwargs: None) -> List[DispenseResults]:
+
+    results = []
+
+    for dp in dispense_parameters:
+      results.append(DispenseResults(actual_amount=dp.amount))
+
+    return results
+
+
+class TestPowderDispenser(unittest.TestCase):
+  """
+  Test class for PowderDispenser.
+  """
+
+  def setUp(self):
+    self.backend = AsyncMock(spec=MockPowderDispenserBackend)
+    self.deck = Deck()
+    self.dispenser = PowderDispenser(backend=self.backend, deck=self.deck)
+    self.dispenser.setup()
+
+  async def test_dispense_single_resource(self):
+    plate = Cos_96_DW_1mL(name="test_resource")
+    powder = Powder("salt")
+    await self.dispenser.dispense(plate["A1"], powder, 0.005)
+    self.backend.dispense.assert_called_once()
+
+  async def test_dispense_multiple_resources(self):
+    plate = Cos_96_DW_1mL(name="test_resource")
+    resources = [plate["A1"], plate["A2"]]
+    powders = [Powder("salt"), Powder("salt")]
+    amounts = [0.005, 0.010]
+    await self.dispenser.dispense(resources, powders, amounts)
+    self.assertEqual(self.backend.dispense.call_count, 1)
+
+  async def test_dispense_parameters_handling(self):
+    plate = Cos_96_DW_1mL(name="test_resource")
+    powder = Powder("salt")
+    dispense_parameters = {"param1": "value1"}
+    await self.dispenser.dispense(
+      plate["A1"], powder, 0.005, dispense_parameters=dispense_parameters
+    )
+    self.backend.dispense.assert_called_once()
+
+  async def test_assertion_for_mismatched_lengths(self):
+    with self.assertRaises(AssertionError):
+      plate = Cos_96_DW_1mL(name="test_resource")
+      list_of_powders = [Powder("salt")]
+      await self.dispenser.dispense(plate["A1"], list_of_powders, [0.005])
+
+    with self.assertRaises(AssertionError):
+      plate = Cos_96_DW_1mL(name="test_resource")
+      await self.dispenser.dispense(
+        plate["A1"],
+        Powder("salt"),
+        0.005,
+        dispense_parameters=[{"param": "value"}, {"param": "value"}],
+      )
+
+if __name__ == "__main__":
+  unittest.main()

--- a/pylabrobot/resources/__init__.py
+++ b/pylabrobot/resources/__init__.py
@@ -15,6 +15,7 @@ from .plate import Plate, Lid, Well
 from .resource import Resource, get_resource_class_from_string
 from .tip_rack import TipRack, TipSpot
 from .trash import Trash
+from .powder import Powder
 
 from .tip_tracker import TipTracker, does_tip_tracking, no_tip_tracking, set_tip_tracking
 from .volume_tracker import VolumeTracker, does_volume_tracking, no_volume_tracking, set_volume_tracking

--- a/pylabrobot/resources/powder.py
+++ b/pylabrobot/resources/powder.py
@@ -1,0 +1,11 @@
+class Powder:
+  """
+  A class for powders.
+  """
+  def __init__(self, name: str) -> None:
+    """
+    Initializes a new instance of the Powder class.
+    Args:
+        name (str): The name of the powder.
+    """
+    self.name = name


### PR DESCRIPTION
Initial commit to include front end class for a powder dispenser, abstract class for a backend and a powder resource. The front end class is missing deck related methods that the liquid handlers have. Though, the powder dispensers usually have simpler decks and manipulations.  Could may be transfer methods like _assert_resources_exist to base class?