### PR TITLE
Fix Plate Stacking in ResourceStack

### DIFF
--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1766,25 +1766,26 @@ class LiquidHandler(Machine):
 
     if isinstance(to, ResourceStack):
       assert to.direction == "z", "Only ResourceStacks with direction 'z' are currently supported"
-      top_plate = to.get_top_item()
-      if top_plate.lid is not None:
-        to_location = top_plate.lid.get_absolute_location()
-        to_location = Coordinate(
-          x=to_location.x,
-          y=to_location.y,
-          z=to_location.z  + top_plate.lid.get_size_z())
+      if len(to.children) != 0:
+        print(F"First plate added to ResourceStack '{to.name}'")
+        # TODO: add pedestal handling here once Plate is fixed
+      
+      if len(self.children) != 0:
+        top_plate = to.get_top_item()
+        if top_plate.lid is not None:
+          to_location = top_plate.get_absolute_location()
+          to_location = Coordinate(
+            x=to_location.x,
+            y=to_location.y,
+            z=to_location.z + top_plate.get_size_z() - top_plate.lid.nesting_z_height + top_plate.lid.get_size_z())
+        else:
+          to_location = to.get_absolute_location()
+          to_location = Coordinate(
+            x=to_location.x,
+            y=to_location.y,
+            z=to_location.z  + to.get_size_z())
       else:
-        to_location = to.get_absolute_location()
-        to_location = Coordinate(
-          x=to_location.x,
-          y=to_location.y,
-          z=to_location.z  + to.get_size_z())
-        
-      # to_location = to.get_absolute_location()
-      # to_location = Coordinate(
-      #   x=to_location.x,
-      #   y=to_location.y,
-      #   z=to_location.z  + to.get_size_z())
+        to_location = to # if ResourceStack is empty
     elif isinstance(to, Coordinate):
       to_location = to
     elif isinstance(to, MFXModule):

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1774,7 +1774,7 @@ class LiquidHandler(Machine):
         if not isinstance(top_plate, Plate):
           raise ValueError("Cannot move a plate to a ResourceStack with a non-plate top item")
 
-        if top_plate.has_lid:
+        if top_plate.lid is not None:
           to_location = top_plate.get_absolute_location()
           top_plate_lid_offset = top_plate.lid.get_size_z() - top_plate.lid.nesting_z_height
           to_location = Coordinate(
@@ -1793,6 +1793,8 @@ class LiquidHandler(Machine):
       # Calculate location adjustment of Plate based on PlateAdapter geometry
       adjusted_plate_anchor = to.compute_plate_location(plate)
       to_location = to.get_absolute_location() + adjusted_plate_anchor
+    elif isinstance(to, Coordinate):
+      to_location = to
     else:
       to_location = to.get_absolute_location()
 

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1766,28 +1766,26 @@ class LiquidHandler(Machine):
 
     if isinstance(to, ResourceStack):
       assert to.direction == "z", "Only ResourceStacks with direction 'z' are currently supported"
-      if len(to.children) != 0:
+      if not to.children:
         print(F"First plate added to ResourceStack '{to.name}'")
+        to_location = to.get_absolute_location()  # if ResourceStack is empty
         # TODO: add pedestal handling here once Plate is fixed
-      
-      if len(self.children) != 0:
-        top_plate = to.get_top_item()
-        if top_plate.lid is not None:
-          to_location = top_plate.get_absolute_location()
-          to_location = Coordinate(
-            x=to_location.x,
-            y=to_location.y,
-            z=to_location.z + top_plate.get_size_z() - top_plate.lid.nesting_z_height + top_plate.lid.get_size_z())
-        else:
-          to_location = to.get_absolute_location()
-          to_location = Coordinate(
-            x=to_location.x,
-            y=to_location.y,
-            z=to_location.z  + to.get_size_z())
       else:
-        to_location = to # if ResourceStack is empty
-    elif isinstance(to, Coordinate):
-      to_location = to
+        top_plate = to.get_top_item()
+        to_location = (top_plate.get_absolute_location() 
+                      if top_plate.lid 
+                      else to.get_absolute_location())
+        if top_plate.lid:
+          top_plate_lid_offset = top_plate.lid.get_size_z() - top_plate.lid.nesting_z_height
+          to_location = Coordinate(
+            x=to_location.x,
+            y=to_location.y,
+            z=to_location.z + top_plate.get_size_z() + top_plate_lid_offset)
+        else:
+          to_location = Coordinate(
+            x=to_location.x,
+            y=to_location.y,
+            z=to_location.z + to.get_size_z())
     elif isinstance(to, MFXModule):
       to_location = to.get_absolute_location() + to.child_resource_location
     elif isinstance(to, PlateAdapter):

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1766,22 +1766,23 @@ class LiquidHandler(Machine):
 
     if isinstance(to, ResourceStack):
       assert to.direction == "z", "Only ResourceStacks with direction 'z' are currently supported"
-      if not to.children:
-        print(F"First plate added to ResourceStack '{to.name}'")
-        to_location = to.get_absolute_location()  # if ResourceStack is empty
+      if len(to.children) == 0: # if ResourceStack is empty
+        to_location = to.get_absolute_location()
         # TODO: add pedestal handling here once Plate is fixed
       else:
         top_plate = to.get_top_item()
-        to_location = (top_plate.get_absolute_location()
-                      if top_plate.lid
-                      else to.get_absolute_location())
-        if top_plate.lid:
+        if not isinstance(top_plate, Plate):
+          raise ValueError("Cannot move a plate to a ResourceStack with a non-plate top item")
+
+        if top_plate.has_lid:
+          to_location = top_plate.get_absolute_location()
           top_plate_lid_offset = top_plate.lid.get_size_z() - top_plate.lid.nesting_z_height
           to_location = Coordinate(
             x=to_location.x,
             y=to_location.y,
             z=to_location.z + top_plate.get_size_z() + top_plate_lid_offset)
         else:
+          to_location = to.get_absolute_location()
           to_location = Coordinate(
             x=to_location.x,
             y=to_location.y,

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1766,11 +1766,25 @@ class LiquidHandler(Machine):
 
     if isinstance(to, ResourceStack):
       assert to.direction == "z", "Only ResourceStacks with direction 'z' are currently supported"
-      to_location = to.get_absolute_location()
-      to_location = Coordinate(
-        x=to_location.x,
-        y=to_location.y,
-        z=to_location.z  + to.get_size_z())
+      top_plate = to.get_top_item()
+      if top_plate.lid is not None:
+        to_location = top_plate.lid.get_absolute_location()
+        to_location = Coordinate(
+          x=to_location.x,
+          y=to_location.y,
+          z=to_location.z  + top_plate.lid.get_size_z())
+      else:
+        to_location = to.get_absolute_location()
+        to_location = Coordinate(
+          x=to_location.x,
+          y=to_location.y,
+          z=to_location.z  + to.get_size_z())
+        
+      # to_location = to.get_absolute_location()
+      # to_location = Coordinate(
+      #   x=to_location.x,
+      #   y=to_location.y,
+      #   z=to_location.z  + to.get_size_z())
     elif isinstance(to, Coordinate):
       to_location = to
     elif isinstance(to, MFXModule):

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1772,8 +1772,8 @@ class LiquidHandler(Machine):
         # TODO: add pedestal handling here once Plate is fixed
       else:
         top_plate = to.get_top_item()
-        to_location = (top_plate.get_absolute_location() 
-                      if top_plate.lid 
+        to_location = (top_plate.get_absolute_location()
+                      if top_plate.lid
                       else to.get_absolute_location())
         if top_plate.lid:
           top_plate_lid_offset = top_plate.lid.get_size_z() - top_plate.lid.nesting_z_height

--- a/pylabrobot/liquid_handling/liquid_handler_tests.py
+++ b/pylabrobot/liquid_handling/liquid_handler_tests.py
@@ -20,6 +20,7 @@ from pylabrobot.resources import (
   Deck,
   Lid,
   Plate,
+  ResourceStack,
   TipRack,
   TIP_CAR_480_A00,
   PLT_CAR_L5AC_A00,
@@ -214,6 +215,36 @@ class TestLiquidHandlerLayout(unittest.IsolatedAsyncioTestCase):
     assert plate.get_absolute_location().y == lid.get_absolute_location().y
     assert plate.get_absolute_location().z + plate.get_size_z() - lid_height \
       == lid.get_absolute_location().z
+
+  async def test_move_plate_onto_resource_stack_with_lid(self):
+    plate = Plate("plate", size_x=100, size_y=100, size_z=15, items=[])
+    lid = Lid(name="lid", size_x=plate.get_size_x(), size_y=plate.get_size_y(),
+      size_z=10, nesting_z_height=4)
+
+    stack = ResourceStack("stack", direction="z")
+    self.deck.assign_child_resource(stack, location=Coordinate(100, 100, 0))
+
+    await self.lh.move_plate(plate, stack)
+    await self.lh.move_lid(lid, plate)
+
+    self.assertEqual(plate.location.z, 0)
+    self.assertEqual(lid.location.z, 11)
+    self.assertEqual(plate.lid, lid)
+    self.assertEqual(stack.get_size_z(), 21)
+
+  async def test_move_plate_onto_resource_stack_with_plate(self):
+    plate1 = Plate("plate1", size_x=100, size_y=100, size_z=15, items=[])
+    plate2 = Plate("plate2", size_x=100, size_y=100, size_z=15, items=[])
+
+    stack = ResourceStack("stack", direction="z")
+
+    self.deck.assign_child_resource(stack, location=Coordinate(100, 100, 0))
+    await self.lh.move_plate(plate1, stack)
+    await self.lh.move_plate(plate2, stack)
+
+    self.assertEqual(plate1.location.z, 0)
+    self.assertEqual(plate2.location.z, 15)
+    self.assertEqual(stack.get_size_z(), 30)
 
   def test_serialize(self):
     serialized = self.lh.serialize()

--- a/pylabrobot/resources/corning_costar/plates.py
+++ b/pylabrobot/resources/corning_costar/plates.py
@@ -1082,7 +1082,7 @@ def Cos_6_wellplate_16800ul_Fb(name: str, with_lid: bool = True) -> Plate:
     name=name,
     size_x=127.0,
     size_y=86.0,
-    size_z=19.85,
+    size_z=20.0,
     lid=Cos_6_wellplate_16800ul_Fb_Lid(name=name + "_lid") if with_lid else None,
     model="Cos_6_wellplate_16800ul_Fb",
     items=create_equally_spaced_2d(Well,

--- a/pylabrobot/resources/corning_costar/plates.py
+++ b/pylabrobot/resources/corning_costar/plates.py
@@ -1049,7 +1049,7 @@ def Cos_6_wellplate_16800ul_Fb_Lid(name: str) -> Lid:
     size_x=127.0,
     size_y=86.0,
     size_z=7.8,
-    nesting_z_height=6.6, # measure overlap between lid and plate
+    nesting_z_height=6.7, # measure overlap between lid and plate
     model="Cos_6_wellplate_16800ul_Fb_Lid",
   )
 

--- a/pylabrobot/resources/corning_costar/plates.py
+++ b/pylabrobot/resources/corning_costar/plates.py
@@ -1048,8 +1048,8 @@ def Cos_6_wellplate_16800ul_Fb_Lid(name: str) -> Lid:
     name=name,
     size_x=127.0,
     size_y=86.0,
-    size_z=2,             # measure the total z height
-    nesting_z_height=1.9, # measure overlap between lid and plate
+    size_z=7.8,
+    nesting_z_height=6.6, # measure overlap between lid and plate
     model="Cos_6_wellplate_16800ul_Fb_Lid",
   )
 

--- a/pylabrobot/resources/resource_stack.py
+++ b/pylabrobot/resources/resource_stack.py
@@ -78,9 +78,6 @@ class ResourceStack(Resource):
     return max(resource.get_size_y() for resource in self.children)
 
   def get_size_z(self) -> float:
-    if self.direction != "z":
-      raise NotImplementedError("Only self.direction == 'z' is currently supported")
-
     def get_actual_resource_height(resource: Resource) -> float:
       """ Helper function to get the actual height of a resource, accounting for the lid nesting
       height if the resource is a plate with a lid. """
@@ -88,6 +85,8 @@ class ResourceStack(Resource):
         return resource.get_size_z() + resource.lid.get_size_z() - resource.lid.nesting_z_height
       return resource.get_size_z()
 
+    if self.direction != "z":
+      return max(get_actual_resource_height(child) for child in self.children)
     return sum(get_actual_resource_height(child) for child in self.children)
 
   def assign_child_resource(self, resource: Resource):

--- a/pylabrobot/resources/resource_stack.py
+++ b/pylabrobot/resources/resource_stack.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 
 from pylabrobot.resources.resource import Resource
 from pylabrobot.resources.coordinate import Coordinate
+from pylabrobot.resources.plate import Lid, Plate
 
 
 class ResourceStack(Resource):
@@ -90,7 +91,25 @@ class ResourceStack(Resource):
     elif self.direction == "y":
       resource_location = Coordinate(0, self.get_size_y(), 0)
     elif self.direction == "z":
-      resource_location = Coordinate(0, 0, self.get_size_z())
+      if isinstance(resource, Lid):
+        resource_location = Coordinate(0, 0, self.get_size_z() - resource.nesting_z_height)
+      else:
+        resource_location = Coordinate(0, 0, self.get_size_z())
+      if isinstance(resource, Plate):
+        if resource.lid is not None:
+          to_location = resource.lid.get_absolute_location()
+          to_location = Coordinate(
+            x=to_location.x,
+            y=to_location.y,
+            z=to_location.z  + resource.lid.get_size_z())
+        else:
+          to_location = resource.get_absolute_location()
+          to_location = Coordinate(
+            x=to_location.x,
+            y=to_location.y,
+            z=to_location.z  + resource.get_size_z())
+      else:
+        resource_location = Coordinate(0, 0, self.get_size_z())
     else:
       raise ValueError("self.direction must be one of 'x', 'y', or 'z'")
 

--- a/pylabrobot/resources/resource_stack.py
+++ b/pylabrobot/resources/resource_stack.py
@@ -79,13 +79,16 @@ class ResourceStack(Resource):
 
   def get_size_z(self) -> float:
     if not self.children:
-        return 0
+      return 0
     if self.direction == "z":
-      return sum(
+      if isinstance(self.children[0], Plate): # Assumption: all Resources will be plates
+        return sum(
           child.get_size_z() + (
-              (child.lid.get_size_z() - child.lid.nesting_z_height) if child.lid else 0
+            (child.lid.get_size_z() - child.lid.nesting_z_height) if child.lid else 0
           ) for child in self.children
-      )
+        )
+      else:
+        return sum(child.get_size_z() for child in self.children)
     else:
       raise NotImplementedError("Only self.direction == 'z' is currently supported")
 
@@ -93,7 +96,7 @@ class ResourceStack(Resource):
     # Determine child origin (front-left-bottom) location coordinates
     # update child location (relative to self): we place the child after the last child in the stack
     x, y, z = 0, 0, 0
-    
+
     if self.direction == "x":
       x = self.get_size_x()
     elif self.direction == "y":

--- a/pylabrobot/resources/resource_stack.py
+++ b/pylabrobot/resources/resource_stack.py
@@ -89,31 +89,22 @@ class ResourceStack(Resource):
       return max(get_actual_resource_height(child) for child in self.children)
     return sum(get_actual_resource_height(child) for child in self.children)
 
-  def assign_child_resource(
-    self,
-    resource: Resource,
-    location: Optional[Coordinate] = None,
+  def assign_child_resource(self, resource: Resource, location: Optional[Coordinate] = None,
     reassign: bool = False):
-    # Determine child origin (front-left-bottom) location coordinates
-    # update child location (relative to self): we place the child after the last child in the stack
-
     if self.direction == "x":
       resource_location = Coordinate(self.get_size_x(), 0, 0)
     elif self.direction == "y":
       resource_location = Coordinate(0, self.get_size_y(), 0)
     elif self.direction == "z":
-      z = self.get_size_z()
+      resource_location = Coordinate(0, 0, self.get_size_z())
+
+      # special handling for putting a lid on a plate
       if len(self.children) > 0:
         top_item = self.get_top_item()
         if isinstance(resource, Lid) and isinstance(top_item, Plate):
-          z -= resource.nesting_z_height
-          # TODO: building lid stack, currently assumes self.get_top_item() is a compatible plate
-          # have to add a check of what self.get_top_item() is to modify for lid stacking
-        elif isinstance(resource, Plate):
-          top_plate = self.get_top_item()
-          if top_plate.lid:
-            z = self.get_size_z() - top_plate.lid.nesting_z_height + top_plate.lid.get_size_z()
-      resource_location = Coordinate(0, 0, z)
+          resource_location.z -= resource.nesting_z_height
+          top_item.assign_child_resource(resource, location=resource_location)
+          return
     else:
       raise ValueError("self.direction must be one of 'x', 'y', or 'z'")
 

--- a/pylabrobot/resources/resource_stack.py
+++ b/pylabrobot/resources/resource_stack.py
@@ -93,21 +93,15 @@ class ResourceStack(Resource):
     elif self.direction == "z":
       if isinstance(resource, Lid):
         resource_location = Coordinate(0, 0, self.get_size_z() - resource.nesting_z_height)
-      else:
-        resource_location = Coordinate(0, 0, self.get_size_z())
-      if isinstance(resource, Plate):
-        if resource.lid is not None:
-          to_location = resource.lid.get_absolute_location()
-          to_location = Coordinate(
-            x=to_location.x,
-            y=to_location.y,
-            z=to_location.z  + resource.lid.get_size_z())
+      elif isinstance(resource, Plate):
+        if len(self.children) != 0:
+          top_plate = self.get_top_item()
+          if top_plate.lid is not None:
+            resource_location = Coordinate(0, 0, self.get_size_z() - top_plate.lid.nesting_z_height + top_plate.lid.get_size_z())
+          else:
+            resource_location = Coordinate(0, 0, self.get_size_z())
         else:
-          to_location = resource.get_absolute_location()
-          to_location = Coordinate(
-            x=to_location.x,
-            y=to_location.y,
-            z=to_location.z  + resource.get_size_z())
+            resource_location = Coordinate(0, 0, self.get_size_z())
       else:
         resource_location = Coordinate(0, 0, self.get_size_z())
     else:

--- a/pylabrobot/resources/resource_stack_tests.py
+++ b/pylabrobot/resources/resource_stack_tests.py
@@ -94,3 +94,16 @@ class ResourceStackTests(unittest.TestCase):
     top_item = stacking_area.get_top_item()
     assert top_item is not None
     self.assertEqual(top_item.get_absolute_location(), Coordinate(0, 0, 1))
+
+  def test_move_lid_onto_plate(self):
+    plate = Plate("plate", size_x=1, size_y=1, size_z=10, items=[])
+    lid = Lid(name="lid", size_x=1, size_y=1, size_z=5, nesting_z_height=2)
+    stacking_area = ResourceStack("stacking_area", "z")
+    stacking_area.location = Coordinate.zero()
+    stacking_area.assign_child_resource(plate)
+    stacking_area.assign_child_resource(lid)
+    self.assertEqual(stacking_area.get_top_item(), plate)
+    self.assertEqual(plate.lid, lid)
+    self.assertEqual(stacking_area.get_top_item().get_absolute_location(), Coordinate(0, 0, 0))
+    self.assertEqual(plate.lid.location, Coordinate(0, 0, 8))
+    self.assertEqual(stacking_area.get_size_z(), 13)


### PR DESCRIPTION
Hi everyone,

In this PR I enabled accurate stacking of plates with a lid inside a `ResourceStack`.

This is to enable full access to a deck's z storage capabilities and increase run throughputs by multiples of its current (mostly) single-plate use.

## Summary of the Problem
`ResourceStack` is a "management" `Resource` class. That means a subclass of `Resource` which does not represent a particular physical object. Instead it is designed to facilitate handling of stacking / placing `Resource`s on top of each other, similar to how `list`s can store elements in Python. In analogy to Python's `list` `ResourceStack` is also mutable.

However, while adapting some of the changes I proposed in [PR#173](https://github.com/PyLabRobot/pylabrobot/pull/173) to enable accurate stacking of `Plate`s with lids, I encountered a couple of issues with the current implementation of `ResourceStack`:
- `ResourceStack` so far ignored whether a `Plate` has a `Lid`, and as a result placing more than 2-3 plates on top of one another raised a Z-drive error / was impossible; this was ignored on 3 separate implementation levels:
  - `ResourceStack.get_size_z()` ignored it, giving the wrong height of the `ResourceStack`
  - `ResourceStack.assign_child_resource()` ignored it, giving wrong coordinates for `Plate`s inside the `ResourceStack`,
  - `liquid_handler.move_plate()` ignored it, leading to incorrect physical movement of  `Plate`s onto a `ResourceStack, creating crashes;
- due to the current `Plate` placement issue, a `ResourceStack` has to be placed on top of a site (i.e. `PlateCarrierSite`, `MFXModule.child_location`) with a `pedestal_z_height = 0` (i.e. which does not have a pedestal) - this can only be fixed once we have fixed `Plate`

![plate_stacking_render](https://github.com/user-attachments/assets/62eb3074-d7f1-498f-b33e-22f49fb05d56)


## PR Content
In this PR the 3 implementation levels mentioned above:
  - `ResourceStack.get_size_z()`
  - `ResourceStack.assign_child_resource()`
  - `liquid_handler.move_plate()` 
...to work together and enable automated placement of plates (with lids) onto an empty and non-empty `ResourceStack`.

Specifically, all of these move an incoming plate if the topmost plate of the `ResourceStack` has a lid on top of that lid (but at the same time does not become a child of that lid, retaining the deck tree organization we discussed PR#173).

This offset is calculated to be 
```python
top_plate.lid.get_size_z() - top_plate.lid.nesting_z_height
```
![lid_nesting_height_explainer](https://github.com/user-attachments/assets/ec9923ca-62fa-4a17-9105-50610fa63f7c)


## Next Steps
This PR does not cover all possible stacking scenarios, both in terms of changes regarding plates and sites.

Importantly, we should clearly distinguish between the following plate placements on top of one another:
- plate "stacking" ... placing one plate directly on top of another, meaning there is physical contact between the two - however, in most instances we mean that the two plates have a lid in between them and **do not overlap** in the z-dimension, for that case we have...
  - plate "nesting" ... a subtype of stacking, meaning plates **do overlap** in the z-dimension; likely to be the case with e.g. PCR plates (this is not yet implemented)
- plate "hotel" ... plates might be placed on top of one another but do not touch one another; instead a plate hotel is more like a shelf or a vertical carrier, plates can be placed into specified locations and moved in and out of that position freely using an arm like the iSWAP (this is not yet implemented in PLR).

I think we should also add a conditional statement in the future which checks that the top plate in a `ResourceStack` (if it exists) is of the same model than the incoming plate. This is to prevent wrong placements.

I also think we should add a warning to users when their `ResourceStack` crosses the "minimal safety height" / "safe traverse height" of 145 mm above deck / absolute z-coordinate 245 mm.