### PR TITLE
Expose Well.bottom() & Well.top() 

### DIFF
--- a/pylabrobot/resources/well.py
+++ b/pylabrobot/resources/well.py
@@ -2,6 +2,7 @@ import enum
 import math
 from typing import Callable, List, Optional, Tuple, Union
 
+from pylabrobot.resources.coordinate import Coordinate
 from pylabrobot.resources.container import Container
 from pylabrobot.resources.liquid import Liquid
 
@@ -78,8 +79,6 @@ class Well(Container):
     self.bottom_type = bottom_type
     self._compute_volume_from_height = compute_volume_from_height
     self.cross_section_type = cross_section_type
-    self.bottom = compute_well_bottom_coordinate
-    self.top = compute_well_top_coordinate
 
     self.tracker.register_callback(self._state_updated)
 
@@ -109,17 +108,28 @@ class Well(Container):
 
     return self._compute_volume_from_height(height)
   
-  def compute_well_bottom_coordinate(self, z_offset: float = 0.0) -> float:
-    """ Compute the 2D center coordinate of the bottom of a well, with the potential
+  def bottom(self, z_offset: float = 0.0):
+    """ Compute the absolute coordinate of the bottom of a well, with the potential
       to conveniantly declare a z_offset directly.
     """
-
-    if self._compute_volume_from_height is None:
-      raise NotImplementedError("compute_volume_from_height not implemented.")
-
-    return self._compute_volume_from_height(height)
-
-
+    
+    if self.location is None:
+      return None
+    else:
+      well_bottom_coordinate = self.get_absolute_location() + self.center()
+      return well_bottom_coordinate+Coordinate(0,0,z_offset)
+  
+  def top(self, z_offset: float = 0.0):
+    """ Compute the absolute coordinate of the top of a well, with the potential
+      to conveniantly declare a z_offset directly.
+    """
+    
+    if self.location is None:
+      return None
+    else:
+      well_top_coordinate = self.get_absolute_location() + self.center() + Coordinate(0,0,self.get_size_z())
+      return well_top_coordinate+Coordinate(0,0,z_offset)
+    
   def set_liquids(self, liquids: List[Tuple[Optional["Liquid"], float]]):
     """ Set the liquids in the well.
 

--- a/pylabrobot/resources/well.py
+++ b/pylabrobot/resources/well.py
@@ -130,25 +130,26 @@ class Well(Container):
     return self._compute_height_from_volume(liquid_volume)
 
   def bottom(self, z_offset: float = 0.0):
-      """ Compute the absolute coordinate of the bottom of a well, with the potential
-        to conveniantly declare a z_offset directly.
-      """
-      
-      if self.location is None:
-        return None
-      else:
-        well_bottom_coordinate = self.get_absolute_location() + self.center()
-        return well_bottom_coordinate + Coordinate(0,0,z_offset)
-  
+    """ Compute the absolute coordinate of the bottom of a well, with the potential
+      to conveniantly declare a z_offset directly.
+    """
+
+    if self.location is None:
+      return None
+    else:
+      well_bottom_coordinate = self.get_absolute_location() + self.center()
+      return well_bottom_coordinate + Coordinate(0,0,z_offset)
+
   def top(self, z_offset: float = 0.0):
     """ Compute the absolute coordinate of the top of a well, with the potential
       to conveniantly declare a z_offset directly.
     """
-    
+
     if self.location is None:
       return None
     else:
-      well_top_coordinate = self.get_absolute_location() + self.center() + Coordinate(0,0,self.get_size_z())
+      well_top_coordinate = self.get_absolute_location() + self.center() + \
+        Coordinate(0,0,self.get_size_z())
       return well_top_coordinate + Coordinate(0,0,z_offset)
 
   def set_liquids(self, liquids: List[Tuple[Optional["Liquid"], float]]):

--- a/pylabrobot/resources/well.py
+++ b/pylabrobot/resources/well.py
@@ -78,6 +78,8 @@ class Well(Container):
     self.bottom_type = bottom_type
     self._compute_volume_from_height = compute_volume_from_height
     self.cross_section_type = cross_section_type
+    self.bottom = compute_well_bottom_coordinate
+    self.top = compute_well_top_coordinate
 
     self.tracker.register_callback(self._state_updated)
 
@@ -106,6 +108,17 @@ class Well(Container):
       raise NotImplementedError("compute_volume_from_height not implemented.")
 
     return self._compute_volume_from_height(height)
+  
+  def compute_well_bottom_coordinate(self, z_offset: float = 0.0) -> float:
+    """ Compute the 2D center coordinate of the bottom of a well, with the potential
+      to conveniantly declare a z_offset directly.
+    """
+
+    if self._compute_volume_from_height is None:
+      raise NotImplementedError("compute_volume_from_height not implemented.")
+
+    return self._compute_volume_from_height(height)
+
 
   def set_liquids(self, liquids: List[Tuple[Optional["Liquid"], float]]):
     """ Set the liquids in the well.

--- a/pylabrobot/resources/well.py
+++ b/pylabrobot/resources/well.py
@@ -117,7 +117,7 @@ class Well(Container):
       return None
     else:
       well_bottom_coordinate = self.get_absolute_location() + self.center()
-      return well_bottom_coordinate+Coordinate(0,0,z_offset)
+      return well_bottom_coordinate + Coordinate(0,0,z_offset)
   
   def top(self, z_offset: float = 0.0):
     """ Compute the absolute coordinate of the top of a well, with the potential
@@ -128,7 +128,7 @@ class Well(Container):
       return None
     else:
       well_top_coordinate = self.get_absolute_location() + self.center() + Coordinate(0,0,self.get_size_z())
-      return well_top_coordinate+Coordinate(0,0,z_offset)
+      return well_top_coordinate + Coordinate(0,0,z_offset)
     
   def set_liquids(self, liquids: List[Tuple[Optional["Liquid"], float]]):
     """ Set the liquids in the well.

--- a/pylabrobot/resources/well.py
+++ b/pylabrobot/resources/well.py
@@ -129,6 +129,28 @@ class Well(Container):
 
     return self._compute_height_from_volume(liquid_volume)
 
+  def bottom(self, z_offset: float = 0.0):
+      """ Compute the absolute coordinate of the bottom of a well, with the potential
+        to conveniantly declare a z_offset directly.
+      """
+      
+      if self.location is None:
+        return None
+      else:
+        well_bottom_coordinate = self.get_absolute_location() + self.center()
+        return well_bottom_coordinate + Coordinate(0,0,z_offset)
+  
+  def top(self, z_offset: float = 0.0):
+    """ Compute the absolute coordinate of the top of a well, with the potential
+      to conveniantly declare a z_offset directly.
+    """
+    
+    if self.location is None:
+      return None
+    else:
+      well_top_coordinate = self.get_absolute_location() + self.center() + Coordinate(0,0,self.get_size_z())
+      return well_top_coordinate + Coordinate(0,0,z_offset)
+
   def set_liquids(self, liquids: List[Tuple[Optional["Liquid"], float]]):
     """ Set the liquids in the well.
 

--- a/pylabrobot/resources/well.py
+++ b/pylabrobot/resources/well.py
@@ -39,6 +39,7 @@ class Well(Container):
     bottom_type: Union[WellBottomType, str] = WellBottomType.UNKNOWN, category: str = "well",
     max_volume: Optional[float] = None, model: Optional[str] = None,
     compute_volume_from_height: Optional[Callable[[float], float]] = None,
+    compute_height_from_volume: Optional[Callable[[float], float]] = None,
     cross_section_type: Union[CrossSectionType, str] = CrossSectionType.CIRCLE):
     """ Create a new well.
 
@@ -78,6 +79,7 @@ class Well(Container):
       max_volume=max_volume, model=model)
     self.bottom_type = bottom_type
     self._compute_volume_from_height = compute_volume_from_height
+    self._compute_height_from_volume = compute_height_from_volume
     self.cross_section_type = cross_section_type
 
     self.tracker.register_callback(self._state_updated)
@@ -107,7 +109,26 @@ class Well(Container):
       raise NotImplementedError("compute_volume_from_height not implemented.")
 
     return self._compute_volume_from_height(height)
-  
+
+  def compute_height_from_volume(self, liquid_volume: float) -> float:
+    """ Compute the height of liquid in a well relative to the well's bottom
+      from the volume of the liquid.
+
+    Args:
+      liquid_volume: Volume of the liquid in the well.
+
+    Returns:
+      Height of the liquid in the well relative to the bottom.
+
+    Raises:
+      NotImplementedError: If the plate does not have a volume computation function.
+    """
+
+    if self._compute_height_from_volume is None:
+      raise NotImplementedError("compute_height_from_volume not implemented.")
+
+    return self._compute_height_from_volume(liquid_volume)
+
   def bottom(self, z_offset: float = 0.0):
     """ Compute the absolute coordinate of the bottom of a well, with the potential
       to conveniantly declare a z_offset directly.
@@ -129,7 +150,7 @@ class Well(Container):
     else:
       well_top_coordinate = self.get_absolute_location() + self.center() + Coordinate(0,0,self.get_size_z())
       return well_top_coordinate + Coordinate(0,0,z_offset)
-    
+
   def set_liquids(self, liquids: List[Tuple[Optional["Liquid"], float]]):
     """ Set the liquids in the well.
 


### PR DESCRIPTION
Hi everyone,

Let's expose some of that Opentrons wisdom to PLR:

In this PR I added two small methods to the `Well` class in `resources/well.py`:
1. `Well.bottom(z_offset=0.0)` ... convenient method to compute the absolute Coordinate of the 2D central bottom of a well, with the added functionality that a z_offset can directly be declared.
2. `Well.top(z_offset=0.0)` ... similar as above just for the 2D central top of a well.

## Why

With `Well.get_absolute_location()` already in place there is a valid question as to why generate these two methods.
The main reason is convenience and clarity to facilitate plate definition creation.

Currently, when defining labware there is no PLR `probe_z_height_using_channel` function (which I created in #69) that works with standard plates and tubes because `probe_z_height_using_channel` detects items using capacitative liquid level detection but cannot detect plates due to their material being highly electrically resistant.

As a consequence, the dimensions of a plate have to be manually evaluated. In particular the depth of a well represents a small but important challenge: it is arguably one of the most important definitions to get right to avoid crashes and minimise dead volume.

It is therefore important that the machine used enables moving a tip quickly to the bottom of a well and to the top of a well, back and forth, with the ability to efficiently add a z_offset to each Coordinate.
(A laminated piece of paper is very effective at testing whether `Well.top()` is indeed the top of the well, and when moving the tip to `Well.bottom()`, the tip can be slightly moved by hand, sensing slight resistance to the move, i.e. the tip hasn't crashed.)

## Example Use Case

A step-by-step guide to conveniently and transparently use these little methods:

```python
# Define plate carrier & assign to deck
plt_carrier_1 = PLT_CAR_L5AC_A00(name='plt_carrier_1')
lh.deck.assign_child_resource(plt_carrier_1, rails=1)

# Define & assign plate to carrier site
plt_carrier_1[0] = ThermoScientific_96_1200ul_Rd_1 = ThermoScientific_96_1200ul_Rd(name="ThermoScientific_96_1200ul_Rd")

# Pick up tip (any way you want to, there are many options to automate tip selection)

# Safety first :)
await lh.backend.move_all_channels_in_z_safety() # safe z height

y_pos_start = 10    # safe y positions (for an 8-channel STAR system, be careful with 12- & 16-channel systems)
for channel_idx in reversed(range(0,8)):
    print(f"channel {channel_idx} -> {y_pos_start}")
    await lh.backend.move_channel_y(y=y_pos_start, channel=channel_idx)
    y_pos_start += 9
# channel 7 -> 10
# channel 6 -> 19
# channel 5 -> 28
# channel 4 -> 37
# channel 3 -> 46
# channel 2 -> 55
# channel 1 -> 64
# channel 0 -> 73

# Move tip to plate well for definition testing
test_well_bottom_coordinate = ThermoScientific_96_1200ul_Rd_1['H1'][0].bottom()
# Coordinate(x=117.75, y=82.95, z=186.35)

test_well_top_coordinate = ThermoScientific_96_1200ul_Rd_1['H1'][0].top()
# Coordinate(x=117.75, y=82.95, z=206.85)

# note channel_0 (most backwards channel) can currently move in y to any well without crashing into another channel
# do not use any other channel, because it will crash :)

await lh.backend.move_channel_x(x=test_well_bottom_coordinate.x, channel=0)
await lh.backend.move_channel_y(y=test_well_bottom_coordinate.y, channel=0)


# Probe correctness of the top of the well: place laminated piece of paper on top of well and
# move channel_0 incrementally until paper cannot be moved without some resistance

# await lh.backend.move_channel_z(z=test_well_top_coordinate.z+2, channel=0)
# await lh.backend.move_channel_z(z=test_well_top_coordinate.z+1, channel=0)
# await lh.backend.move_channel_z(z=test_well_top_coordinate.z, channel=0)
...
await lh.backend.move_channel_z(z=test_well_top_coordinate.z-3.2, channel=0)

# => you found that the top of the well is actually 3.2 mm below where PLR thinks it is


# Probe correctness of the bottom of the well: move tip a couple of mm above the bottom
# and incrementally move tip down in z until manual tip "jiggling" encounters some resistance

# await lh.backend.move_channel_z(z=test_well_bottom_coordinate.z+2, channel=0)
# await lh.backend.move_channel_z(z=test_well_bottom_coordinate.z+1, channel=0)
await lh.backend.move_channel_z(z=test_well_bottom_coordinate.z, channel=0)

# => you found that the bottom of the well is correctly defined

# Calculate the true depth of the well
(test_well_top_coordinate.z-3.2) - test_well_bottom_coordinate.z

# => update Plate definition based on your labware testing results 
# & submit a pull request to share your findings with the community
```

I hope this helps PLR users to create more robust labware definitions.