### PR TITLE
Make PlateAdapter accessible on PlateCarrierSite

### DIFF
--- a/pylabrobot/resources/carrier.py
+++ b/pylabrobot/resources/carrier.py
@@ -6,7 +6,7 @@ from typing import Generic, List, Optional, Type, TypeVar, Union
 from .coordinate import Coordinate
 from .plate import Plate
 from .resource import Resource
-
+from .plate_adapter import PlateAdapter
 
 logger = logging.getLogger("pylabrobot")
 
@@ -172,7 +172,9 @@ class Carrier(Resource, Generic[S]):
 
 
 class TipCarrier(Carrier):
-  """ Base class for tip carriers. """
+  """ Base class for tip carriers.
+  Name prefix: 'TIP_'
+  """
   def __init__(
     self,
     name: str,
@@ -202,8 +204,9 @@ class PlateCarrierSite(CarrierSite):
 
   def assign_child_resource(self, resource: Resource, location: Coordinate = Coordinate.zero(),
                             reassign: bool = True):
-    if not isinstance(resource, Plate):
-      raise TypeError(f"PlateCarrierSite can only store Plate resources, not {type(resource)}")
+    if not isinstance(resource, (Plate, PlateAdapter)):
+      raise TypeError("PlateCarrierSite can only store Plate or PlateAdapter resources," + \
+                      f" not {type(resource)}")
 
     # TODO: add conditional logic to modify Plate position based on whether
     # pedestal_size_z>plate_true_dz OR pedestal_z<pedestal_size_z IF child.category == 'plate'
@@ -214,7 +217,9 @@ class PlateCarrierSite(CarrierSite):
 
 
 class PlateCarrier(Carrier):
-  """ Base class for plate carriers. """
+  """ Base class for plate carriers.
+  Name prefix: 'PLT_'
+  """
   def __init__(
     self,
     name: str,
@@ -229,7 +234,9 @@ class PlateCarrier(Carrier):
 
 
 class MFXCarrier(Carrier):
-  """ Base class for multiflex carriers (i.e. carriers with mixed-use and/or specialized sites). """
+  """ Base class for multiflex carriers (i.e. carriers with mixed-use and/or specialized sites).
+  Name prefix: 'MFX_'
+  """
   def __init__(
     self,
     name: str,
@@ -243,24 +250,10 @@ class MFXCarrier(Carrier):
       sites,category=category, model=model)
 
 
-class ShakerCarrier(Carrier):
-  """ Base class for shaker carriers (i.e. 7-track carriers with mixed-use and/or specialized
-  sites). """
-  def __init__(
-    self,
-    name: str,
-    size_x: float,
-    size_y: float,
-    size_z: float,
-    sites: Optional[List[CarrierSite]] = None,
-    category="shaker_carrier",
-    model: Optional[str] = None):
-    super().__init__(name, size_x, size_y, size_z,
-      sites,category=category, model=model)
-
-
 class TubeCarrier(Carrier):
-  """ Base class for tube/sample carriers. """
+  """ Base class for tube/sample carriers.
+  Name prefix: 'SMP_'
+  """
   def __init__(
     self,
     name: str,
@@ -269,6 +262,23 @@ class TubeCarrier(Carrier):
     size_z: float,
     sites: Optional[List[CarrierSite]] = None,
     category="tube_carrier",
+    model: Optional[str] = None):
+    super().__init__(name, size_x, size_y, size_z,
+      sites,category=category, model=model)
+
+
+class ReagentCarrier(Carrier):
+  """ Base class for reagent/trough carriers.
+  Name prefix: 'RGT_'
+  """
+  def __init__(
+    self,
+    name: str,
+    size_x: float,
+    size_y: float,
+    size_z: float,
+    sites: Optional[List[CarrierSite]] = None,
+    category="reagent_carrier",
     model: Optional[str] = None):
     super().__init__(name, size_x, size_y, size_z,
       sites,category=category, model=model)


### PR DESCRIPTION
Hi everyone,

A tiny PR in which I have made changes in `pylabrobot/resources/carrier.py`...

1. enabled the assignment of a resource of type `PlateAdapter` as a child to `PlateCarrierSite` (specifically thinking about SLAS layout plate adapters like [Opentrons 96-well adapter](https://labware.opentrons.com/opentrons_96_well_aluminum_block?category=adapter)),
2. removed the `ShakerCarrier` subclass because there is only one shaker carrier and its only instance is implemented as a `MFXCarrier`,
3. added `ReagentCarrier` as a new subclass of `Carrier` as we discussed on [this automation forum thread](https://labautomation.io/t/standardized-labware-naming-convention-discussion/3787/19) that we keep all Hamilton carriers as separate, and
4. added the carrier name prefix to the docstrings to help people adhere to the naming convention.