### PR TITLE
Add pytest filter to suppress expected warning

### DIFF
--- a/pylabrobot/liquid_handling/liquid_handler_tests.py
+++ b/pylabrobot/liquid_handling/liquid_handler_tests.py
@@ -1,6 +1,7 @@
 """ Tests for LiquidHandler """
 # pylint: disable=missing-class-docstring
 
+import pytest
 import tempfile
 from typing import Any, Dict, List, Optional, cast
 import unittest
@@ -496,6 +497,7 @@ class TestLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     with self.assertRaises(ValueError):
       await self.lh.aspirate([well], vols=10)
 
+  @pytest.mark.filterwarnings("ignore:Extra arguments to backend.pick_up_tips")
   async def test_strictness(self):
     class TestBackend(backends.SaverBackend):
       """ Override pick_up_tips for testing. """


### PR DESCRIPTION
This change cleans up the test output by preventing the expected warning from being printed. No alterations were made to the test logic or functionality of the code being tested.