### PR TITLE
Add serialization and deserialization methods to Pump, PumpArray, and PumpCalibration

### DIFF
--- a/pylabrobot/machines/__init__.py
+++ b/pylabrobot/machines/__init__.py
@@ -1,2 +1,1 @@
-
 from .machine import Machine

--- a/pylabrobot/machines/__init__.py
+++ b/pylabrobot/machines/__init__.py
@@ -1,0 +1,2 @@
+
+from .machine import Machine

--- a/pylabrobot/pumps/calibration.py
+++ b/pylabrobot/pumps/calibration.py
@@ -87,6 +87,16 @@ class PumpCalibration:
       raise NotImplementedError("Calibration filetype not supported.")
     raise NotImplementedError("Calibration format not supported.")
 
+  def serialize(self) -> dict:
+    return {
+      "calibration": self.calibration,
+      "calibration_mode": self.calibration_mode
+    }
+
+  @classmethod
+  def deserialize(cls, data: dict) -> PumpCalibration:
+    return cls(calibration=data["calibration"], calibration_mode=data["calibration_mode"])
+
   @classmethod
   def load_from_json(
     cls,

--- a/pylabrobot/pumps/pump.py
+++ b/pylabrobot/pumps/pump.py
@@ -33,6 +33,20 @@ class Pump(Machine):
       raise ValueError("Calibration may only have a single item for this pump")
     self.calibration = calibration
 
+  def serialize(self) -> dict:
+    if self.calibration is None:
+      return super().serialize()
+    return {**super().serialize(), "calibration": self.calibration.serialize()}
+
+  @classmethod
+  def deserialize(cls, data: dict):
+    data_copy = data.copy()
+    calibration_data = data_copy.pop("calibration", None)
+    if calibration_data is not None:
+      calibration = PumpCalibration.deserialize(calibration_data)
+      data_copy["calibration"] = calibration
+    return super().deserialize(data_copy)
+
   async def run_revolutions(self, num_revolutions: float):
     """ Run a given number of revolutions. This method will return after the command has been sent,
     and the pump will run until `halt` is called.

--- a/pylabrobot/pumps/pumparray.py
+++ b/pylabrobot/pumps/pumparray.py
@@ -51,6 +51,20 @@ class PumpArray(Machine):
 
     return self.backend.num_channels
 
+  def serialize(self) -> dict:
+    if self.calibration is None:
+      return super().serialize()
+    return {**super().serialize(), "calibration": self.calibration.serialize()}
+
+  @classmethod
+  def deserialize(cls, data: dict):
+    data_copy = data.copy()
+    calibration_data = data_copy.pop("calibration", None)
+    if calibration_data is not None:
+      calibration = PumpCalibration.deserialize(calibration_data)
+      data_copy["calibration"] = calibration
+    return super().deserialize(data_copy)
+
   async def run_revolutions(self, num_revolutions: Union[float, List[float]],
                             use_channels: Union[int, List[int]]):
     """ Run the specified channels for the specified number of revolutions.

--- a/pylabrobot/utils/object_parsing.py
+++ b/pylabrobot/utils/object_parsing.py
@@ -1,10 +1,7 @@
 from typing import Type, TypeVar, Optional
 
 T = TypeVar("T")
-def find_subclass(
-  class_name: str,
-  cls: Type[T]
-) -> Optional[Type[T]]:
+def find_subclass(class_name: str, cls: Type[T]) -> Optional[Type[T]]:
   """ Recursively find a subclass with the correct name.
 
   Args:


### PR DESCRIPTION
Allows for calibrations to be serialized and deserialized separately and within instances of pumps.

The commit adds serialization and deserialization methods to the `Pump`, `PumpArray`, and 'PumpCalibration' classes. These methods allow instances of the classes to be converted to and from a dictionary representation, making it easier to store and retrieve their state. This feature improves the flexibility and usability of the classes.