### PR TITLE
Enable adding labware in any order

### DIFF
--- a/pylabrobot/resources/hamilton/hamilton_decks.py
+++ b/pylabrobot/resources/hamilton/hamilton_decks.py
@@ -146,13 +146,16 @@ class HamiltonDeck(Deck, metaclass=ABCMeta):
         og_y = cast(Coordinate, og_resource.location).y
 
         # A resource is not allowed to overlap with another resource. Resources overlap when a
-        # corner of one resource is inside the boundaries other resource.
-        if (og_x <= resource_location.x < og_x + og_resource.get_size_x() or \
-          og_x <= resource_location.x + resource.get_size_x() <
-            og_x + og_resource.get_size_x()) and \
-            (og_y <= resource_location.y < og_y + og_resource.get_size_y() or \
-              og_y <= resource_location.y + resource.get_size_y() <
-                og_y + og_resource.get_size_y()):
+        # corner of one resource is inside the boundaries of another resource.
+        if any([
+          og_x <= resource_location.x < og_x + og_resource.get_size_x(),
+          og_x < resource_location.x + resource.get_size_x() < og_x + og_resource.get_size_x()
+          ]) and any(
+            [
+              og_y <= resource_location.y < og_y + og_resource.get_size_y(),
+              og_y < resource_location.y + resource.get_size_y() < og_y + og_resource.get_size_y()
+            ]
+          ):
           raise ValueError(f"Location {resource_location} is already occupied by resource "
                             f"'{og_resource.name}'.")
 


### PR DESCRIPTION
1. Fixed a small logic bug: inserting a carrier in between two carriers (exactly one carrier apart in the x-dimension) incorrectly threw up a ValueError if carriers are of the same size (specialised case but important for moving a central carrier in and out of the deck in an interactive manner during an automation run). 
2. Changing `if nested-logic AND nested-logic` condition to represent `nested-logic` with any() to enhance readability.