### PR TITLE
[libusb] add libusb to simplify installation

### DIFF
--- a/pylabrobot/liquid_handling/backends/USBBackend.py
+++ b/pylabrobot/liquid_handling/backends/USBBackend.py
@@ -4,6 +4,7 @@ from abc import ABCMeta, abstractmethod
 import logging
 import time
 from typing import List, Optional, TYPE_CHECKING
+import libusb_package
 
 from pylabrobot.liquid_handling.backends.backend import LiquidHandlerBackend
 
@@ -149,7 +150,11 @@ class USBBackend(LiquidHandlerBackend, metaclass=ABCMeta):
     """ Get a list of available devices that match the specified vendor and product IDs, and serial
     number and address if specified. """
 
-    found_devices = usb.core.find(idVendor=self.id_vendor, idProduct=self.id_product, find_all=True)
+    found_devices = libusb_package.find(
+      idVendor=self.id_vendor,
+      idProduct=self.id_product,
+      find_all=True
+    )
     devices: List["usb.core.Device"] = []
     for dev in found_devices:
       if self.address is not None:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 
 extras_fw = [
-  "pyusb"
+  "pyusb",
+  "libusb_package<=1.0.26.2"
 ]
 
 extras_http = [


### PR DESCRIPTION
I found libusb_package debugging the "no backend available" error here https://github.com/pyusb/pyusb/blob/master/docs/faq.rst#how-do-i-fix-no-backend-available-errors

Seems like it's a very thin wrapper that adds the dll's in a findable place:

https://github.com/pyocd/libusb-package/blob/main/src/libusb_package/__init__.py

Seems like we could just use it from the start and avoid people from encountering this error in the first place?