### PR TITLE
Add liquid handler operation callbacks

### DIFF
--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1519,7 +1519,7 @@ class LiquidHandler(MachineFrontend):
     """
     if callback := self._callbacks.get(method_name):
       callback(self, *args, error=error, **kwargs)
-    elif callback is None and error:
+    elif error is not None:
       raise error
 
   @property

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -65,20 +65,13 @@ class LiquidHandler(MachineFrontend):
   ALLOWED_CALLBACKS = {
     "aspirate",
     "aspirate_plate",
-    "discard_tips",
     "dispense",
     "dispense_plate",
     "drop_tips",
     "drop_tips96",
-    "move_lid",
-    "move_plate",
     "move_resource",
     "pick_up_tips",
     "pick_up_tips96",
-    "return_tips",
-    "return_tips96",
-    "stamp",
-    "transfer",
   }
 
   def __init__(self, backend: LiquidHandlerBackend, deck: Deck):
@@ -1435,7 +1428,7 @@ class LiquidHandler(MachineFrontend):
     """
     if callback := self._callbacks.get(method_name):
       callback(*args, error=error, **kwargs)
-    elif error:
+    elif callback is None and error:
       raise error
 
   @property

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1427,7 +1427,7 @@ class LiquidHandler(MachineFrontend):
     NB: If an error exists it will be passed to the callback instead of being raised.
     """
     if callback := self._callbacks.get(method_name):
-      callback(*args, error=error, **kwargs)
+      callback(self, *args, error=error, **kwargs)
     elif callback is None and error:
       raise error
 

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -375,17 +375,32 @@ class LiquidHandler(MachineFrontend):
 
     try:
       await self.backend.pick_up_tips(ops=pickups, use_channels=use_channels, **backend_kwargs)
-    except:
+    except Exception as error:  # pylint: disable=broad-except
       for channel, op in zip(use_channels, pickups):
         if does_tip_tracking() and not op.resource.tracker.is_disabled:
           op.resource.tracker.rollback()
         self.head[channel].rollback()
-      raise
+      self._trigger_callback(
+        "pick_up_tips",
+        liquid_handler=self,
+        operations=pickups,
+        use_channels=use_channels,
+        error=error,
+        **backend_kwargs,
+      )
     else:
       for channel, op in zip(use_channels, pickups):
         if does_tip_tracking() and not op.resource.tracker.is_disabled:
           op.resource.tracker.commit()
         self.head[channel].commit()
+      self._trigger_callback(
+        "pick_up_tips",
+        liquid_handler=self,
+        operations=pickups,
+        use_channels=use_channels,
+        error=None,
+        **backend_kwargs,
+      )
 
   @need_setup_finished
   async def drop_tips(
@@ -473,19 +488,34 @@ class LiquidHandler(MachineFrontend):
 
     try:
       await self.backend.drop_tips(ops=drops, use_channels=use_channels, **backend_kwargs)
-    except:
+    except Exception as error:  # pylint: disable=broad-except
       for channel, op in zip(use_channels, drops):
         if does_tip_tracking() and \
           (isinstance(op.resource, TipSpot) and not op.resource.tracker.is_disabled):
           op.resource.tracker.rollback()
         self.head[channel].rollback()
-      raise
+      self._trigger_callback(
+        "drop_tips",
+        liquid_handler=self,
+        operations=drops,
+        use_channels=use_channels,
+        error=error,
+        **backend_kwargs,
+      )
     else:
       for channel, op in zip(use_channels, drops):
         if does_tip_tracking() and \
           (isinstance(op.resource, TipSpot) and not op.resource.tracker.is_disabled):
           op.resource.tracker.commit()
         self.head[channel].commit()
+      self._trigger_callback(
+        "drop_tips",
+        liquid_handler=self,
+        operations=drops,
+        use_channels=use_channels,
+        error=None,
+        **backend_kwargs,
+      )
 
   async def return_tips(self):
     """ Return all tips that are currently picked up to their original place.
@@ -856,17 +886,32 @@ class LiquidHandler(MachineFrontend):
 
     try:
       await self.backend.dispense(ops=dispenses, use_channels=use_channels, **backend_kwargs)
-    except:
+    except Exception as error:  # pylint: disable=broad-except
       for op in dispenses:
         if not op.resource.tracker.is_disabled:
           op.resource.tracker.rollback()
           op.tip.tracker.rollback()
-      raise
+      self._trigger_callback(
+        "dispense",
+        liquid_handler=self,
+        operations=dispenses,
+        use_channels=use_channels,
+        error=error,
+        **backend_kwargs,
+      )
     else:
       for op in dispenses:
         if not op.resource.tracker.is_disabled:
           op.resource.tracker.commit()
           op.tip.tracker.commit()
+      self._trigger_callback(
+        "dispense",
+        liquid_handler=self,
+        operations=dispenses,
+        use_channels=use_channels,
+        error=None,
+        **backend_kwargs,
+      )
 
     if end_delay > 0:
       time.sleep(end_delay)
@@ -975,13 +1020,22 @@ class LiquidHandler(MachineFrontend):
     for extra in extras:
       del backend_kwargs[extra]
 
+    pickup_operation = PickupTipRack(resource=tip_rack, offset=offset)
     await self.backend.pick_up_tips96(
-      pickup=PickupTipRack(resource=tip_rack, offset=offset),
+      pickup=pickup_operation,
       **backend_kwargs
     )
 
     # Save the tips as picked up.
     self._picked_up_tips96 = tip_rack
+
+    self._trigger_callback(
+      "pick_up_tips96",
+      liquid_handler=self,
+      pickup=pickup_operation,
+      error=None,
+      **backend_kwargs,
+    )
 
   async def drop_tips96(
     self,
@@ -1006,12 +1060,21 @@ class LiquidHandler(MachineFrontend):
     for extra in extras:
       del backend_kwargs[extra]
 
+    drop_operation = DropTipRack(resource=tip_rack, offset=offset)
     await self.backend.drop_tips96(
-      drop=DropTipRack(resource=tip_rack, offset=offset),
+      drop=drop_operation,
       **backend_kwargs
     )
 
     self._picked_up_tips96 = None
+
+    self._trigger_callback(
+      "drop_tips96",
+      liquid_handler=self,
+      drop=drop_operation,
+      error=None,
+      **backend_kwargs,
+    )
 
   async def return_tips96(self):
     """ Return the tips on the 96 head to the tip rack where they were picked up.
@@ -1078,7 +1141,7 @@ class LiquidHandler(MachineFrontend):
         liquids.append(w.tracker.get_liquids(top_volume=volume))
 
     if plate.num_items_x == 12 and plate.num_items_y == 8:
-      await self.backend.aspirate96(aspiration=AspirationPlate(
+      aspiration_plate = AspirationPlate(
         resource=plate,
         volume=volume,
         offset=Coordinate.zero(),
@@ -1086,8 +1149,16 @@ class LiquidHandler(MachineFrontend):
         tips=tips,
         liquid_height=None,
         blow_out_air_volume=0,
-        liquids=liquids),
-        **backend_kwargs)
+        liquids=liquids,
+      )
+      await self.backend.aspirate96(aspiration=aspiration_plate, **backend_kwargs)
+      self._trigger_callback(
+        "aspirate_plate",
+        liquid_handler=self,
+        aspiration=aspiration_plate,
+        error=None,
+        **backend_kwargs,
+      )
     else:
       raise NotImplementedError(f"It is not possible to plate aspirate from an {plate.num_items_x} "
                                 f"by {plate.num_items_y} plate")
@@ -1142,7 +1213,7 @@ class LiquidHandler(MachineFrontend):
         liquids.append(w.tracker.get_liquids(top_volume=volume))
 
     if plate.num_items_x == 12 and plate.num_items_y == 8:
-      await self.backend.dispense96(dispense=DispensePlate(
+      dispense_plate = DispensePlate(
         resource=plate,
         volume=volume,
         offset=Coordinate.zero(),
@@ -1150,8 +1221,16 @@ class LiquidHandler(MachineFrontend):
         tips=tips,
         liquid_height=None,
         blow_out_air_volume=0,
-        liquids=liquids),
-        **backend_kwargs)
+        liquids=liquids,
+      )
+      await self.backend.dispense96(dispense=dispense_plate, **backend_kwargs)
+      self._trigger_callback(
+        "dispense_plate",
+        liquid_handler=self,
+        dispense=dispense_plate,
+        error=None,
+        **backend_kwargs,
+      )
     else:
       raise NotImplementedError(f"It is not possible to plate dispense to an {plate.num_items_x} "
                                f"by {plate.num_items_y} plate")
@@ -1227,7 +1306,7 @@ class LiquidHandler(MachineFrontend):
     for extra in extras:
       del backend_kwargs[extra]
 
-    return await self.backend.move_resource(move=Move(
+    move_operation = Move(
       resource=resource,
       destination=to,
       intermediate_locations=intermediate_locations or [],
@@ -1235,8 +1314,20 @@ class LiquidHandler(MachineFrontend):
       destination_offset=destination_offset,
       pickup_distance_from_top=pickup_distance_from_top,
       get_direction=get_direction,
-      put_direction=put_direction),
-      **backend_kwargs)
+      put_direction=put_direction,
+    )
+
+    result = await self.backend.move_resource(move=move_operation, **backend_kwargs)
+
+    self._trigger_callback(
+      "move_resource",
+      liquid_handler=self,
+      move=move_operation,
+      error=None,
+      **backend_kwargs,
+    )
+
+    return result
 
   async def move_lid(
     self,

--- a/pylabrobot/liquid_handling/liquid_handler_tests.py
+++ b/pylabrobot/liquid_handling/liquid_handler_tests.py
@@ -605,7 +605,7 @@ class TestLiquidHandlerCallbacks(unittest.IsolatedAsyncioTestCase):
 
   def test_trigger_callback_without_error(self):
     self.lh.register_callback("test_operation_without_error", self.callback)
-    self.lh.trigger_callback("test_operation_without_error", self.lh)
+    self.lh.trigger_callback("test_operation_without_error")
     self.callback.assert_called_once()
 
   def test_trigger_callback_with_error_raised(self):
@@ -632,6 +632,5 @@ class TestLiquidHandlerCallbacks(unittest.IsolatedAsyncioTestCase):
     with pytest.raises(RuntimeError):
       self.lh.trigger_callback(
         "test_callback_not_registered_with_error",
-        liquid_handler=self.lh,
         error=RuntimeError("test"),
       )

--- a/pylabrobot/liquid_handling/liquid_handler_tests.py
+++ b/pylabrobot/liquid_handling/liquid_handler_tests.py
@@ -599,17 +599,34 @@ class TestLiquidHandlerCallbacks(unittest.IsolatedAsyncioTestCase):
     with pytest.raises(RuntimeError):
       self.lh.register_callback("test_duplicate", self.callback)
 
+  def test_register_disallowed_callback(self):
+    with pytest.raises(RuntimeError):
+      self.lh.register_callback("not_allowed", self.callback)
+
   def test_trigger_callback_without_error(self):
     self.lh.register_callback("test_operation_without_error", self.callback)
     self.lh.trigger_callback("test_operation_without_error", self.lh)
     self.callback.assert_called_once()
 
   def test_trigger_callback_with_error_raised(self):
+    callback = unittest.mock.Mock(spec = OperationCallback, side_effect=RuntimeError)
+    self.lh.register_callback("test_operation", callback)
     with pytest.raises(RuntimeError):
       self.lh.trigger_callback(
         "test_operation",
         error=RuntimeError("test")
       )
+    error_passed = callback.call_args[1].get("error")
+    assert isinstance(error_passed, Exception)
+
+  def test_trigger_callback_with_error_not_raised(self):
+    error = RuntimeError("test")
+    self.lh.register_callback("test_operation", self.callback)
+    try:
+      self.lh.trigger_callback("test_operation", error=error)
+    except RuntimeError as e:
+      pytest.fail(f"Unexpected exception raised: {e}")
+    self.callback.assert_called_with(self.lh, error=error)
 
   def test_trigger_callback_not_found_with_error(self):
     with pytest.raises(RuntimeError):
@@ -618,7 +635,3 @@ class TestLiquidHandlerCallbacks(unittest.IsolatedAsyncioTestCase):
         liquid_handler=self.lh,
         error=RuntimeError("test"),
       )
-
-  def test_trigger_disallowed_callback(self):
-    with pytest.raises(RuntimeError):
-      self.lh.register_callback("not_allowed", self.callback)


### PR DESCRIPTION
A quick pass at adding callback registration to `LiquidHandler`, generally following your suggestions @rickwierenga. Let me know what you think about this approach. Would you want to handle state tracker transactions in the callback? 