### PR TITLE
Update location of Opentrons ID for temperature module opentrons_back…

### DIFF
--- a/pylabrobot/temperature_controlling/opentrons_backend.py
+++ b/pylabrobot/temperature_controlling/opentrons_backend.py
@@ -23,7 +23,7 @@ class OpentronsTemperatureModuleBackend(TemperatureControllerBackend):
 
     Args:
       opentrons_id: Opentrons ID of the temperature module. Get it from
-        `OpentronsBackend().list_connected_modules()`.
+        `OpentronsBackend(host="x.x.x.x", port=31950).list_connected_modules()`.
     """
     self.opentrons_id = opentrons_id
 

--- a/pylabrobot/temperature_controlling/opentrons_backend.py
+++ b/pylabrobot/temperature_controlling/opentrons_backend.py
@@ -23,7 +23,7 @@ class OpentronsTemperatureModuleBackend(TemperatureControllerBackend):
 
     Args:
       opentrons_id: Opentrons ID of the temperature module. Get it from
-        `OpentronsTemperatureModuleBackend.list_connected_modules()`.
+        `OpentronsBackend().list_connected_modules()`.
     """
     self.opentrons_id = opentrons_id
 


### PR DESCRIPTION
I think the current comment docs here is a mistake?

```
>>> OpentronsTemperatureModuleBackend.list_connected_modules()

AttributeError: type object 'OpentronsTemperatureModuleBackend' has no attribute 'list_connected_modules'
```

Whereas:
```
>>> await OpentronsBackend(host="169.254.184.185", port=31950).list_connected_modules()

[{'id': 'fc409cc91770129af8eb0a01724c56cb052b306a',
  'serialNumber': 'TDV21P20201224B13',
  'firmwareVersion': 'v2.1.0',
  'hardwareRevision': 'temp_deck_v21',
  'hasAvailableUpdate': False,
  'moduleType': 'temperatureModuleType',
  'moduleModel': 'temperatureModuleV2',
  'data': {'status': 'idle', 'currentTemperature': 22.0},
  'usbPort': {'port': 1,
   'portGroup': 'main',
   'hub': False,
   'path': '1.0/tty/ttyACM1/dev'}},
 {'id': '8c4fba0f6c9d0a036e78ad80254cd55d1c091c29',
  'serialNumber': 'TCV0220210809A02',
  'firmwareVersion': 'v1.1.0',
  'hardwareRevision': 'v02',
  'hasAvailableUpdate': False,
  'moduleType': 'thermocyclerModuleType',
  'moduleModel': 'thermocyclerModuleV1',
  'data': {'status': 'idle',
   'currentTemperature': 22.1,
   'lidStatus': 'closed',
   'lidTemperatureStatus': 'idle',
   'lidTemperature': 21.97},
  'usbPort': {'port': 2,
   'portGroup': 'main',
   'hub': False,
   'path': '1.0/tty/ttyACM0/dev'}}]
```