### PR TITLE
Correct plate dimensions

### DIFF
--- a/docs/resources/plates.md
+++ b/docs/resources/plates.md
@@ -1,6 +1,8 @@
 # Plates
 
-Microplates are modelled by the {class}`~pylabrobot.resources.plate.Plate` class consist of equally spaced wells. Wells are children of the `Plate` and are modelled by the {class}`~pylabrobot.resources.well.Well` class. `Plate` is a subclass of {class}`~pylabrobot.resources.itemized_resource.ItemizedResource`, allowing convenient integer and string indexing.
+Microplates are modelled by the {class}`~pylabrobot.resources.plate.Plate` class consist of equally spaced wells. Wells are children of the `Plate` and are modelled by the {class}`~pylabrobot.resources.well.Well` class. The relative positioning of `Well`s is what determines their location. `Plate` is a subclass of {class}`~pylabrobot.resources.itemized_resource.ItemizedResource`, allowing convenient integer and string indexing.
+
+There is some standardization on plate dimensions by SLAS, which you can read more about in the [ANSI SLAS 1-2004 (R2012): Footprint Dimensions doc](https://www.slas.org/SLAS/assets/File/public/standards/ANSI_SLAS_1-2004_FootprintDimensions.pdf). Note that PLR fully supports all plate dimensions, sizes, relative well spacings, etc.
 
 ## Lids
 

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
@@ -602,10 +602,10 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
   async def test_iswap(self):
     await self.lh.move_plate(self.plate, self.plt_car[2])
     self._assert_command_sent_once(
-      "C0PPid0011xs03475xd0yj1145yd0zj1874zd0gr1th2450te2450gw4go1300gb1237gt20ga0gc1",
+      "C0PPid0011xs03478xd0yj1142yd0zj1874zd0gr1th2450te2450gw4go1307gb1244gt20ga0gc1",
       "xs#####xd#yj####yd#zj####zd#gr#th####te####gw#go####gb####gt##ga#gc#")
     self._assert_command_sent_once(
-      "C0PRid0012xs03475xd0yj3065yd0zj1874zd0th2450te2450gr1go1300ga0",
+      "C0PRid0012xs03478xd0yj3062yd0zj1874zd0th2450te2450gr1go1307ga0",
       "xs#####xd#yj####yd#zj####zd#th####te####go####ga#")
 
   async def test_iswap_plate_reader(self):
@@ -617,23 +617,23 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     await self.lh.move_plate(self.plate, plate_reader, pickup_distance_from_top=8.2,
       get_direction=GripDirection.FRONT, put_direction=GripDirection.LEFT)
     self._assert_command_sent_once(
-      "C0PPid0003xs03475xd0yj1145yd0zj1924zd0th2450te2450gw4gb1237go1300gt20gr1ga0gc1",
+      "C0PPid0003xs03478xd0yj1142yd0zj1924zd0th2450te2450gw4gb1244go1307gt20gr1ga0gc1",
                 "xs#####xd#yj####yd#zj####zd#th####te####gw#gb####go####gt##gr#ga#gc#")
     self._assert_command_sent_once(
-      "C0PRid0004xs10430xd0yj3282yd0zj2063zd0th2450te2450go1300gr4ga0",
+      "C0PRid0004xs10427xd0yj3285yd0zj2063zd0th2450te2450go1307gr4ga0",
                 "xs#####xd#yj####yd#zj####zd#th####te####go####gr#ga#")
 
     assert self.plate.rotation == 90
-    assert self.plate.get_size_x() == 86 and self.plate.get_size_y() == 127
+    assert self.plate.get_size_x() == 85.48 and self.plate.get_size_y() == 127.76
 
     await self.lh.move_plate(plate_reader.get_plate(), self.plt_car[0],
       pickup_distance_from_top=8.2, get_direction=GripDirection.LEFT,
       put_direction=GripDirection.FRONT)
     self._assert_command_sent_once(
-      "C0PPid0005xs10430xd0yj3282yd0zj2063zd0gr4th2450te2450gw4go1300gb1237gt20ga0gc1",
+      "C0PPid0005xs10427xd0yj3285yd0zj2063zd0gr4th2450te2450gw4go1307gb1244gt20ga0gc1",
                 "xs#####xd#yj####yd#zj####zd#gr#th####te####gw#go####gb####gt##ga#gc#")
     self._assert_command_sent_once(
-      "C0PRid0006xs03475xd0yj1145yd0zj1924zd0th2450te2450gr1go1300ga0",
+      "C0PRid0006xs03478xd0yj1142yd0zj1924zd0th2450te2450gr1go1307ga0",
                 "xs#####xd#yj####yd#zj####zd#th####te####gr#go####ga#")
 
   async def test_iswap_move_lid(self):
@@ -642,10 +642,10 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     await self.lh.move_lid(self.plate.lid, self.other_plate)
 
     self._assert_command_sent_once(
-      "C0PPid0002xs03475xd0yj1145yd0zj1949zd0gr1th2450te2450gw4go1300gb1237gt20ga0gc1",
+      "C0PPid0002xs03478xd0yj1142yd0zj1949zd0gr1th2450te2450gw4go1307gb1244gt20ga0gc1",
       GET_PLATE_FMT)
     self._assert_command_sent_once( # zj sent = 1849
-      "C0PRid0003xs03475xd0yj2105yd0zj1949zd0th2450te2450gr1go1300ga0", PUT_PLATE_FMT)
+      "C0PRid0003xs03478xd0yj2102yd0zj1949zd0th2450te2450gr1go1307ga0", PUT_PLATE_FMT)
 
   async def test_iswap_stacking_area(self):
     stacking_area = ResourceStack("stacking_area", direction="z")
@@ -657,18 +657,18 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     assert self.plate.lid is not None
     await self.lh.move_lid(self.plate.lid, stacking_area)
     self._assert_command_sent_once(
-      "C0PPid0002xs03475xd0yj1145yd0zj1949zd0gr1th2450te2450gw4go1300gb1237gt20ga0gc1",
+      "C0PPid0002xs03478xd0yj1142yd0zj1949zd0gr1th2450te2450gw4go1307gb1244gt20ga0gc1",
         GET_PLATE_FMT)
     self._assert_command_sent_once(
-      "C0PRid0003xs00695xd0yj4570yd0zj2305zd0th2450te2450gr1go1300ga0", PUT_PLATE_FMT)
+      "C0PRid0003xs00698xd0yj4567yd0zj2305zd0th2450te2450gr1go1307ga0", PUT_PLATE_FMT)
 
     # Move lids back (reverse order)
     await self.lh.move_lid(cast(Lid, stacking_area.get_top_item()), self.plate)
     self._assert_command_sent_once(
-      "C0PPid0004xs00695xd0yj4570yd0zj2305zd0gr1th2450te2450gw4go1300gb1237gt20ga0gc1",
+      "C0PPid0004xs00698xd0yj4567yd0zj2305zd0gr1th2450te2450gw4go1307gb1244gt20ga0gc1",
       GET_PLATE_FMT)
     self._assert_command_sent_once(
-      "C0PRid0005xs03475xd0yj1145yd0zj1949zd0th2450te2450gr1go1300ga0", PUT_PLATE_FMT)
+      "C0PRid0005xs03478xd0yj1142yd0zj1949zd0th2450te2450gr1go1307ga0", PUT_PLATE_FMT)
 
   async def test_iswap_stacking_area_2lids(self):
     # for some reason it was like this at some point
@@ -680,36 +680,36 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
 
     await self.lh.move_lid(self.plate.lid, stacking_area)
     self._assert_command_sent_once(
-      "C0PPid0002xs03475xd0yj1145yd0zj1949zd0gr1th2450te2450gw4go1300gb1237gt20ga0gc1",
+      "C0PPid0002xs03478xd0yj1142yd0zj1949zd0gr1th2450te2450gw4go1307gb1244gt20ga0gc1",
         GET_PLATE_FMT)
     self._assert_command_sent_once(
-      "C0PRid0003xs00695xd0yj4570yd0zj2305zd0th2450te2450gr1go1300ga0", PUT_PLATE_FMT)
+      "C0PRid0003xs00698xd0yj4567yd0zj2305zd0th2450te2450gr1go1307ga0", PUT_PLATE_FMT)
 
     await self.lh.move_lid(self.other_plate.lid, stacking_area)
     self._assert_command_sent_once(
-      "C0PPid0004xs03475xd0yj2105yd0zj1949zd0gr1th2450te2450gw4go1300gb1237gt20ga0gc1",
+      "C0PPid0004xs03478xd0yj2102yd0zj1949zd0gr1th2450te2450gw4go1307gb1244gt20ga0gc1",
         GET_PLATE_FMT)
     self._assert_command_sent_once(
-      "C0PRid0005xs00695xd0yj4570yd0zj2405zd0th2450te2450gr1go1300ga0", PUT_PLATE_FMT)
+      "C0PRid0005xs00698xd0yj4567yd0zj2405zd0th2450te2450gr1go1307ga0", PUT_PLATE_FMT)
 
     # Move lids back (reverse order)
     top_item = stacking_area.get_top_item()
     assert isinstance(top_item, Lid)
     await self.lh.move_lid(top_item, self.plate)
     self._assert_command_sent_once(
-      "C0PPid0004xs00695xd0yj4570yd0zj2405zd0gr1th2450te2450gw4go1300gb1237gt20ga0gc1",
+      "C0PPid0004xs00698xd0yj4567yd0zj2405zd0gr1th2450te2450gw4go1307gb1244gt20ga0gc1",
       GET_PLATE_FMT)
     self._assert_command_sent_once(
-      "C0PRid0005xs03475xd0yj1145yd0zj1949zd0th2450te2450gr1go1300ga0", PUT_PLATE_FMT)
+      "C0PRid0005xs03478xd0yj1142yd0zj1949zd0th2450te2450gr1go1307ga0", PUT_PLATE_FMT)
 
     top_item = stacking_area.get_top_item()
     assert isinstance(top_item, Lid)
     await self.lh.move_lid(top_item, self.other_plate)
     self._assert_command_sent_once(
-      "C0PPid0004xs00695xd0yj4570yd0zj2305zd0gr1th2450te2450gw4go1300gb1237gt20ga0gc1",
+      "C0PPid0004xs00698xd0yj4567yd0zj2305zd0gr1th2450te2450gw4go1307gb1244gt20ga0gc1",
       GET_PLATE_FMT)
     self._assert_command_sent_once(
-      "C0PRid0005xs03475xd0yj2105yd0zj1949zd0th2450te2450gr1go1300ga0", PUT_PLATE_FMT)
+      "C0PRid0005xs03478xd0yj2102yd0zj1949zd0th2450te2450gr1go1307ga0", PUT_PLATE_FMT)
 
   async def test_iswap_move_with_intermediate_locations(self):
     await self.lh.move_plate(self.plate, self.plt_car[1], intermediate_locations=[
@@ -718,14 +718,14 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     ])
 
     self._assert_command_sent_once(
-      "C0PPid0023xs03475xd0yj1145yd0zj1874zd0gr1th2450te2450gw4go1300gb1237gt20ga0gc1",
+      "C0PPid0023xs03478xd0yj1142yd0zj1874zd0gr1th2450te2450gw4go1307gb1244gt20ga0gc1",
       GET_PLATE_FMT)
     self._assert_command_sent_once(
-      "C0PMid0025xs03975xd0yj3065yd0zj2434zd0gr1th2450ga1xe4 1", INTERMEDIATE_FMT)
+      "C0PMid0024xs02978xd0yj4022yd0zj2434zd0gr1th2450ga1xe4 1", INTERMEDIATE_FMT)
     self._assert_command_sent_once(
-      "C0PMid0024xs02975xd0yj4025yd0zj2434zd0gr1th2450ga1xe4 1", INTERMEDIATE_FMT)
+      "C0PMid0025xs03978xd0yj3062yd0zj2434zd0gr1th2450ga1xe4 1", INTERMEDIATE_FMT)
     self._assert_command_sent_once(
-      "C0PRid0026xs03475xd0yj2105yd0zj1874zd0th2450te2450gr1go1300ga0",
+      "C0PRid0026xs03478xd0yj2102yd0zj1874zd0th2450te2450gr1go1307ga0",
       PUT_PLATE_FMT)
 
   async def test_discard_tips(self):
@@ -771,10 +771,10 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
                              use_arm="core")
     self._assert_command_sent_once("C0ZTid0020xs07975xd0ya1240yb1065pa07pb08tp2350tz2250th2450tt14",
                                    "xs#####xd#ya####yb####pa##pb##tp####tz####th####tt##")
-    self._assert_command_sent_once("C0ZPid0021xs03475xd0yj1145yv0050zj1876zy0500yo0890yg0830yw15"
+    self._assert_command_sent_once("C0ZPid0021xs03478xd0yj1142yv0050zj1876zy0500yo0884yg0824yw15"
                                    "th2450te2450",
                                    "xs#####xd#yj####yv####zj####zy####yo####yg####yw##th####te####")
-    self._assert_command_sent_once("C0ZRid0022xs03475xd0yj2105zj1876zi000zy0500yo0890th2450te2450",
+    self._assert_command_sent_once("C0ZRid0022xs03478xd0yj2102zj1876zi000zy0500yo0884th2450te2450",
                                    "xs#####xd#yj####zj####zi###zy####yo####th####te####")
     self._assert_command_sent_once("C0ZSid0023xs07975xd0ya1240yb1065tp2150tz2050th2450te2450",
                                     "xs#####xd#ya####yb####tp####tz####th####te####")

--- a/pylabrobot/liquid_handling/backends/hamilton/vantage_tests.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/vantage_tests.py
@@ -349,11 +349,11 @@ class TestVantageLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
 
     # pickup
     self._assert_command_sent_once(
-      "A1RMDGid0240xp6175yp1145zp1954yw81yo1302yg1237pt20zc0hd0te2840",
+      "A1RMDGid0240xp6178yp1142zp1954yw81yo1309yg1244pt20zc0hd0te2840",
       {"xp": "int", "yp": "int", "zp": "int", "yw": "int", "yo": "int", "yg": "int", "pt": "int",
        "zc": "int", "hd": "int", "te": "int"})
 
     # release
     self._assert_command_sent_once(
-      "A1RMDRid0242xp6175yp2105zp1954yo1302zc0hd0te2840",
+      "A1RMDRid0242xp6178yp2102zp1954yo1309zc0hd0te2840",
       {"xp": "int", "yp": "int", "zp": "int", "yo": "int", "zc": "int", "hd": "int", "te": "int"})

--- a/pylabrobot/resources/alpaqua/magnetic_racks.py
+++ b/pylabrobot/resources/alpaqua/magnetic_racks.py
@@ -11,8 +11,8 @@ def Alpaqua_96_magnum_flx(name: str) -> PlateAdapter:
   """
   return PlateAdapter(
     name=name,
-    size_x=127.0,
-    size_y=86.0,
+    size_x=127.76,
+    size_y=85.48,
     size_z=35.0,
     dx=9.8,
     dy=6.8,
@@ -21,5 +21,4 @@ def Alpaqua_96_magnum_flx(name: str) -> PlateAdapter:
     adapter_hole_size_y=8.0,
     site_pedestal_z=6.2,
     model="Alpaqua_96_magnum_flx",
-    )
-
+  )

--- a/pylabrobot/resources/azenta/plates.py
+++ b/pylabrobot/resources/azenta/plates.py
@@ -23,8 +23,8 @@ def Azenta4titudeFrameStar_96_wellplate_skirted_Lid(name: str) -> Lid:
   # See https://github.com/PyLabRobot/pylabrobot/pull/161.
   # return Lid(
   #   name=name,
-  #   size_x=127.0,
-  #   size_y=86.0,
+  #   size_x=127.76,
+  #   size_y=85.48,
   #   size_z=5,           # measure the total z height
   #   nesting_z_height=None, # measure overlap between lid and plate
   #   model="Azenta4titudeFrameStar_96_wellplate_skirted_Lid",
@@ -35,8 +35,8 @@ def Azenta4titudeFrameStar_96_wellplate_skirted(name: str, with_lid: bool = Fals
   # https://www.azenta.com/products/framestar-96-well-skirted-pcr-plate#specifications
   return Plate(
     name=name,
-    size_x=127.0,
-    size_y=86.0,
+    size_x=127.76,
+    size_y=85.48,
     size_z=16,
     lid=Azenta4titudeFrameStar_96_wellplate_skirted_Lid(name + "_lid") if with_lid else None,
     model="Azenta4titudeFrameStar_96_wellplate_skirted",

--- a/pylabrobot/resources/corning_axygen/plates.py
+++ b/pylabrobot/resources/corning_axygen/plates.py
@@ -25,7 +25,7 @@ def Axy_24_DW_10ML_Lid(name: str) -> Lid:
   # See https://github.com/PyLabRobot/pylabrobot/pull/161.
   # return Lid(
   #   name=name,
-  #   size_x=127.0,
+  #   size_x=127.76,
   #   size_y=86.0,
   #   size_z=5,
   #   nesting_z_height=None, # measure overlap between lid and plate
@@ -37,8 +37,8 @@ def Axy_24_DW_10ML_Lid(name: str) -> Lid:
 def Axy_24_DW_10ML(name: str, with_lid: bool = False) -> Plate:
   return Plate(
     name=name,
-    size_x=127.0,
-    size_y=86.0,
+    size_x=127.76,
+    size_y=85.48,
     size_z=44.24,
     lid=Axy_24_DW_10ML_Lid(name + "_lid") if with_lid else None,
     model="Axy_24_DW_10ML",

--- a/pylabrobot/resources/corning_costar/plates.py
+++ b/pylabrobot/resources/corning_costar/plates.py
@@ -484,8 +484,8 @@ def Cos_96_EZWash(name: str, with_lid: bool = False) -> Plate:
   """ Cos_96_EZWash """
   return Plate(
     name=name,
-    size_x=127.0,
-    size_y=86.0,
+    size_x=127.76,
+    size_y=85.48,
     size_z=14.5,
     lid=Cos_96_EZWash_Lid(name=name + "_lid") if with_lid else None,
     model="Cos_96_EZWash",

--- a/pylabrobot/resources/ml_star/mfx_modules.py
+++ b/pylabrobot/resources/ml_star/mfx_modules.py
@@ -23,7 +23,7 @@ class MFXModule(Resource):
       Create `MFXModule` for tips,
       Assign the `MFXModule` for tips to a carrier_site on the `MFXCarrier`,
       Create and assign a tip_rack to the MFXModule:
-      
+
       >>> mfx_carrier_1 = MFX_CAR_L5_base(name='mfx_carrier_1')
       >>> mfx_carrier_1[0] = mfx_tip_module_1 = MFX_TIP_module(name="mfx_tip_module_1")
       >>> tip_50ul_rack = TIP_50ul_L(name="tip_50ul_rack")
@@ -114,8 +114,8 @@ def MFX_DWP_rackbased_module(name: str) -> MFXModule:
   Module to position a Deep Well Plate / tube racks (MATRIX or MICRONICS) / NUNC reagent trough.
   """
 
-  # site_size_x=127.0,
-  # site_size_y=86.0,
+  # site_size_x=127.76,
+  # site_size_y=85.48,
 
   return MFXModule(
     name=name,

--- a/pylabrobot/resources/petri_dish.py
+++ b/pylabrobot/resources/petri_dish.py
@@ -45,8 +45,8 @@ class PetriDishHolder(Resource):
   def __init__(
     self,
     name: str,
-    size_x: float = 127.0,
-    size_y: float = 86.0,
+    size_x: float = 127.76,
+    size_y: float = 85.48,
     size_z: float = 14.5,
     category: str = "petri_dish_holder",
     model: Optional[str] = None

--- a/pylabrobot/resources/petri_dish_tests.py
+++ b/pylabrobot/resources/petri_dish_tests.py
@@ -57,8 +57,8 @@ class TestPetriDish(unittest.TestCase):
     })
 
     self.assertEqual(petri_dish_holder.name, "petri_dish_holder")
-    self.assertEqual(petri_dish_holder.get_size_x(), 127.0)
-    self.assertEqual(petri_dish_holder.get_size_y(), 86.0)
+    self.assertEqual(petri_dish_holder.get_size_x(), 127.76)
+    self.assertEqual(petri_dish_holder.get_size_y(), 85.48)
 
   def test_petri_dish_holder_deserialization_with_dish(self):
     petri_dish_holder = PetriDishHolder.deserialize({
@@ -93,8 +93,8 @@ class TestPetriDish(unittest.TestCase):
     })
 
     self.assertEqual(petri_dish_holder.name, "petri_dish_holder")
-    self.assertEqual(petri_dish_holder.get_size_x(), 127.0)
-    self.assertEqual(petri_dish_holder.get_size_y(), 86.0)
+    self.assertEqual(petri_dish_holder.get_size_x(), 127.76)
+    self.assertEqual(petri_dish_holder.get_size_y(), 85.48)
     self.assertEqual(petri_dish_holder.get_size_z(), 14.5)
 
     self.assertEqual(len(petri_dish_holder.children), 1)

--- a/pylabrobot/resources/petri_dish_tests.py
+++ b/pylabrobot/resources/petri_dish_tests.py
@@ -30,8 +30,8 @@ class TestPetriDish(unittest.TestCase):
     self.assertEqual(serialized, {
       "name": "petri_dish_holder",
       "category": "petri_dish_holder",
-      "size_x": 127.0,
-      "size_y": 86.0,
+      "size_x": 127.76,
+      "size_y": 85.48,
       "size_z": 14.5,
       "parent_name": None,
       "type": "PetriDishHolder",
@@ -45,8 +45,8 @@ class TestPetriDish(unittest.TestCase):
     petri_dish_holder = PetriDishHolder.deserialize({
       "name": "petri_dish_holder",
       "category": "petri_dish_holder",
-      "size_x": 127.0,
-      "size_y": 86.0,
+      "size_x": 127.76,
+      "size_y": 85.48,
       "size_z": 14.5,
       "children": [],
       "location": None,
@@ -64,8 +64,8 @@ class TestPetriDish(unittest.TestCase):
     petri_dish_holder = PetriDishHolder.deserialize({
       "name": "petri_dish_holder",
       "category": "petri_dish_holder",
-      "size_x": 127.0,
-      "size_y": 86.0,
+      "size_x": 127.76,
+      "size_y": 85.48,
       "size_z": 14.5,
       "children": [
         {

--- a/pylabrobot/resources/plate.py
+++ b/pylabrobot/resources/plate.py
@@ -156,7 +156,7 @@ class Plate(ItemizedResource[Well]):
     Example:
       Set the volume of each well in a 96-well plate to 10 uL.
 
-      >>> plate = Plate("plate", 127.0, 86.0, 14.5, num_items_x=12, num_items_y=8)
+      >>> plate = Plate("plate", 127.76, 85.48, 14.5, num_items_x=12, num_items_y=8)
       >>> plate.set_well_liquids((Liquid.WATER, 10))
     """
 

--- a/pylabrobot/resources/porvair/plates.py
+++ b/pylabrobot/resources/porvair/plates.py
@@ -38,8 +38,8 @@ def Porvair_6_reservoir_47ml_Vb_Lid(name: str) -> Lid:
   # See https://github.com/PyLabRobot/pylabrobot/pull/161.
   # return Lid(
   #   name=name,
-  #   size_x=127.0,
-  #   size_y=86.0,
+  #   size_x=127.76,
+  #   size_y=85.48,
   #   size_z=5,
   #   nesting_z_height=None, # measure overlap between lid and plate
   #   model="Porvair_6_reservoir_47ml_Vb_Lid",
@@ -59,8 +59,8 @@ def Porvair_6_reservoir_47ml_Vb(name: str, with_lid: bool = False) -> Plate:
   """
   return Plate(
     name=name,
-    size_x=127.0,
-    size_y=86.0,
+    size_x=127.76,
+    size_y=85.48,
     size_z=44,
     lid=Porvair_6_reservoir_47ml_Vb_Lid(name + "_lid") if with_lid else None,
     model="Porvair_6_reservoir_47ml_Vb",

--- a/pylabrobot/resources/revvity/plates.py
+++ b/pylabrobot/resources/revvity/plates.py
@@ -28,8 +28,8 @@ def Revvity_ProxiPlate_384Plus_Lid(name: str) -> Lid:
   # See https://github.com/PyLabRobot/pylabrobot/pull/161.
   # return Lid(
   #   name=name,
-  #   size_x=127.0,
-  #   size_y=86.0,
+  #   size_x=127.76,
+  #   size_y=85.48,
   #   size_z=None,           # measure the total z height
   #   nesting_z_height=None, # measure overlap between lid and plate
   #   model="Revvity_ProxiPlate_384Plus_Lid",
@@ -41,8 +41,8 @@ def Revvity_ProxiPlate_384Plus(name: str, with_lid: bool = False) -> Plate:
   # https://www.perkinelmer.com/uk/Product/proxiplate-384-plus-50w-6008280
   return Plate(
     name=name,
-    size_x=127.0,
-    size_y=86.0,
+    size_x=127.76,
+    size_y=85.48,
     size_z=14.35,
     lid=Revvity_ProxiPlate_384Plus_Lid(name + "_lid") if with_lid else None,
     model="Revvity_ProxiPlate_384Plus",

--- a/pylabrobot/resources/thermo_fisher/plates.py
+++ b/pylabrobot/resources/thermo_fisher/plates.py
@@ -35,8 +35,8 @@ def ThermoScientific_96_DWP_1200ul_Rd_Lid(name: str) -> Lid:
   # See https://github.com/PyLabRobot/pylabrobot/pull/161.
   # return Lid(
   #   name=name,
-  #   size_x=127.0,
-  #   size_y=86.0,
+  #   size_x=127.76,
+  #   size_y=85.48,
   #   size_z=5,
   #   nesting_z_height=None, # measure overlap between lid and plate
   #   model="ThermoScientific_96_DWP_1200ul_Rd_Lid",
@@ -60,8 +60,8 @@ def ThermoScientific_96_DWP_1200ul_Rd(name: str, with_lid: bool = False) -> Plat
   """
   return Plate(
     name=name,
-    size_x=127.0,
-    size_y=86.0,
+    size_x=127.76,
+    size_y=85.48,
     size_z=24.0,
     lid=ThermoScientific_96_DWP_1200ul_Rd_Lid(name + "_lid") if with_lid else None,
     model="ThermoScientific_96_DWP_1200ul_Rd",

--- a/pylabrobot/resources/tube_rack.py
+++ b/pylabrobot/resources/tube_rack.py
@@ -92,7 +92,7 @@ class TubeRack(ItemizedResource[Tube]):
     Example:
       Set the volume of each tube in a 4x6 rack to 1000 uL.
 
-      >>> rack = TubeRack("rack", 127.0, 86.0, 14.5, num_items_x=6, num_items_y=4)
+      >>> rack = TubeRack("rack", 127.76, 85.48, 14.5, num_items_x=6, num_items_y=4)
       >>> rack.set_tube_liquids((Liquid.WATER, 1000))
     """
 


### PR DESCRIPTION
Venus apparently defines plate footprints as 127.0 and 86.0, whereas the [ANSI SLAS 1-2004 (R2012): Footprint Dimensions](https://www.slas.org/SLAS/assets/File/public/standards/ANSI_SLAS_1-2004_FootprintDimensions.pdf) has them standardized to 127.76 and 85.48. This mistakes has unfortunately spread throughout PLR, but this PR fixes it.

I noticed Hamilton gripping is slightly inaccurate as a result of these inaccurate plate definitions. That is the case in our lab, on which I based these PLR commands. It might be better to grip plates slightly differently in the future (that means updating the unit tests) rather than applying an ad-hoc de-correctifier in STAR (essentially treating 127.76 as 127.0 again). As an example of this, looking from venus perspective, command `PP` parameter `go: Open gripper position [0.1mm]` was always 1300, which is 127mm+3mm. The 3mm is much more reasonable than 2.62mm. So I guess 1300 needs to be 1307 for ideal gripping. In similar spirit, I also updated some other parameters (like the center of the resource gripped with `xs` and `yj`).