### PR TITLE
[lids] fix move lid to plate

### DIFF
--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1542,7 +1542,7 @@ class LiquidHandler(Machine):
     elif isinstance(to, Plate):
       to.assign_child_resource(resource=lid)
     else:
-      raise Exception("'to' must be either a Coordinate, ResourceStack or Plate")
+      raise ValueError("'to' must be either a Coordinate, ResourceStack or Plate")
 
   async def move_plate(
     self,

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1539,8 +1539,10 @@ class LiquidHandler(Machine):
       self.deck.assign_child_resource(lid, location=to_location)
     elif isinstance(to, ResourceStack): # manage its own resources
       to.assign_child_resource(lid)
+    elif isinstance(to, Plate):
+      to.assign_child_resource(resource=lid)
     else:
-      to.assign_child_resource(lid, location=to_location)
+      raise Exception("'to' must be either a Coordinate, ResourceStack or Plate")
 
   async def move_plate(
     self,

--- a/pylabrobot/liquid_handling/liquid_handler_tests.py
+++ b/pylabrobot/liquid_handling/liquid_handler_tests.py
@@ -210,6 +210,25 @@ class TestLiquidHandlerLayout(unittest.IsolatedAsyncioTestCase):
     self.assertEqual(plate.get_absolute_location(),
       Coordinate(1000, 1000, 1000))
 
+  async def test_move_lid(self):
+    plate = Plate("plate", size_x=100, size_y=100, size_z=15, lid_height=10, items=[])
+    plate.location = Coordinate(0, 0, 100)
+    lid = Lid(name="lid", size_x=plate.get_size_x(), size_y=plate.get_size_y(),
+      size_z=plate.lid_height)
+    lid.location = Coordinate(100, 100, 200)
+
+    assert plate.get_absolute_location().x != lid.get_absolute_location().x
+    assert plate.get_absolute_location().y != lid.get_absolute_location().y
+    assert plate.get_absolute_location().z + plate.get_size_z() - plate.lid_height \
+      != lid.get_absolute_location().z
+
+    await self.lh.move_lid(lid, plate)
+
+    assert plate.get_absolute_location().x == lid.get_absolute_location().x
+    assert plate.get_absolute_location().y == lid.get_absolute_location().y
+    assert plate.get_absolute_location().z + plate.get_size_z() - plate.lid_height \
+      == lid.get_absolute_location().z
+
   def test_serialize(self):
     serialized = self.lh.serialize()
     deserialized = LiquidHandler.deserialize(serialized)

--- a/pylabrobot/resources/plate.py
+++ b/pylabrobot/resources/plate.py
@@ -81,18 +81,22 @@ class Plate(ItemizedResource[Well]):
       assert lid_height > 0, "Lid height must be greater than 0 if with_lid == True."
 
       lid = Lid(name + "_lid", size_x=size_x, size_y=size_y, size_z=lid_height)
-      self.assign_child_resource(lid, location=Coordinate(0, 0, self.get_size_z() - lid_height))
+      self.assign_child_resource(lid)
 
   def assign_child_resource(
     self,
     resource: Resource,
-    location: Optional[Coordinate],
+    location: Optional[Coordinate] = None,
     reassign: bool = True
   ):
     if isinstance(resource, Lid):
       if self.has_lid():
         raise ValueError(f"Plate '{self.name}' already has a lid.")
       self.lid = resource
+      assert self.lid_height > 0, "Lid height must be greater than 0."
+      location = Coordinate(0, 0, self.get_size_z() - self.lid_height)
+    else:
+      assert location is not None, "Location must be specified for if resource is not a lid."
     return super().assign_child_resource(resource, location=location, reassign=reassign)
 
   def unassign_child_resource(self, resource):


### PR DESCRIPTION
Previously we were passing the absolute location of the "to_location" when assigning the resource. But it expects the relative location.