### PR TITLE
deprecate single values in LH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Changed
+
+- The `offset` attribute of `Pickup`, `Drop`, `Aspirate`, and `Dispense` dataclasses are now always wrt the center of its `resource`.
+
 ### Added
 
 - Cor_96_wellplate_360ul_Fb plate (catalog number [3603](https://ecatalog.corning.com/life-sciences/b2b/NL/en/Microplates/Assay-Microplates/96-Well-Microplates/Corning®-96-well-Black-Clear-and-White-Clear-Bottom-Polystyrene-Microplates/p/3603))
@@ -14,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - All VENUS-imported Corning-Costar plates, because they don't have unique and usable identifiers, and are probably wrong.
 - HamiltonDeck.load_from_lay_file
+- Passing single values to LiquidHandler `pick_up_tips`, `drop_tips`, `aspirate`, and `dispense` methods. These methods now require a list of values.
 
 ### Fixed
 

--- a/pylabrobot/liquid_handling/backends/chatterbox_backend_tests.py
+++ b/pylabrobot/liquid_handling/backends/chatterbox_backend_tests.py
@@ -41,11 +41,11 @@ class ChatterBoxBackendTests(unittest.IsolatedAsyncioTestCase):
 
   async def test_aspirate(self):
     await self.lh.pick_up_tips(self.tip_rack["A1"])
-    await self.lh.aspirate(self.plate["A1"], vols=10)
+    await self.lh.aspirate(self.plate["A1"], vols=[10])
 
   async def test_dispense(self):
     await self.lh.pick_up_tips(self.tip_rack["A1"])
-    await self.lh.dispense(self.plate["A1"], vols=10)
+    await self.lh.dispense(self.plate["A1"], vols=[10])
 
   async def test_aspirate96(self):
     await self.lh.pick_up_tips96(self.tip_rack)

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
@@ -440,7 +440,7 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     self.plate.lid.unassign()
     well = self.plate.get_item("A1")
     well.tracker.set_liquids([(None, 100 * 1.072)]) # liquid class correction
-    await self.lh.aspirate([well], vols=[100], liquid_height=10)
+    await self.lh.aspirate([well], vols=[100], liquid_height=[10])
 
     # This passes the test, but is not the real command.
     self._assert_command_sent_once(
@@ -460,7 +460,7 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     wells = self.plate.get_items("A1:B1")
     for well in wells:
       well.tracker.set_liquids([(None, 100 * 1.072)]) # liquid class correction
-    await self.lh.aspirate(self.plate["A1:B1"], vols=100)
+    await self.lh.aspirate(self.plate["A1:B1"], vols=[100]*2)
 
     # This passes the test, but is not the real command.
     self._assert_command_sent_once(
@@ -477,7 +477,7 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
   async def test_aspirate_single_resource(self):
     self.lh.update_head_state({i: self.tip_rack.get_tip(i) for i in range(5)})
     with no_volume_tracking():
-      await self.lh.aspirate(self.bb, vols=10, use_channels=[0, 1, 2, 3, 4], liquid_height=1)
+      await self.lh.aspirate([self.bb], vols=[10]*5, use_channels=[0,1,2,3,4], liquid_height=[1]*5)
     self._assert_command_sent_once(
       "C0ASid0002at0 0 0 0 0 0&tm1 1 1 1 1 0&xp04865 04865 04865 04865 04865 00000&yp2098 1961 "
       "1825 1688 1551 0000&th2450te2450lp2000 2000 2000 2000 2000 2000&ch000 000 000 000 000 000&"
@@ -497,8 +497,7 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
   async def test_dispense_single_resource(self):
     self.lh.update_head_state({i: self.tip_rack.get_tip(i) for i in range(5)})
     with no_volume_tracking():
-      await self.lh.dispense(self.bb, vols=10, use_channels=[0, 1, 2, 3, 4], liquid_height=1,
-                            #  blow_out=[True]*5, jet=[True]*5)
+      await self.lh.dispense([self.bb], vols=[10]*5, use_channels=[0,1,2,3,4], liquid_height=[1]*5,
                              blow_out=[True]*5, jet=[True]*5)
     self._assert_command_sent_once(
       "C0DSid0002dm1 1 1 1 1 1&tm1 1 1 1 1 0&xp04865 04865 04865 04865 04865 00000&yp2098 1961 "
@@ -533,7 +532,7 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     assert self.plate.lid is not None
     self.plate.lid.unassign()
     with no_volume_tracking():
-      await self.lh.dispense(self.plate["A1:B1"], vols=100, jet=[True]*2, blow_out=[True]*2)
+      await self.lh.dispense(self.plate["A1:B1"], vols=[100]*2, jet=[True]*2, blow_out=[True]*2)
 
     self._assert_command_sent_once(
       "C0DSid0002dm1 1 1&tm1 1 0&xp02980 02980 00000&yp1460 1370 0000&zx1931 1931 1931&lp2011 2011 "
@@ -751,7 +750,7 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     await self.lh.pick_up_tips(self.tip_rack["A1:H1"])
     await self.lh.discard_tips()
     self._assert_command_sent_once(
-     "C0TRid0206xp08000 08000 08000 08000 08000 08000 08000 08000yp4050 3782 3514 3246 2978 2710 "
+     "C0TRid0206xp08000 08000 08000 08000 08000 08000 08000 08000yp4050 3782 3514 3245 2978 2710 "
      "2442 2174tp1970tz1870th2450te2450tm1 1 1 1 1 1 1 1ti0",
      DROP_TIP_FORMAT)
 

--- a/pylabrobot/liquid_handling/backends/hamilton/base.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/base.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, TypeVar, cast
 from pylabrobot.liquid_handling.backends.backend import LiquidHandlerBackend
 from pylabrobot.liquid_handling.standard import PipettingOp
 from pylabrobot.machines.backends import USBBackend
-from pylabrobot.resources import TipSpot, Well
+from pylabrobot.resources import TipSpot
 from pylabrobot.resources.ml_star import HamiltonTip, TipPickupMethod, TipSize
 
 T = TypeVar("T")

--- a/pylabrobot/liquid_handling/backends/hamilton/base.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/base.py
@@ -332,16 +332,12 @@ class HamiltonLiquidHandler(LiquidHandlerBackend, USBBackend, metaclass=ABCMeta)
       channels_involved.append(True)
       offset = ops[i].offset
 
-      x_pos = ops[i].resource.get_absolute_location().x
-      if isinstance(ops[i].resource, (TipSpot, Well)):
-        x_pos += ops[i].resource.center().x
+      x_pos = ops[i].resource.get_absolute_location(x="c", y="c", z="b").x
       if offset is not None:
         x_pos += offset.x
       x_positions.append(int(x_pos*10))
 
-      y_pos = ops[i].resource.get_absolute_location().y
-      if isinstance(ops[i].resource, (TipSpot, Well)):
-        y_pos += ops[i].resource.center().y
+      y_pos = ops[i].resource.get_absolute_location(x="c", y="c", z="b").y
       if offset is not None:
         y_pos += offset.y
       y_positions.append(int(y_pos*10))

--- a/pylabrobot/liquid_handling/backends/hamilton/vantage_tests.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/vantage_tests.py
@@ -294,7 +294,7 @@ class TestVantageLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
 
   async def test_aspirate(self):
     await self.lh.pick_up_tips(self.tip_rack["A1"]) # pick up tips first
-    await self.lh.aspirate(self.plate["A1"], vols=100)
+    await self.lh.aspirate(self.plate["A1"], vols=[100])
 
     self._assert_command_sent_once(
       "A1PMDAid0248at0&tm1 0&xp05680 0&yp1460 0 &th2450&te2450&lp2001&"
@@ -305,8 +305,8 @@ class TestVantageLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
 
   async def test_dispense(self):
     await self.lh.pick_up_tips(self.tip_rack["A1"]) # pick up tips first
-    await self.lh.aspirate(self.plate["A1"], vols=100)
-    await self.lh.dispense(self.plate["A2"], vols=100, liquid_height=[5], jet=[False],
+    await self.lh.aspirate(self.plate["A1"], vols=[100])
+    await self.lh.dispense(self.plate["A2"], vols=[100], liquid_height=[5], jet=[False],
                            blow_out=[True])
 
     self._assert_command_sent_once(
@@ -318,8 +318,8 @@ class TestVantageLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
   async def test_zero_volume_liquid_handling(self):
      # just test that this does not throw an error
     await self.lh.pick_up_tips(self.tip_rack["A1"]) # pick up tips first
-    await self.lh.aspirate(self.plate["A1"], vols=0)
-    await self.lh.dispense(self.plate["A2"], vols=0)
+    await self.lh.aspirate(self.plate["A1"], vols=[0])
+    await self.lh.dispense(self.plate["A2"], vols=[0])
 
   async def test_tip_pickup96(self):
     await self.lh.pick_up_tips96(self.tip_rack)

--- a/pylabrobot/liquid_handling/backends/http_tests.py
+++ b/pylabrobot/liquid_handling/backends/http_tests.py
@@ -132,7 +132,7 @@ class TestHTTPBackendOps(unittest.IsolatedAsyncioTestCase):
     self.lh.update_head_state({0: self.tip_rack.get_tip("A1")})
     well = self.plate.get_item("A1")
     well.tracker.set_liquids([(None, 10)])
-    await self.lh.aspirate([well], 10)
+    await self.lh.aspirate([well], [10])
 
   @responses.activate
   async def test_dispense(self):
@@ -146,7 +146,7 @@ class TestHTTPBackendOps(unittest.IsolatedAsyncioTestCase):
     self.lh.update_head_state({0: self.tip_rack.get_tip("A1")})
     self.lh.head[0].get_tip().tracker.add_liquid(None, 10)
     with no_volume_tracking():
-      await self.lh.dispense(self.plate["A1"], 10)
+      await self.lh.dispense(self.plate["A1"], [10])
 
   @responses.activate
   async def test_pick_up_tips96(self):

--- a/pylabrobot/liquid_handling/backends/serializing_backend_tests.py
+++ b/pylabrobot/liquid_handling/backends/serializing_backend_tests.py
@@ -73,13 +73,13 @@ class SerializingBackendTests(unittest.IsolatedAsyncioTestCase):
     tip = self.tip_rack.get_tip(0)
     self.lh.update_head_state({0: tip})
     self.backend.clear()
-    await self.lh.aspirate([well], vols=10)
+    await self.lh.aspirate([well], vols=[10])
     self.assertEqual(len(self.backend.sent_commands), 1)
     self.assertEqual(self.backend.sent_commands[0]["command"], "aspirate")
     self.assertEqual(self.backend.sent_commands[0]["data"], {
       "channels": [{
         "resource_name": well.name,
-        "offset": None,
+        "offset": serialize(Coordinate.zero()),
         "tip": tip.serialize(),
         "volume": 10,
         "flow_rate": None,
@@ -94,13 +94,13 @@ class SerializingBackendTests(unittest.IsolatedAsyncioTestCase):
     self.lh.update_head_state({0: tip})
     self.backend.clear()
     with no_volume_tracking():
-      await self.lh.dispense(wells, vols=10)
+      await self.lh.dispense(wells, vols=[10])
     self.assertEqual(len(self.backend.sent_commands), 1)
     self.assertEqual(self.backend.sent_commands[0]["command"], "dispense")
     self.assertEqual(self.backend.sent_commands[0]["data"], {
       "channels": [{
         "resource_name": wells[0].name,
-        "offset": None,
+        "offset": serialize(Coordinate.zero()),
         "tip": tip.serialize(),
         "volume": 10,
         "flow_rate": None,

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -686,10 +686,10 @@ class LiquidHandler(Machine):
     use_channels = use_channels or self._default_use_channels or list(range(len(resources)))
 
     # expand default arguments
-    offsets = offsets or [None] * len(resources)
-    flow_rates = flow_rates or [None] * len(resources)
-    liquid_height = liquid_height or [None] * len(resources)
-    blow_out_air_volume = blow_out_air_volume or [None] * len(resources)
+    offsets = offsets or [None] * len(use_channels)
+    flow_rates = flow_rates or [None] * len(use_channels)
+    liquid_height = liquid_height or [None] * len(use_channels)
+    blow_out_air_volume = blow_out_air_volume or [None] * len(use_channels)
 
     # If the user specified a single resource, but multiple channels to use, we will assume they
     # want to space the channels evenly across the resource. Note that offsets are relative to the
@@ -864,10 +864,10 @@ class LiquidHandler(Machine):
     use_channels = use_channels or self._default_use_channels or list(range(len(resources)))
 
     # expand default arguments
-    offsets = offsets or [None] * len(resources)
-    flow_rates = flow_rates or [None] * len(resources)
-    liquid_height = liquid_height or [None] * len(resources)
-    blow_out_air_volume = blow_out_air_volume or [None] * len(resources)
+    offsets = offsets or [None] * len(use_channels)
+    flow_rates = flow_rates or [None] * len(use_channels)
+    liquid_height = liquid_height or [None] * len(use_channels)
+    blow_out_air_volume = blow_out_air_volume or [None] * len(use_channels)
 
     # If the user specified a single resource, but multiple channels to use, we will assume they
     # want to space the channels evenly across the resource. Note that offsets are relative to the

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -41,7 +41,6 @@ from pylabrobot.resources import (
   does_cross_contamination_tracking
 )
 from pylabrobot.resources.liquid import Liquid
-from pylabrobot.utils.list import expand
 
 from .backends import LiquidHandlerBackend
 from .standard import (

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -620,12 +620,12 @@ class LiquidHandler(Machine):
   async def aspirate(
     self,
     resources: Union[Container, Sequence[Container]],
-    vols: Union[List[float], float],
+    vols: List[float],
     use_channels: Optional[List[int]] = None,
-    flow_rates: Optional[Union[float, List[Optional[float]]]] = None,
-    offsets: Union[Optional[Coordinate], Sequence[Optional[Coordinate]]] = None,
-    liquid_height: Union[Optional[float], List[Optional[float]]] = None,
-    blow_out_air_volume: Union[Optional[float], List[Optional[float]]] = None,
+    flow_rates: Optional[List[Optional[float]]] = None,
+    offsets: Optional[List[Optional[Coordinate]]] = None,
+    liquid_height: Optional[List[Optional[float]]] = None,
+    blow_out_air_volume: Optional[List[Optional[float]]] = None,
     **backend_kwargs
   ):
     """ Aspirate liquid from the specified wells.
@@ -792,12 +792,12 @@ class LiquidHandler(Machine):
   async def dispense(
     self,
     resources: Union[Container, Sequence[Container]],
-    vols: Union[List[float], float],
+    vols: List[float],
     use_channels: Optional[List[int]] = None,
-    flow_rates: Optional[Union[float, List[Optional[float]]]] = None,
-    offsets: Union[Optional[Coordinate], Sequence[Optional[Coordinate]]] = None,
-    liquid_height: Union[Optional[float], List[Optional[float]]] = None,
-    blow_out_air_volume: Union[Optional[float], List[Optional[float]]] = None,
+    flow_rates: Optional[List[Optional[float]]] = None,
+    offsets: Optional[List[Optional[Coordinate]]] = None,
+    liquid_height: Optional[List[Optional[float]]] = None,
+    blow_out_air_volume: Optional[List[Optional[float]]] = None,
     **backend_kwargs
   ):
     """ Dispense liquid to the specified channels.

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -307,7 +307,7 @@ class LiquidHandler(Machine):
     self,
     tip_spots: List[TipSpot],
     use_channels: Optional[List[int]] = None,
-    offsets: Optional[Union[Coordinate, List[Optional[Coordinate]]]] = None,
+    offsets: Optional[List[Optional[Coordinate]]] = None,
     **backend_kwargs
   ):
     """ Pick up tips from a resource.
@@ -340,7 +340,7 @@ class LiquidHandler(Machine):
       tip_spots: List of tip spots to pick up tips from.
       use_channels: List of channels to use. Index from front to back. If `None`, the first
         `len(channels)` channels will be used.
-      offsets: List of offsets for each channel, a translation that will be applied to the tip
+      offsets: List of offsets, one for each channel: a translation that will be applied to the tip
         drop location. If `None`, no offset will be applied.
       backend_kwargs: Additional keyword arguments for the backend, optional.
 
@@ -355,13 +355,17 @@ class LiquidHandler(Machine):
     """
 
     # fix arguments
-    offsets = expand(offsets, len(tip_spots))
+    if isinstance(offsets, Coordinate):
+      raise NotImplementedError("Single offset is deprecated, use a list of offsets.")
     if use_channels is None:
       if self._default_use_channels is None:
         use_channels = list(range(len(tip_spots)))
       else:
         use_channels = self._default_use_channels
     tips = [tip_spot.get_tip() for tip_spot in tip_spots]
+
+    # expand default arguments
+    offsets = offsets or [None] * len(tip_spots)
 
     # checks
     self._assert_resources_exist(tip_spots)
@@ -420,7 +424,7 @@ class LiquidHandler(Machine):
     self,
     tip_spots: List[Union[TipSpot, Resource]],
     use_channels: Optional[List[int]] = None,
-    offsets: Optional[Union[Coordinate, List[Optional[Coordinate]]]] = None,
+    offsets: Optional[List[Optional[Coordinate]]] = None,
     allow_nonzero_volume: bool = False,
     **backend_kwargs
   ):
@@ -446,8 +450,8 @@ class LiquidHandler(Machine):
       tips: Tip resource locations to drop to.
       use_channels: List of channels to use. Index from front to back. If `None`, the first
         `len(channels)` channels will be used.
-      offsets: List of offsets for each channel, a translation that will be applied to the tip
-        pickup location. If `None`, no offset will be applied.
+      offsets: List of offsets, one for each channel, a translation that will be applied to the tip
+        drop location. If `None`, no offset will be applied.
       allow_nonzero_volume: If `True`, the tip will be dropped even if its volume is not zero (there
         is liquid in the tip). If `False`, a RuntimeError will be raised if the tip has nonzero
         volume.
@@ -466,9 +470,9 @@ class LiquidHandler(Machine):
       HasTipError: If a spot already has a tip.
     """
 
-
     # fix arguments
-    offsets = expand(offsets, len(tip_spots))
+    if isinstance(offsets, Coordinate):
+      raise NotImplementedError("Single offset is deprecated, use a list of offsets.")
     if use_channels is None:
       if self._default_use_channels is None:
         use_channels = list(range(len(tip_spots)))
@@ -480,6 +484,9 @@ class LiquidHandler(Machine):
       if tip.tracker.get_used_volume() > 0 and not allow_nonzero_volume:
         raise RuntimeError(f"Cannot drop tip with volume {tip.tracker.get_used_volume()}")
       tips.append(tip)
+
+    # expand default arguments
+    offsets = offsets or [None] * len(tip_spots)
 
     # checks
     self._assert_resources_exist(tip_spots)
@@ -600,7 +607,7 @@ class LiquidHandler(Machine):
       raise RuntimeError("No tips have been picked up and no channels were specified.")
 
     trash = self.deck.get_trash_area()
-    offsets = list(reversed(trash.centers(yn=n)))
+    offsets = [c - trash.center() for c in reversed(trash.centers(yn=n))] # offset is wrt center
 
     return await self.drop_tips(
         tip_spots=[trash]*n,
@@ -671,60 +678,49 @@ class LiquidHandler(Machine):
       ValueError: If all channels are `None`.
     """
 
-    # Start with computing the locations of the aspirations. Can either be a single resource, in
-    # which case all channels will aspirate from there, or a list of resources.
-    if isinstance(resources, Resource): # if single resource, space channels evenly
-      if use_channels is None:
-        if self._default_use_channels is None:
-          if isinstance(vols, list):
-            use_channels = list(range(len(vols)))
-          else:
-            use_channels = [0]
-        else:
-          use_channels = self._default_use_channels
+    if isinstance(resources, Resource):
+      raise NotImplementedError("Single resource is deprecated, use a list of resources. If you "
+                                "want to aspirate from a single resource, use a list with that "
+                                "resource and specify the channels to use.")
 
-      self._make_sure_channels_exist(use_channels)
+    use_channels = use_channels or self._default_use_channels or list(range(len(resources)))
 
+    # expand default arguments
+    offsets = offsets or [None] * len(resources)
+    flow_rates = flow_rates or [None] * len(resources)
+    liquid_height = liquid_height or [None] * len(resources)
+    blow_out_air_volume = blow_out_air_volume or [None] * len(resources)
+
+    # If the user specified a single resource, but multiple channels to use, we will assume they
+    # want to space the channels evenly across the resource. Note that offsets are relative to the
+    # center of the resource.
+    if len(resources) == 1:
+      resource = resources[0]
       n = len(use_channels)
+      resources = [resource] * len(use_channels)
+      centers = list(reversed(resource.centers(yn=n, zn=0)))
+      centers = [c - resource.center() for c in centers] # offset is wrt center
+      offsets = [(c + o) if o is not None else c for c, o in zip(centers, offsets)] # user-defined
 
-      # If offsets is supplied, make sure it is a list of the correct length. If it is not in this
-      # format, raise an error. If it is not supplied, make it a list of the correct length by
-      # spreading channels across the resource evenly.
-      center_offsets = list(reversed(resources.centers(yn=n, zn=0)))
-      if offsets is not None:
-        if not isinstance(offsets, list) or len(offsets) != n:
-          raise ValueError("Number of offsets must match number of channels used when aspirating "
-                           "from a resource.")
-        offsets = [o + co for o, co in zip(offsets, center_offsets)]
-      else:
-        offsets = center_offsets
+    # Deprecation check for single values
+    if isinstance(vols, numbers.Number):
+      raise NotImplementedError("Single volume is deprecated, use a list of volumes.")
+    if isinstance(flow_rates, numbers.Number):
+      raise NotImplementedError("Single flow rate is deprecated, use a list of flow rates.")
+    if isinstance(liquid_height, numbers.Number):
+      raise NotImplementedError("Single liquid height is deprecated, use a list of liquid heights.")
+    if isinstance(blow_out_air_volume, numbers.Number):
+      raise NotImplementedError("Single blow out air volume is deprecated, use a list of volumes.")
 
-      resources = [resources] * n
-    else:
-      if len(resources) == 0:
-        raise ValueError("No channels specified")
-      self._assert_resources_exist(resources)
-      n = len(resources)
-
-      for resource in resources:
-        if isinstance(resource.parent, Plate) and resource.parent.has_lid():
-          raise ValueError("Aspirating from plate with lid")
-
-      if use_channels is None:
-        use_channels = list(range(len(resources)))
-
-      self._make_sure_channels_exist(use_channels)
-
-      offsets = expand(offsets, n)
-
-    # expand the rest of the arguments
-    vols = expand(vols, n)
-    flow_rates = expand(flow_rates, n)
-    liquid_height = expand(liquid_height, n)
-    blow_out_air_volume = expand(blow_out_air_volume, n)
     self._blow_out_air_volume = blow_out_air_volume
     tips = [self.head[channel].get_tip() for channel in use_channels]
 
+    # Checks
+    for resource in resources:
+      if isinstance(resource.parent, Plate) and resource.parent.has_lid():
+        raise ValueError("Aspirating from a well with a lid is not supported.")
+
+    self._make_sure_channels_exist(use_channels)
     assert len(vols) == len(offsets) == len(flow_rates) == len(liquid_height)
 
     # liquid(s) for each channel. If volume tracking is disabled, use None as the liquid.
@@ -856,65 +852,58 @@ class LiquidHandler(Machine):
       ValueError: If all channels are `None`.
     """
 
-    # Start with computing the locations of the dispenses. Can either be a single resource, in
-    # which case all channels will dispense to there, or a list of resources.
-    if isinstance(resources, Resource): # if single resource, space channels evenly
-      if use_channels is None:
-        if self._default_use_channels is None:
-          if isinstance(vols, list):
-            use_channels = list(range(len(vols)))
-          else:
-            use_channels = [0]
-        else:
-          use_channels = self._default_use_channels
+    # If the user specified a single resource, but multiple channels to use, we will assume they
+    # want to space the channels evenly across the resource. Note that offsets are relative to the
+    # center of the resource.
 
-      self._make_sure_channels_exist(use_channels)
+    if isinstance(resources, Resource):
+      raise NotImplementedError("Single resource is deprecated, use a list of resources. If you "
+                                "want to dispense to a single resource, use a list with that "
+                                "resource and specify the channels to use.")
 
+    use_channels = use_channels or self._default_use_channels or list(range(len(resources)))
+
+    # expand default arguments
+    offsets = offsets or [None] * len(resources)
+    flow_rates = flow_rates or [None] * len(resources)
+    liquid_height = liquid_height or [None] * len(resources)
+    blow_out_air_volume = blow_out_air_volume or [None] * len(resources)
+
+    # If the user specified a single resource, but multiple channels to use, we will assume they
+    # want to space the channels evenly across the resource. Note that offsets are relative to the
+    # center of the resource.
+    if len(resources) == 1:
+      resource = resources[0]
       n = len(use_channels)
+      resources = [resource] * len(use_channels)
+      centers = list(reversed(resource.centers(yn=n, zn=0)))
+      centers = [c - resource.center() for c in centers] # offset is wrt center
+      offsets = [(c + o) if o is not None else c for c, o in zip(centers, offsets)] # user-defined
 
-      # If offsets is supplied, make sure it is a list of the correct length. If it is not in this
-      # format, raise an error. If it is not supplied, make it a list of the correct length by
-      # spreading channels across the resource evenly.
-      center_offsets = list(reversed(resources.centers(yn=n, zn=0)))
-      if offsets is not None:
-        if not isinstance(offsets, list) or len(offsets) != n:
-          raise ValueError("Number of offsets must match number of channels used when dispensing "
-                          "to a resource.")
-        offsets = [o + co for o, co in zip(offsets, center_offsets)]
-      else:
-        offsets = center_offsets
+    # Deprecation check for single values
+    if isinstance(vols, numbers.Number):
+      raise NotImplementedError("Single volume is deprecated, use a list of volumes.")
+    if isinstance(flow_rates, numbers.Number):
+      raise NotImplementedError("Single flow rate is deprecated, use a list of flow rates.")
+    if isinstance(liquid_height, numbers.Number):
+      raise NotImplementedError("Single liquid height is deprecated, use a list of liquid heights.")
+    if isinstance(blow_out_air_volume, numbers.Number):
+      raise NotImplementedError("Single blow out air volume is deprecated, use a list of volumes.")
 
-      resources = [resources] * n
-    else:
-      if len(resources) == 0:
-        raise ValueError("No channels specified")
-      self._assert_resources_exist(resources)
-      n = len(resources)
+    self._blow_out_air_volume = None
+    tips = [self.head[channel].get_tip() for channel in use_channels]
 
-      for resource in resources:
-        if isinstance(resource.parent, Plate) and resource.parent.has_lid():
-          raise ValueError("Dispensing to plate with lid")
-
-      if use_channels is None:
-        use_channels = list(range(len(resources)))
-
-      self._make_sure_channels_exist(use_channels)
-
-      offsets = expand(offsets, n)
-
-    # expand the rest of the arguments
-    vols = expand(vols, n)
-    flow_rates = expand(flow_rates, n)
-    liquid_height = expand(liquid_height, n)
-    blow_out_air_volume = expand(blow_out_air_volume, n)
+    # Check the blow out air volume with what was aspirated
     if any(bav is not None for bav in blow_out_air_volume):
       if self._blow_out_air_volume is None:
         raise BlowOutVolumeError("No blowout volume was aspirated.")
       for requested_bav, done_bav in zip(blow_out_air_volume, self._blow_out_air_volume):
         if requested_bav is not None and done_bav is not None and requested_bav > done_bav:
           raise BlowOutVolumeError("Blowout volume is larger than aspirated volume")
-    self._blow_out_air_volume = None
-    tips = [self.head[channel].get_tip() for channel in use_channels]
+
+    for resource in resources:
+      if isinstance(resource.parent, Plate) and resource.parent.has_lid():
+        raise ValueError("Dispensing to plate with lid")
 
     assert len(vols) == len(offsets) == len(flow_rates) == len(liquid_height)
 
@@ -982,7 +971,7 @@ class LiquidHandler(Machine):
   async def transfer(
     self,
     source: Well,
-    targets: Union[Well, List[Well]],
+    targets: List[Well],
     source_vol: Optional[float] = None,
     ratios: Optional[List[float]] = None,
     target_vols: Optional[List[float]] = None,
@@ -1028,11 +1017,11 @@ class LiquidHandler(Machine):
       RuntimeError: If the setup has not been run. See :meth:`~LiquidHandler.setup`.
     """
 
+    # Deprecation check for single values
     if isinstance(targets, Well):
-      targets = [targets]
-
+      raise NotImplementedError("Single target is deprecated, use a list of targets.")
     if isinstance(dispense_flow_rates, numbers.Rational):
-      dispense_flow_rates = [dispense_flow_rates] * len(targets)
+      raise NotImplementedError("Single dispense flow rate is deprecated, use a list of flow rates")
 
     if target_vols is not None:
       if ratios is not None:
@@ -1056,7 +1045,7 @@ class LiquidHandler(Machine):
     for target, vol in zip(targets, target_vols):
       await self.dispense(
         resources=[target],
-        vols=vol,
+        vols=[vol],
         flow_rates=dispense_flow_rates,
         use_channels=[0],
         **backend_kwargs)
@@ -1094,7 +1083,8 @@ class LiquidHandler(Machine):
     self,
     tip_rack: TipRack,
     offset: Coordinate = Coordinate.zero(),
-    **backend_kwargs):
+    **backend_kwargs
+  ):
     """ Pick up tips using the 96 head. This will pick up 96 tips.
 
     Examples:

--- a/pylabrobot/liquid_handling/liquid_handler_tests.py
+++ b/pylabrobot/liquid_handling/liquid_handler_tests.py
@@ -38,11 +38,13 @@ from .standard import (
   DispensePlate
 )
 
-def _make_asp(r: Container, vol: float, tip: Any, offset: Optional[Coordinate]=None) -> Aspiration:
+def _make_asp(
+  r: Container, vol: float, tip: Any, offset: Optional[Coordinate]=Coordinate.zero()) -> Aspiration:
   return Aspiration(resource=r, volume=vol, tip=tip, offset=offset,
                    flow_rate=None, liquid_height=None, blow_out_air_volume=None,
                    liquids=[(None, vol)])
-def _make_disp(r: Container, vol: float, tip: Any, offset: Optional[Coordinate]=None) -> Dispense:
+def _make_disp(
+  r: Container, vol: float, tip: Any, offset: Optional[Coordinate]=Coordinate.zero()) -> Dispense:
   return Dispense(resource=r, volume=vol, tip=tip, offset=offset,
                   flow_rate=None, liquid_height=None, blow_out_air_volume=None,
                   liquids=[(None, vol)])
@@ -245,8 +247,8 @@ class TestLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
   async def test_offsets_tips(self):
     tip_spot = self.tip_rack.get_item("A1")
     tip = tip_spot.get_tip()
-    await self.lh.pick_up_tips([tip_spot], offsets=Coordinate(x=1, y=1, z=1))
-    await self.lh.drop_tips([tip_spot], offsets=Coordinate(x=1, y=1, z=1))
+    await self.lh.pick_up_tips([tip_spot], offsets=[Coordinate(x=1, y=1, z=1)])
+    await self.lh.drop_tips([tip_spot], offsets=[Coordinate(x=1, y=1, z=1)])
 
     self.assertEqual(self.get_first_command("pick_up_tips"), {
       "command": "pick_up_tips",
@@ -288,8 +290,8 @@ class TestLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     well.tracker.set_liquids([(None, 10)])
     t = self.tip_rack.get_item("A1").get_tip()
     self.lh.update_head_state({0: t})
-    await self.lh.aspirate([well], vols=10, offsets=Coordinate(x=1, y=1, z=1))
-    await self.lh.dispense([well], vols=10, offsets=Coordinate(x=1, y=1, z=1))
+    await self.lh.aspirate([well], vols=[10], offsets=[Coordinate(x=1, y=1, z=1)])
+    await self.lh.dispense([well], vols=[10], offsets=[Coordinate(x=1, y=1, z=1)])
 
     self.assertEqual(self.get_first_command("aspirate"), {
       "command": "aspirate",
@@ -515,7 +517,9 @@ class TestLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     tips = self.tip_rack.get_tips("A1:D1")
     await self.lh.pick_up_tips(self.tip_rack["A1", "B1", "C1", "D1"], use_channels=[0, 1, 3, 4])
     await self.lh.discard_tips()
-    offsets = list(reversed(self.deck.get_trash_area().centers(yn=4)))
+    trash = self.deck.get_trash_area()
+    offsets = list(reversed(trash.centers(yn=4)))
+    offsets = [o - trash.center() for o in offsets] # offset is wrt trash center
 
     self.assertEqual(self.get_first_command("drop_tips"), {
       "command": "drop_tips",
@@ -542,7 +546,7 @@ class TestLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     t = self.tip_rack.get_item("A1").get_tip()
     self.lh.update_head_state({0: t})
     with self.assertRaises(ValueError):
-      await self.lh.aspirate([well], vols=10)
+      await self.lh.aspirate([well], vols=[10])
 
   @pytest.mark.filterwarnings("ignore:Extra arguments to backend.pick_up_tips")
   async def test_strictness(self):
@@ -634,8 +638,8 @@ class TestLiquidHandlerVolumeTracking(unittest.IsolatedAsyncioTestCase):
     well = self.plate.get_item("A1")
     await self.lh.pick_up_tips(self.tip_rack["A1"])
     well.tracker.set_liquids([(None, 10)])
-    await self.lh.aspirate([well], vols=10)
-    await self.lh.dispense([well], vols=10)
+    await self.lh.aspirate([well], vols=[10])
+    await self.lh.dispense([well], vols=[10])
     self.assertEqual(well.tracker.liquids, [(None, 10)])
 
   async def test_mix_volume_tracking(self):
@@ -645,8 +649,8 @@ class TestLiquidHandlerVolumeTracking(unittest.IsolatedAsyncioTestCase):
     await self.lh.pick_up_tips(self.tip_rack[0:8])
     initial_liquids = [self.plate.get_item(i).tracker.liquids for i in range(8)]
     for _ in range(10):
-      await self.lh.aspirate(self.plate[0:8], vols=45)
-      await self.lh.dispense(self.plate[0:8], vols=45)
+      await self.lh.aspirate(self.plate[0:8], vols=[45]*8)
+      await self.lh.dispense(self.plate[0:8], vols=[45]*8)
     liquids_now = [self.plate.get_item(i).tracker.liquids for i in range(8)]
     self.assertEqual(liquids_now, initial_liquids)
 
@@ -675,21 +679,21 @@ class TestLiquidHandlerCrossContaminationTracking(unittest.IsolatedAsyncioTestCa
     await self.lh.pick_up_tips(self.tip_rack["A1"])
     blood_well.tracker.set_liquids([(Liquid.BLOOD, 10)])
     etoh_well.tracker.set_liquids([(Liquid.ETHANOL, 10)])
-    await self.lh.aspirate([blood_well], vols=10)
-    await self.lh.dispense([dest_well], vols=10)
+    await self.lh.aspirate([blood_well], vols=[10])
+    await self.lh.dispense([dest_well], vols=[10])
     with self.assertRaises(CrossContaminationError):
-      await self.lh.aspirate([etoh_well], vols=10)
+      await self.lh.aspirate([etoh_well], vols=[10])
 
   async def test_aspirate_from_same_well_twice(self):
     src_well = self.plate.get_item("A1")
     dst_well = self.plate.get_item("A2")
     await self.lh.pick_up_tips(self.tip_rack["A1"])
     src_well.tracker.set_liquids([(Liquid.BLOOD, 20)])
-    await self.lh.aspirate([src_well], vols=10)
-    await self.lh.dispense([dst_well], vols=10)
+    await self.lh.aspirate([src_well], vols=[10])
+    await self.lh.dispense([dst_well], vols=[10])
     self.assertEqual(dst_well.tracker.liquids, [(Liquid.BLOOD, 10)])
-    await self.lh.aspirate([src_well], vols=10)
-    await self.lh.dispense([dst_well], vols=10)
+    await self.lh.aspirate([src_well], vols=[10])
+    await self.lh.dispense([dst_well], vols=[10])
     self.assertEqual(dst_well.tracker.liquids, [(Liquid.BLOOD, 20)])
 
   async def test_aspirate_from_well_with_partial_overlap(self):
@@ -698,12 +702,12 @@ class TestLiquidHandlerCrossContaminationTracking(unittest.IsolatedAsyncioTestCa
     await self.lh.pick_up_tips(self.tip_rack["A1"])
     pure_blood_well.tracker.set_liquids([(Liquid.BLOOD, 20)])
     mix_well.tracker.set_liquids([(Liquid.ETHANOL, 20)])
-    await self.lh.aspirate([pure_blood_well], vols=10)
-    await self.lh.dispense([mix_well], vols=10)
+    await self.lh.aspirate([pure_blood_well], vols=[10])
+    await self.lh.dispense([mix_well], vols=[10])
     self.assertEqual(mix_well.tracker.liquids, [(Liquid.ETHANOL, 20),
                                                     (Liquid.BLOOD, 10)]) # order matters
     with self.assertRaises(CrossContaminationError):
-      await self.lh.aspirate([pure_blood_well], vols=10)
+      await self.lh.aspirate([pure_blood_well], vols=[10])
 
 
 class LiquidHandlerForTesting(LiquidHandler):

--- a/pylabrobot/utils/__init__.py
+++ b/pylabrobot/utils/__init__.py
@@ -1,3 +1,3 @@
-from .list import assert_shape, reshape_2d, expand
+from .list import assert_shape, reshape_2d
 from .positions import string_to_position, string_to_index, string_to_indices, string_to_pattern
 from .object_parsing import find_subclass

--- a/pylabrobot/utils/list.py
+++ b/pylabrobot/utils/list.py
@@ -1,7 +1,6 @@
 """ Utilities for working with lists. """
 
-import collections.abc
-from typing import List, Tuple, TypeVar, Union, Sequence, cast
+from typing import List, Tuple, TypeVar
 
 
 T = TypeVar("T")
@@ -44,14 +43,3 @@ def reshape_2d(list_: List[T], shape: Tuple[int, int]) -> List[List[T]]:
       new_list[i].append(list_[i * shape[1] + j])
 
   return new_list
-
-
-def expand(list_or_item: Union[Sequence[T], T], n: int) -> List[T]:
-  if n <= 0:
-    raise ValueError(f"Cannot expand list {list_or_item} by {n}.")
-  if isinstance(list_or_item, collections.abc.Sequence) and not isinstance(list_or_item, str):
-    if len(list_or_item) != n:
-      raise ValueError(f"Expected list of length {n}, got {len(list_or_item)}.")
-    return list(list_or_item)
-  # cast to T to avoid mypy error (thinks it's a string). This can probably be written better.
-  return [cast(T, list_or_item)] * n

--- a/pylabrobot/utils/list_tests.py
+++ b/pylabrobot/utils/list_tests.py
@@ -2,11 +2,7 @@
 
 import unittest
 
-from pylabrobot.utils import (
-  assert_shape,
-  reshape_2d,
-  expand
-)
+from pylabrobot.utils import assert_shape, reshape_2d
 
 
 class TestListUtils(unittest.TestCase):
@@ -29,13 +25,3 @@ class TestListUtils(unittest.TestCase):
       reshape_2d([1, 2, 3, 4], (2, 3))
     with self.assertRaises(ValueError):
       reshape_2d([1, 2, 3, 4, 5, 6], (2, 2))
-
-  def test_expand(self):
-    self.assertEqual(expand(1, n=3), [1, 1, 1])
-    self.assertEqual(expand([1, 2, 3], n=3), [1, 2, 3])
-    self.assertEqual(expand("test", n=3), ["test", "test", "test"])
-
-    with self.assertRaises(ValueError):
-      expand(1, n=0)
-    with self.assertRaises(ValueError):
-      expand(1, n=-1)


### PR DESCRIPTION
two changes in this PR:

- The `offset` attribute of `Pickup`, `Drop`, `Aspirate`, and `Dispense` dataclasses are now always wrt the center of its `resource`.
- Passing single values to LiquidHandler `pick_up_tips`, `drop_tips`, `aspirate`, and `dispense` methods. These methods now require a list of values. (tracking deprecation in https://github.com/PyLabRobot/pylabrobot/issues/184)