### PR TITLE
fix: close event loop that starts in thread

### DIFF
--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -182,6 +182,7 @@ class LiquidHandler(Machine):
       loop = asyncio.new_event_loop()
       asyncio.set_event_loop(loop)
       loop.run_until_complete(func(*args, **kwargs))
+      loop.close()
 
     t = threading.Thread(target=callback, args=args, kwargs=kwargs)
     t.start()


### PR DESCRIPTION
## Problem
The `_run_async_in_thread` method in the `LiquidHandler` class was causing `ResourceWarning` issues related to unclosed sockets. This warning was being raised at the end of pytests in a library of mine that is starting to use PyLabRobot: [graphmix](https://github.com/jt05610/python-graphmix). 


![Screenshot 2024-06-04 at 5 07 18 PM](https://github.com/PyLabRobot/pylabrobot/assets/59382877/bfbf2b9a-86cc-41d8-ae4d-cc3e88ea2d4e)

## To reproduce
Set filterwarnings = error in pytest.ini:

```ini

[pytest]
python_files = *_tests.py

filterwarnings =
    error
```


## Solution
Added `loop.close()` to the end of the callback in _run_async_in_thread to close the event loop that gets created for the callback.

## Testing
- Ran the existing test suite, and all tests pass with the applied changes.
- Verified that the `ResourceWarning` is no longer raised at the end of Python tests.

Please review and consider merging this pull request to resolve the socket warning issue.