### PR TITLE
[liquid_handling] fix unawaited machine backend setup

### DIFF
--- a/pylabrobot/liquid_handling/backends/backend.py
+++ b/pylabrobot/liquid_handling/backends/backend.py
@@ -46,7 +46,7 @@ class LiquidHandlerBackend(MachineBackend, metaclass=ABCMeta):
   async def setup(self):
     """ Set up the robot. This method should be called before any other method is called. """
     assert self._deck is not None, "Deck not set"
-    super().setup()
+    await super().setup()
 
   async def assigned_resource_callback(self, resource: Resource):
     """ Called when a new resource was assigned to the robot.


### PR DESCRIPTION
`lh.setup()` is broken since we don't await the machine backend setup