### PR TITLE
Update basic.ipynb docs to reference PyLabRobot instead of PyHamilton

### DIFF
--- a/docs/basic.ipynb
+++ b/docs/basic.ipynb
@@ -6,7 +6,7 @@
       "source": [
         "# Basic liquid handling\n",
         "\n",
-        "In this notebook, you will learn how to use PyHamilton to move water from one range of wells to another.\n",
+        "In this notebook, you will learn how to use PyLabRobot to move water from one range of wells to another.\n",
         "\n",
         "**Note: before running this notebook, you should have**:\n",
         "\n",


### PR DESCRIPTION
Seems like this should reference PyLabRobot instead of PyHamilton, but I could be wrong?