### PR TITLE
remove “currently defined”

### DIFF
--- a/pylabrobot/resources/alpaqua/README.md
+++ b/pylabrobot/resources/alpaqua/README.md
@@ -1,4 +1,3 @@
-
 ## Resource defintions: Alpaqua Engineering, LLC
 
 Company page: [Alpaqua Engineering, LLC](https://www.alpaqua.com/about-us/)
@@ -6,7 +5,7 @@ Company page: [Alpaqua Engineering, LLC](https://www.alpaqua.com/about-us/)
 > Alpaqua Engineering, LLC, founded in 2006, is a global provider of tools for accelerating genomic applications such as NGS, nucleic acid extraction and clean up, target capture, and molecular diagnostics.
 Our products include a line of innovative, high performance magnet plates built with proprietary magnet architecture and spring cushion technology.  Also available are aluminum tube blocks to help maintain temperature control, SBS /ANSI standard tube racks and the Alpillo® Plate Cushion, which enables pipetting from the bottom of a well without tip occlusion​.
 
-### Currently defined labware:
+### Labware:
 
 | Description               | Image              |
 |--------------------|--------------------|

--- a/pylabrobot/resources/azenta/README.md
+++ b/pylabrobot/resources/azenta/README.md
@@ -1,4 +1,3 @@
-
 ## Resource defintions: Azenta
 
 Company wikipedia: [Azenta](https://en.wikipedia.org/wiki/Azenta)
@@ -7,7 +6,7 @@ Company wikipedia: [Azenta](https://en.wikipedia.org/wiki/Azenta)
 > In 2017, Brooks acquired 4titude, a maker of scientific tools and consumables, while in 2018, Brooks acquired GENEWIZ, a genomics services provider as part of their life sciences division's expansion.
 > In November 2021, Brooks Automation Inc. split into two entities, Brooks Automation and Azenta Life Sciences. The latter will focus exclusively on their life science division.
 
-### Currently defined labware:
+### Labware:
 
 | Description               | Image              | PLR definition |
 |--------------------|--------------------|--------------------|

--- a/pylabrobot/resources/corning_axygen/README.md
+++ b/pylabrobot/resources/corning_axygen/README.md
@@ -1,11 +1,10 @@
-
 ## Resource defintions: Corning - Axygen
 
 Company page: [Corning - Axygen® Brand Products](https://www.corning.com/emea/en/products/life-sciences/resources/brands/axygen-brand-products.html)
 
 > Corning acquired Axygen BioScience, Inc. and its subsidiaries in 2009. This acquisition included Axygen's broad portfolio of high-quality plastic consumables, liquid handling products, and bench-top laboratory equipment, which complemented and expanded Corning's offerings in the life sciences segment​.
 
-### Currently defined labware:
+### Labware:
 
 | Description               | Image              |
 |--------------------|--------------------|

--- a/pylabrobot/resources/corning_costar/README.md
+++ b/pylabrobot/resources/corning_costar/README.md
@@ -1,4 +1,3 @@
-
 ## Resource defintions: Corning - Costar
 
 Wikipedia page: [Corning](https://en.wikipedia.org/wiki/Corning_Inc.)
@@ -7,7 +6,7 @@ Wikipedia page: [Corning](https://en.wikipedia.org/wiki/Corning_Inc.)
 
 As of 2014, Corning had five major business sectors: display technologies, environmental technologies, life sciences, optical communications, and specialty materials.
 
-### Currently defined labware:
+### Labware:
 
 | Description               | Image              | PLR definition |
 |--------------------|--------------------|--------------------|

--- a/pylabrobot/resources/ml_star/README.md
+++ b/pylabrobot/resources/ml_star/README.md
@@ -1,4 +1,3 @@
-
 ## Resource defintions: "ML_STAR"
 
 Company history: [Hamilton Robotics history](https://www.hamiltoncompany.com/history)
@@ -7,7 +6,7 @@ Company history: [Hamilton Robotics history](https://www.hamiltoncompany.com/his
 
 ---
 
-### Currently defined tip carriers:
+### Tip carriers:
 
 | Description               | Image              | PLR definition |
 |--------------------|--------------------|--------------------|
@@ -15,7 +14,7 @@ Company history: [Hamilton Robotics history](https://www.hamiltoncompany.com/his
 
 ---
 
-### Currently defined plate carriers:
+### Plate carriers:
 
 | Description               | Image              | PLR definition |
 |--------------------|--------------------|--------------------|
@@ -23,7 +22,7 @@ Company history: [Hamilton Robotics history](https://www.hamiltoncompany.com/his
 
 ---
 
-### Currently defined MFX carriers:
+### MFX carriers:
 
 | Description               | Image              | PLR definition |
 |--------------------|--------------------|--------------------|
@@ -31,7 +30,7 @@ Company history: [Hamilton Robotics history](https://www.hamiltoncompany.com/his
 
 
 
-#### Currently defined MFX modules:
+#### MFX modules:
 
 | Description               | Image              | PLR definition |
 |--------------------|--------------------|--------------------|
@@ -41,7 +40,7 @@ Company history: [Hamilton Robotics history](https://www.hamiltoncompany.com/his
 
 ---
 
-### Currently defined Trough carriers:
+### Trough carriers:
 
 | Description               | Image              | PLR definition |
 |--------------------|--------------------|--------------------|
@@ -49,20 +48,17 @@ Company history: [Hamilton Robotics history](https://www.hamiltoncompany.com/his
 
 
 
-#### Currently defined Troughs:
+#### Troughs:
 
 | Description               | Image              | PLR definition |
 |--------------------|--------------------|--------------------|
 | 'Hamilton_1_trough_200ml_Vb'<br>Part no.: 56695-02<br>[manufacturer website](https://www.hamiltoncompany.com/automated-liquid-handling/other-robotics/56695-02) <br>Trough 200ml, w lid, self standing, Black. <br>Compatible with Trough_CAR_4R200_A00 (185436). | <img src="ims/Hamilton_1_trough_200ml_Vb.jpg" alt="Hamilton_1_trough_200ml_Vb" width="250"/> | `Hamilton_1_trough_200ml_Vb` |
 
 
-
 ---
 
-### Currently defined Adapters:
+### Adapters:
 
 | Description               | Image              | PLR definition |
 |--------------------|--------------------|--------------------|
 | 'Hamilton_96_adapter_188182'<br>Part no.: 188182<br>[manufacturer website](https://www.hamiltoncompany.com/automated-liquid-handling/other-robotics/188182) (<-non-functional link?) <br>Adapter for 96 well PCR plate, plunged. Does not have an ANSI/SLAS footprint -> requires assignment with specified location. | <img src="ims/Hamilton_96_adapter_188182.png" alt="Hamilton_96_adapter_188182" width="250"/> | `Hamilton_96_adapter_188182` |
-
-

--- a/pylabrobot/resources/porvair/README.md
+++ b/pylabrobot/resources/porvair/README.md
@@ -1,11 +1,10 @@
-
 ## Resource defintions: Porvair
 
 Company history: [Porvair Filtration Group](https://www.porvairfiltration.com/about/our-history/)
 
 > Porvair Filtration Group, a wholly owned subsidiary of Porvair plc, is a specialist filtration and environmental technology group involved in developing, designing and manufacturing filtration and separation solutions to industry sectors such as the aviation, molten metal, energy, water treatment and life sciences markets. Porvair plc is a publically owned company with four principal subsidiaries: Porvair Filtration Group Ltd., Porvair Sciences Ltd., Selee Corporation and Seal Analytical Ltd.
 
-### Currently defined labware:
+### Labware:
 
 | Description               | Image              | PLR definition |
 |--------------------|--------------------|--------------------|

--- a/pylabrobot/resources/revvity/README.md
+++ b/pylabrobot/resources/revvity/README.md
@@ -1,11 +1,10 @@
-
 ## Resource defintions: Revvity
 
 Company wikipedia: [Revvity, Inc. (formerly PerkinElmer, Inc.)](https://en.wikipedia.org/wiki/Revvity)
 
 > In 2022, a split of PerkinElmer resulted in one part, comprising its applied, food and enterprise services businesses, being sold to the private equity firm New Mountain Capital for $2.45 billion and thus no longer being public but keeping the PerkinElmer name. The other part, comprised of the life sciences and diagnostics businesses, remained public but required a new name, which in 2023 was announced as Revvity, Inc. From the perspective of Revvity, the goal of creating a separate company was that its businesses might show greater profit margins and more in the way of growth potential. An associated goal was to have more financial flexibility moving forward. On May 16, 2023, the PerkinElmer stock symbol PKI was replaced by the new symbol RVTY.
 
-### Currently defined labware:
+### Labware:
 
 | Description               | Image              | PLR definition |
 |--------------------|--------------------|--------------------|


### PR DESCRIPTION
I removed "Currently defined" from the README labware docs, because no resource in the list is "currently undefined".

@BioCam, what do you think?