### PR TITLE
Fix module loading for Opentrons

### DIFF
--- a/pylabrobot/liquid_handling/backends/opentrons_backend.py
+++ b/pylabrobot/liquid_handling/backends/opentrons_backend.py
@@ -151,7 +151,7 @@ class OpentronsBackend(LiquidHandlerBackend):
       assert isinstance(ot_location, int)
       ot_api.modules.load_module(
         slot=ot_location,
-        model="temperatureModuleV2",
+        model=resource.model,
         module_id=resource.backend.opentrons_id # type: ignore
       )
 

--- a/pylabrobot/temperature_controlling/opentrons.py
+++ b/pylabrobot/temperature_controlling/opentrons.py
@@ -30,7 +30,7 @@ class OpentronsTemperatureModuleV2(TemperatureController, OTModule):
       size_z=84.0, # height without any aluminum block
       backend=OpentronsTemperatureModuleBackend(opentrons_id=opentrons_id),
       category="temperature_controller",
-      model="opentrons_temperature_module_v2"
+      model="temperatureModuleV2"  # Must match OT moduleModel in list_connected_modules()
     )
 
     self.backend = OpentronsTemperatureModuleBackend(opentrons_id=opentrons_id)


### PR DESCRIPTION
Fixed how the Opentrons backend loads modules. Previously it was hard-coded to load the temp controller. Now it loads whatever the module name from the `model` attribute in the module classes (e.g., `OpentronsTemperatureModuleV2`)