### PR TITLE
Exposing autoload carrier load, unload & barcode reading (v1)

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -5325,13 +5325,22 @@ class STAR(HamiltonLiquidHandler):
     assert resp is not None
     return resp["ct"] == 1
 
-    # Park autoload
+  # Park autoload
   async def park_autoload(
       self,
       ):
     """ Park autoload """
 
-    return await self.send_command(module="C0", command="CS")
+    # Identify max number of x positions for your liquid handler
+    extended_conf = await self.request_extended_configuration()
+    max_x_pos = str(extended_conf["xt"]).zfill(2)
+
+    # Park autoload to max x position available
+    return await self.send_command(
+      module="I0",
+      command="XP",
+      xp=max_x_pos
+      )
 
   # TODO:(command:CA) Push out carrier to loading tray (after identification CI)
 

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -5339,7 +5339,7 @@ class STAR(HamiltonLiquidHandler):
 
   # TODO:(command:CA) Push out carrier to loading tray (after identification CI)
 
-  async def auto_unload_carrier(
+  async def unload_carrier(
       self,
       carrier: Carrier,
       ):
@@ -5363,7 +5363,7 @@ class STAR(HamiltonLiquidHandler):
     await self.park_autoload()
     return resp
 
-  async def auto_load_carrier(
+  async def load_carrier(
       self,
       carrier: Carrier,
       barcode_reading: bool = False,

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -1226,7 +1226,7 @@ class STAR(HamiltonLiquidHandler):
     left_x_drive_configuration_byte_1 = left_x_drive_configuration_byte_1 + \
       "0" * (16 - len(left_x_drive_configuration_byte_1))
     left_x_drive_configuration_byte_1 = left_x_drive_configuration_byte_1[2:]
-    autoload_configuration_byte = bin(conf['kb']).split('b')[-1][-3]
+    autoload_configuration_byte = bin(conf["kb"]).split("b")[-1][-3]
     # Identify installations
     self.autoload_installed = autoload_configuration_byte == "1"
     self.core96_head_installed = left_x_drive_configuration_byte_1[2] == "1"

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -1226,7 +1226,7 @@ class STAR(HamiltonLiquidHandler):
     left_x_drive_configuration_byte_1 = left_x_drive_configuration_byte_1 + \
       "0" * (16 - len(left_x_drive_configuration_byte_1))
     left_x_drive_configuration_byte_1 = left_x_drive_configuration_byte_1[2:]
-    autoload_configuration_byte = bin(conf["kb"]).split("b")[-1][-3]
+    autoload_configuration_byte = bin(conf["kb"])[2:][-3]
     # Identify installations
     self.autoload_installed = autoload_configuration_byte == "1"
     self.core96_head_installed = left_x_drive_configuration_byte_1[2] == "1"

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -1226,7 +1226,7 @@ class STAR(HamiltonLiquidHandler):
     left_x_drive_configuration_byte_1 = left_x_drive_configuration_byte_1 + \
       "0" * (16 - len(left_x_drive_configuration_byte_1))
     left_x_drive_configuration_byte_1 = left_x_drive_configuration_byte_1[2:]
-    autoload_configuration_byte = bin(conf["kb"])[2:][-3]
+    autoload_configuration_byte = bin(conf["kb"])[2:].zfill(8)[-3]
     # Identify installations
     self.autoload_installed = autoload_configuration_byte == "1"
     self.core96_head_installed = left_x_drive_configuration_byte_1[2] == "1"

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -1226,7 +1226,7 @@ class STAR(HamiltonLiquidHandler):
     left_x_drive_configuration_byte_1 = left_x_drive_configuration_byte_1 + \
       "0" * (16 - len(left_x_drive_configuration_byte_1))
     left_x_drive_configuration_byte_1 = left_x_drive_configuration_byte_1[2:]
-    autoload_configuration_byte = bin(conf["kb"])[2:].zfill(8)[-3]
+    autoload_configuration_byte = bin(conf["kb"])[.split("b")[-1]][-3]
     # Identify installations
     self.autoload_installed = autoload_configuration_byte == "1"
     self.core96_head_installed = left_x_drive_configuration_byte_1[2] == "1"

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -9,7 +9,7 @@ import enum
 import functools
 import logging
 import re
-from typing import Callable, Dict, ItemsView, List, Optional, Sequence, Type, TypeVar, cast
+from typing import Callable, Dict, ItemsView, List, Literal, Optional, Sequence, Type, TypeVar, cast
 
 from pylabrobot.liquid_handling.backends.hamilton.base import (
   HamiltonLiquidHandler,
@@ -1069,6 +1069,7 @@ class STAR(HamiltonLiquidHandler):
     self._iswap_parked: Optional[bool] = None
     self._num_channels: Optional[int] = None
     self._core_parked: Optional[bool] = None
+    self._extended_conf: Optional[dict] = None
 
   @property
   def num_channels(self) -> int:
@@ -1080,6 +1081,13 @@ class STAR(HamiltonLiquidHandler):
   @property
   def module_id_length(self):
     return 2
+
+  @property
+  def extended_conf(self) -> dict:
+    """ Extended configuration. """
+    if self._extended_conf is None:
+      raise RuntimeError("has not loaded extended_conf, forgot to call `setup`?")
+    return self._extended_conf
 
   def serialize(self) -> dict:
     return {
@@ -1220,9 +1228,9 @@ class STAR(HamiltonLiquidHandler):
 
     # Request machine information
     conf = await self.request_machine_configuration()
-    extended_conf = await self.request_extended_configuration()
+    self._extended_conf = await self.request_extended_configuration()
 
-    left_x_drive_configuration_byte_1 = bin(extended_conf["xl"])
+    left_x_drive_configuration_byte_1 = bin(self.extended_conf["xl"])
     left_x_drive_configuration_byte_1 = left_x_drive_configuration_byte_1 + \
       "0" * (16 - len(left_x_drive_configuration_byte_1))
     left_x_drive_configuration_byte_1 = left_x_drive_configuration_byte_1[2:]
@@ -1247,7 +1255,7 @@ class STAR(HamiltonLiquidHandler):
       y_positions = [4050 - i * dy for i in range(self.num_channels)]
 
       await self.initialize_pipetting_channels(
-        x_positions=[extended_conf["xw"]],  # Tip eject waste X position.
+        x_positions=[self.extended_conf["xw"]],  # Tip eject waste X position.
         y_positions=y_positions,
         begin_of_tip_deposit_process=2450,
         end_of_tip_deposit_process=1220,
@@ -1261,7 +1269,7 @@ class STAR(HamiltonLiquidHandler):
       if not autoload_initialized:
         await self.initialize_autoload()
 
-        await self.park_autoload()
+      await self.park_autoload()
 
     if self.iswap_installed:
       iswap_initialized = await self.request_iswap_initialization_status()
@@ -3109,8 +3117,7 @@ class STAR(HamiltonLiquidHandler):
     """ Request machine configuration """
 
     # TODO: parse res
-    return await self.send_command(module="C0", command="RM",
-                                   fmt="kb**kp**")
+    return await self.send_command(module="C0", command="RM", fmt="kb**kp**")
 
   async def request_extended_configuration(self):
     """ Request extended configuration """
@@ -5326,31 +5333,23 @@ class STAR(HamiltonLiquidHandler):
     return resp["ct"] == 1
 
   # Park autoload
-  async def park_autoload(
-      self,
-      ):
+  async def park_autoload(self):
     """ Park autoload """
 
     # Identify max number of x positions for your liquid handler
-    extended_conf = await self.request_extended_configuration()
-    max_x_pos = str(extended_conf["xt"]).zfill(2)
+    max_x_pos = str(self.extended_conf["xt"]).zfill(2)
 
     # Park autoload to max x position available
     return await self.send_command(
       module="I0",
       command="XP",
       xp=max_x_pos
-      )
+    )
 
   # TODO:(command:CA) Push out carrier to loading tray (after identification CI)
 
-  async def unload_carrier(
-      self,
-      carrier: Carrier,
-      ):
-    """
-    Use autoload to unload carrier.
-    """
+  async def unload_carrier(self, carrier: Carrier):
+    """ Use autoload to unload carrier. """
     # Identify carrier end rail
     track_width = 22.5
     carrier_width = carrier.get_absolute_location().x - 100  + carrier.get_size_x()
@@ -5364,26 +5363,43 @@ class STAR(HamiltonLiquidHandler):
       module="C0",
       command="CR",
       cp=carrier_end_rail_str,
-      )
+    )
     # Park autoload
     await self.park_autoload()
     return resp
 
   async def load_carrier(
-      self,
-      carrier: Carrier,
-      barcode_reading: bool = False,
-      barcode_reading_direction: str = "horizontal",
-      barcode_symbology: str = "Code 128 (Subset B and C)",
-      no_container_per_carrier: int = 5,
-      park_autoload_after: bool = True
-      ):
+    self,
+    carrier: Carrier,
+    barcode_reading: bool = False,
+    barcode_reading_direction: Literal["horizontal", "vertical"] = "horizontal",
+    barcode_symbology:
+      Literal[
+        "ISBT Standard",
+        "Code 128 (Subset B and C)",
+        "Code 39",
+        "Codebar",
+        "Code 2of5 Interleaved",
+        "UPC A/E",
+        "YESN/EAN 8",
+        "Code 93"
+      ] = "Code 128 (Subset B and C)",
+    no_container_per_carrier: int = 5,
+    park_autoload_after: bool = True
+  ):
     """
     Use autoload to load carrier.
 
-    Barcode reading is disabled by default.
-
+    Args:
+      carrier: Carrier to load
+      barcode_reading: Whether to read barcodes. Default False.
+      barcode_reading_direction: Barcode reading direction. Either "vertical" or "horizontal",
+        default "horizontal".
+      barcode_symbology: Barcode symbology. Default "Code 128 (Subset B and C)".
+      no_container_per_carrier: Number of containers per carrier. Default 5.
+      park_autoload_after: Whether to park autoload after loading. Default True.
     """
+
     barcode_reading_direction_dict = {
       "vertical": "0",
       "horizontal": "1"
@@ -5408,53 +5424,44 @@ class STAR(HamiltonLiquidHandler):
     presence_check = await self.request_single_carrier_presence(carrier_end_rail)
     carrier_end_rail_str = str(carrier_end_rail).zfill(2)
 
-    if presence_check == 1:
-      # Set carrier type for identification purposes
-      await self.send_command(module="C0", command="CI", cp=carrier_end_rail_str)
-
-      # Load carrier
-      # with barcoding
-      if barcode_reading:
-
-        # Choose barcode symbology
-        await self.send_command(
-          module="C0",
-          command="CB",
-          bt=barcode_symbology_dict[barcode_symbology]
-        )
-        # Load and read out barcodes
-        resp = await self.send_command(
-          module="C0",
-          command="CL",
-          bd=barcode_reading_direction_dict[barcode_reading_direction],
-          bp="0616", # Barcode reading direction (0 = vertical 1 = horizontal)
-          co="0960", # Distance between containers (pattern) [0.1 mm]
-          cf="380", # Width of reading window [0.1 mm]
-          cv="1281", # Carrier reading speed [0.1 mm]/s
-          cn=str(no_container_per_carrier).zfill(2), # No of containers (cups, plates) in a carrier
-          )
-        # Check for presence of other carriers & park autoload
-        if park_autoload_after:
-          await self.send_command(module="C0", command="CS")
-        return resp
-
-      # without barcoding
-      else:
-        resp = await self.send_command(
-          module="C0",
-          command="CL",
-          cn="00"
-          )
-        # Check for presence of other carriers & park autoload
-        if park_autoload_after:
-          await self.send_command(module="C0", command="CS")
-      return resp
-
-    else:
+    if presence_check != 1:
       raise ValueError(f"""No carrier found at position {carrier_end_rail},
                        have you placed the carrier onto the correct autoload tray position?""")
 
+    # Set carrier type for identification purposes
+    await self.send_command(module="C0", command="CI", cp=carrier_end_rail_str)
 
+    # Load carrier
+    # with barcoding
+    if barcode_reading:
+      # Choose barcode symbology
+      await self.send_command(
+        module="C0",
+        command="CB",
+        bt=barcode_symbology_dict[barcode_symbology]
+      )
+      # Load and read out barcodes
+      resp = await self.send_command(
+        module="C0",
+        command="CL",
+        bd=barcode_reading_direction_dict[barcode_reading_direction],
+        bp="0616", # Barcode reading direction (0 = vertical 1 = horizontal)
+        co="0960", # Distance between containers (pattern) [0.1 mm]
+        cf="380", # Width of reading window [0.1 mm]
+        cv="1281", # Carrier reading speed [0.1 mm]/s
+        cn=str(no_container_per_carrier).zfill(2), # No of containers (cups, plates) in a carrier
+      )
+    else: # without barcoding
+      resp = await self.send_command(
+        module="C0",
+        command="CL",
+        cn="00"
+      )
+
+    # Check for presence of other carriers & park autoload
+    if park_autoload_after:
+      await self.send_command(module="C0", command="CS")
+    return resp
 
   async def set_loading_indicators(
     self,

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -2642,7 +2642,7 @@ class STAR(HamiltonLiquidHandler):
     Convenient substitute for checking whether machine has an autoload.
     """
 
-    resp = await self.backend.send_command(module="I0", command="RO", fmt="ao####")
+    resp = await self.send_command(module="I0", command="RO", fmt="ao####")
     return resp is not None and resp["ao"] > 2015
 
   async def request_autoload_initialization_status(self) -> bool:
@@ -5448,7 +5448,7 @@ class STAR(HamiltonLiquidHandler):
     else:
       raise ValueError(f"""No carrier found at position {carrier_end_rail},
                        have you placed the carrier onto the correct autoload tray position?""")
-  
+
 
 
   async def set_loading_indicators(

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -1226,7 +1226,7 @@ class STAR(HamiltonLiquidHandler):
     left_x_drive_configuration_byte_1 = left_x_drive_configuration_byte_1 + \
       "0" * (16 - len(left_x_drive_configuration_byte_1))
     left_x_drive_configuration_byte_1 = left_x_drive_configuration_byte_1[2:]
-    autoload_configuration_byte = bin(conf["kb"])[.split("b")[-1]][-3]
+    autoload_configuration_byte = bin(conf["kb"]).split("b")[-1][-3]
     # Identify installations
     self.autoload_installed = autoload_configuration_byte == "1"
     self.core96_head_installed = left_x_drive_configuration_byte_1[2] == "1"


### PR DESCRIPTION
I have written code to use the autoload on Hamilton STAR liquid handlers.

I used the iSWAP implementation as inspiration to make this function comprehensive and (in my hands) safe (an autoload or carrier left in the middle of the machine has the potential to damage the machine, users operate on their own responsibility):

1. Check whether autoload is installed during setup. (I couldn't find a specific cue of the machine or direct command that checks this (this could be because autoloads cannot be retrofitted into Hamilton liquid handlers, and therefore no need for checking would VENUS-normally arise). So instead I am using the `I0RO` fw command ("Request download date") to check when the autoload software has been downloaded. If the download has happened after 2015 the machine is considered to have an autoload installed. I will have to receive feedback from other users who do not have an autoload whether this truly recognises the absence of the autoload - similar to how the absence of an iSWAP had to be figured out by a user without an iSWAP :)
2. If an autoload is installed, a check whether the autoload is initialised will be performed.
3. If not initialised, the autoload will initialise.
4. Initialisation leaves the autoload hanging on the wrong end of the robot (i.e. crash danger). Hence, I implemented a "park_autoload" function. However, I couldn't find a direct fw command to simply move the autoload out of the way yet. So instead the fw command `C0CS` ("Check for presence of carriers on loading tray") acts as an intermediate solution because it ends with the autoload parked in a save position.

This enables loading of carriers:
```python
await STAR.load_carrier(tip_carrier_0)
```

This enables unloading of carriers:
```python
await STAR.unload_carrier(tip_carrier_0)
```

Furthermore, the fw command for loading is the main way of quickly identifying the barcodes of your labware.
This is activated using...
```python
await STAR.load_carrier(tip_carrier_0, barcode_reading=True)
```
This function can currently specify further:
```python
barcode_reading_direction: str = 'horizontal',
barcode_symbology: str = 'Code 128 (Subset B and C)',
no_container_per_carrier: int = 5,
park_autoload_after: bool = True
```

I have verified the ability to read barcodes from Hamilton tip carriers and Hamilton tips. 

Plate barcodes cannot be read yet.

After closing this PR I will write a forum post detailing the functionalities for easy adaptation by other users.

