### PR TITLE
full xyz rotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - When providing offsets to LH, individual items in the `offsets` list are no longer optional. They must be provided as `Coordinate` objects. The `offsets` list itself is still optional and defaults to `[Coordinate(0, 0, 0)]*len(use_channels)`.
 - To aspirate from a single resource with multiple channels, you must now provide that single resource in a list when calling `LiquidHandler.aspirate` and `LiquidHandler.dispense`.
 - A resource's origin (lfb) is not changed on rotation, it is always fixed locally (https://github.com/PyLabRobot/pylabrobot/pull/195). Before, we updated the location after 90, 180, and 270 degree rotations.
-- `Resource.rotate` and `Resource.rotated` now support all planes and all angles (before it was limited to 90 degree rotations) (https://github.com/PyLabRobot/pylabrobot/pull/195)
+- `Resource.rotate` and `Resource.rotated` now support all planes and all angles (before it was limited to 90 degree rotations around the z axis) (https://github.com/PyLabRobot/pylabrobot/pull/195)
 - Resource children will not be relocated when the parent resource is rotated (https://github.com/PyLabRobot/pylabrobot/pull/195)
 - `Resource.rotation` attribute is now a `Rotation` object (https://github.com/PyLabRobot/pylabrobot/pull/195)
 
 ### Added
 
 - Cor_96_wellplate_360ul_Fb plate (catalog number [3603](https://ecatalog.corning.com/life-sciences/b2b/NL/en/Microplates/Assay-Microplates/96-Well-Microplates/Corning®-96-well-Black-Clear-and-White-Clear-Bottom-Polystyrene-Microplates/p/3603))
-- `Coordinate.vector()` method to return a 3-item list of floats.
+- `Coordinate.vector()` to return a 3-item list of floats.
 - `Rotation` class to represent a rotation in 3D space (https://github.com/PyLabRobot/pylabrobot/pull/195)
-- `Resource.get_absolute_rotation()` method to get the absolute rotation of a resource (https://github.com/PyLabRobot/pylabrobot/pull/195)
+- `Resource.get_absolute_rotation()` to get the absolute rotation of a resource (https://github.com/PyLabRobot/pylabrobot/pull/195)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - When providing offsets to LH, individual items in the `offsets` list are no longer optional. They must be provided as `Coordinate` objects. The `offsets` list itself is still optional and defaults to `[Coordinate(0, 0, 0)]*len(use_channels)`.
 - To aspirate from a single resource with multiple channels, you must now provide that single resource in a list when calling `LiquidHandler.aspirate` and `LiquidHandler.dispense`.
 - A resource's origin (lfb) is not changed on rotation, it is always fixed locally (https://github.com/PyLabRobot/pylabrobot/pull/195). Before, we updated the location after 90, 180, and 270 degree rotations.
-- `Resource.rotate` now supports all planes and all angles (before it was limited to 90 degree rotations) (https://github.com/PyLabRobot/pylabrobot/pull/195)
+- `Resource.rotate` and `Resource.rotated` now support all planes and all angles (before it was limited to 90 degree rotations) (https://github.com/PyLabRobot/pylabrobot/pull/195)
 - Resource children will not be relocated when the parent resource is rotated (https://github.com/PyLabRobot/pylabrobot/pull/195)
 - `Resource.rotation` attribute is now a `Rotation` object (https://github.com/PyLabRobot/pylabrobot/pull/195)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `offset` parameter is no longer optional in `Pickup`, `Drop`, `Aspirate`, and `Dispense` dataclasses. With LiquidHandler it defaults to `Coordinate(0, 0, 0)`.
 - When providing offsets to LH, individual items in the `offsets` list are no longer optional. They must be provided as `Coordinate` objects. The `offsets` list itself is still optional and defaults to `[Coordinate(0, 0, 0)]*len(use_channels)`.
 - To aspirate from a single resource with multiple channels, you must now provide that single resource in a list when calling `LiquidHandler.aspirate` and `LiquidHandler.dispense`.
+- A resource's origin (lfb) is not changed on rotation, it is always fixed locally (https://github.com/PyLabRobot/pylabrobot/pull/195). Before, we updated the location after 90, 180, and 270 degree rotations.
+- `Resource.rotate` now supports all planes and all angles (before it was limited to 90 degree rotations) (https://github.com/PyLabRobot/pylabrobot/pull/195)
+- Resource children will not be relocated when the parent resource is rotated (https://github.com/PyLabRobot/pylabrobot/pull/195)
+- `Resource.rotation` attribute is now a `Rotation` object (https://github.com/PyLabRobot/pylabrobot/pull/195)
 
 ### Added
 
 - Cor_96_wellplate_360ul_Fb plate (catalog number [3603](https://ecatalog.corning.com/life-sciences/b2b/NL/en/Microplates/Assay-Microplates/96-Well-Microplates/Corning®-96-well-Black-Clear-and-White-Clear-Bottom-Polystyrene-Microplates/p/3603))
+- `Coordinate.vector()` method to return a 3-item list of floats.
+- `Rotation` class to represent a rotation in 3D space (https://github.com/PyLabRobot/pylabrobot/pull/195)
+- `Resource.get_absolute_rotation()` method to get the absolute rotation of a resource (https://github.com/PyLabRobot/pylabrobot/pull/195)
 
 ### Deprecated
 

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -2469,6 +2469,8 @@ class STAR(HamiltonLiquidHandler):
     # Get center of source plate. Also gripping height and plate width.
     center = location + resource.rotated(rotation).center() + offset
     grip_height = center.z + resource.get_size_z() - pickup_distance_from_top
+    # grip_direction here is the put_direction. We use `rotation` to cancel it out and get the
+    # original grip direction. Hack.
     if grip_direction in (GripDirection.FRONT, GripDirection.BACK):
       plate_width = resource.rotated(rotation).get_size_x()
     elif grip_direction in (GripDirection.RIGHT, GripDirection.LEFT):

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -2467,14 +2467,14 @@ class STAR(HamiltonLiquidHandler):
     assert self.iswap_installed, "iswap must be installed"
 
     # Get center of source plate. Also gripping height and plate width.
-    center = location + resource.rotated(rotation).center() + offset
+    center = location + resource.rotated(z=rotation).center() + offset
     grip_height = center.z + resource.get_size_z() - pickup_distance_from_top
     # grip_direction here is the put_direction. We use `rotation` to cancel it out and get the
     # original grip direction. Hack.
     if grip_direction in (GripDirection.FRONT, GripDirection.BACK):
-      plate_width = resource.rotated(rotation).get_size_x()
+      plate_width = resource.rotated(z=rotation).get_size_x()
     elif grip_direction in (GripDirection.RIGHT, GripDirection.LEFT):
-      plate_width = resource.rotated(rotation).get_size_y()
+      plate_width = resource.rotated(z=rotation).get_size_y()
     else:
       raise ValueError("Invalid grip direction")
 

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
@@ -641,7 +641,7 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
       "C0PRid0004xs10427xd0yj3285yd0zj2063zd0th2450te2450go1307gr4ga0",
                 "xs#####xd#yj####yd#zj####zd#th####te####go####gr#ga#")
 
-    assert self.plate.rotation.xy == 90
+    assert self.plate.rotation.z == 90
     self.assertAlmostEqual(self.plate.get_size_x(), 85.48, places=2)
     self.assertAlmostEqual(self.plate.get_size_y(), 127.76, places=2)
 
@@ -762,7 +762,7 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     lh = LiquidHandler(self.mockSTAR, deck=deck)
     tip_car = TIP_CAR_288_C00(name="tip carrier")
     tip_car[0] = tr = HT_P(name="tips_01")
-    assert tr.rotation.xy == 90
+    assert tr.rotation.z == 90
     assert tr.location == Coordinate(82.6, 0, 0)
     print(tr.get_item("A1").location)
     deck.assign_child_resource(tip_car, rails=2)

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
@@ -641,8 +641,9 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
       "C0PRid0004xs10427xd0yj3285yd0zj2063zd0th2450te2450go1307gr4ga0",
                 "xs#####xd#yj####yd#zj####zd#th####te####go####gr#ga#")
 
-    assert self.plate.rotation == 90
-    assert self.plate.get_size_x() == 85.48 and self.plate.get_size_y() == 127.76
+    assert self.plate.rotation.xy == 90
+    self.assertAlmostEqual(self.plate.get_size_x(), 85.48, places=2)
+    self.assertAlmostEqual(self.plate.get_size_y(), 127.76, places=2)
 
     await self.lh.move_plate(plate_reader.get_plate(), self.plt_car[0],
       pickup_distance_from_top=8.2, get_direction=GripDirection.LEFT,
@@ -761,6 +762,9 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     lh = LiquidHandler(self.mockSTAR, deck=deck)
     tip_car = TIP_CAR_288_C00(name="tip carrier")
     tip_car[0] = tr = HT_P(name="tips_01")
+    assert tr.rotation.xy == 90
+    assert tr.location == Coordinate(82.6, 0, 0)
+    print(tr.get_item("A1").location)
     deck.assign_child_resource(tip_car, rails=2)
     await lh.setup()
 

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1633,7 +1633,7 @@ class LiquidHandler(Machine):
     # rotate the resource if the move operation has a rotation.
     # this code should be expanded to also update the resource's location
     if move_operation.rotation != 0:
-      move_operation.resource.rotate(move_operation.rotation)
+      move_operation.resource.rotate(z=move_operation.rotation)
 
     self._trigger_callback(
       "move_resource",

--- a/pylabrobot/machines/machine_tests.py
+++ b/pylabrobot/machines/machine_tests.py
@@ -35,7 +35,10 @@ class TestMachine(unittest.TestCase):
       "size_y": 10,
       "size_z": 10,
       "location": None,
-      "rotation": 0,
+      "rotation": {
+        "type": "Rotation",
+        "xy": 0, "xz": 0, "yz": 0
+      },
       "type": "MockMachine",
       "children": [],
       "category": None,

--- a/pylabrobot/machines/machine_tests.py
+++ b/pylabrobot/machines/machine_tests.py
@@ -37,7 +37,7 @@ class TestMachine(unittest.TestCase):
       "location": None,
       "rotation": {
         "type": "Rotation",
-        "xy": 0, "xz": 0, "yz": 0
+        "x": 0, "y": 0, "z": 0
       },
       "type": "MockMachine",
       "children": [],

--- a/pylabrobot/resources/azenta/plates.py
+++ b/pylabrobot/resources/azenta/plates.py
@@ -65,4 +65,4 @@ def Azenta4titudeFrameStar_96_wellplate_skirted_L(name: str, with_lid: bool = Fa
 
 #: Azenta4titudeFrameStar_96_wellplate_skirted_P
 def Azenta4titudeFrameStar_96_wellplate_skirted_P(name: str, with_lid: bool = False) -> Plate:
-  return Azenta4titudeFrameStar_96_wellplate_skirted(name=name, with_lid=with_lid).rotated(90)
+  return Azenta4titudeFrameStar_96_wellplate_skirted(name=name, with_lid=with_lid).rotated(z=90)

--- a/pylabrobot/resources/carrier.py
+++ b/pylabrobot/resources/carrier.py
@@ -124,7 +124,17 @@ class Carrier(Resource, Generic[S]):
     if self.sites[spot].resource is not None:
       raise ValueError(f"spot {spot} already has a resource")
 
-    self.sites[spot].assign_child_resource(resource, location=Coordinate.zero())
+    if not resource.rotation.xz == resource.rotation.yz == 0:
+      raise ValueError("Resource rotation must be 0 on the xz and yz planes")
+    if not resource.rotation.xy % 90 == 0:
+      raise ValueError("Resource rotation must be a multiple of 90 degrees on the xy plane")
+    location = {
+      0.0: Coordinate(x=0, y=0, z=0),
+      90.0: Coordinate(x=resource.get_size_x(), y=0, z=0),
+      180.0: Coordinate(x=resource.get_size_x(), y=resource.get_size_y(), z=0),
+      270.0: Coordinate(x=0, y=resource.get_size_y(), z=0),
+    }[resource.rotation.xy % 360]
+    self.sites[spot].assign_child_resource(resource, location=location)
 
   def unassign_child_resource(self, resource):
     """ Unassign a resource from this carrier, checked by name.

--- a/pylabrobot/resources/carrier.py
+++ b/pylabrobot/resources/carrier.py
@@ -124,16 +124,16 @@ class Carrier(Resource, Generic[S]):
     if self.sites[spot].resource is not None:
       raise ValueError(f"spot {spot} already has a resource")
 
-    if not resource.rotation.xz == resource.rotation.yz == 0:
-      raise ValueError("Resource rotation must be 0 on the xz and yz planes")
-    if not resource.rotation.xy % 90 == 0:
-      raise ValueError("Resource rotation must be a multiple of 90 degrees on the xy plane")
+    if not resource.rotation.y == resource.rotation.x == 0:
+      raise ValueError("Resource rotation must be 0 around the x and y axis")
+    if not resource.rotation.z % 90 == 0:
+      raise ValueError("Resource rotation must be a multiple of 90 degrees on the z axis")
     location = {
       0.0: Coordinate(x=0, y=0, z=0),
       90.0: Coordinate(x=resource.get_size_x(), y=0, z=0),
       180.0: Coordinate(x=resource.get_size_x(), y=resource.get_size_y(), z=0),
       270.0: Coordinate(x=0, y=resource.get_size_y(), z=0),
-    }[resource.rotation.xy % 360]
+    }[resource.rotation.z % 360]
     self.sites[spot].assign_child_resource(resource, location=location)
 
   def unassign_child_resource(self, resource):

--- a/pylabrobot/resources/carrier_tests.py
+++ b/pylabrobot/resources/carrier_tests.py
@@ -171,7 +171,7 @@ class CarrierTests(unittest.TestCase):
       "location": None,
       "rotation": {
         "type": "Rotation",
-        "y": 0, "z": 0, "x": 0
+        "x": 0, "y": 0, "z": 0
       },
       "category": "tip_carrier",
       "model": None,
@@ -191,7 +191,7 @@ class CarrierTests(unittest.TestCase):
           },
           "rotation": {
             "type": "Rotation",
-            "y": 0, "z": 0, "x": 0
+            "x": 0, "y": 0, "z": 0
           },
           "category": "carrier_site",
           "children": [],
@@ -212,7 +212,7 @@ class CarrierTests(unittest.TestCase):
           },
           "rotation": {
             "type": "Rotation",
-            "y": 0, "z": 0, "x": 0
+            "x": 0, "y": 0, "z": 0
           },
           "category": "carrier_site",
           "children": [],
@@ -233,7 +233,7 @@ class CarrierTests(unittest.TestCase):
           },
           "rotation": {
             "type": "Rotation",
-            "y": 0, "z": 0, "x": 0
+            "x": 0, "y": 0, "z": 0
           },
           "category": "carrier_site",
           "children": [],
@@ -254,7 +254,7 @@ class CarrierTests(unittest.TestCase):
           },
           "rotation": {
             "type": "Rotation",
-            "y": 0, "z": 0, "x": 0
+            "x": 0, "y": 0, "z": 0
           },
           "category": "carrier_site",
           "children": [],
@@ -275,7 +275,7 @@ class CarrierTests(unittest.TestCase):
           },
           "rotation": {
             "type": "Rotation",
-            "y": 0, "z": 0, "x": 0
+            "x": 0, "y": 0, "z": 0
           },
           "category": "carrier_site",
           "children": [],

--- a/pylabrobot/resources/carrier_tests.py
+++ b/pylabrobot/resources/carrier_tests.py
@@ -169,7 +169,10 @@ class CarrierTests(unittest.TestCase):
       "size_y": 497.0,
       "size_z": 13.0,
       "location": None,
-      "rotation": 0,
+      "rotation": {
+        "type": "Rotation",
+        "xz": 0, "xy": 0, "yz": 0
+      },
       "category": "tip_carrier",
       "model": None,
       "parent_name": None,
@@ -186,7 +189,10 @@ class CarrierTests(unittest.TestCase):
             "y": 20,
             "z": 30
           },
-          "rotation": 0,
+          "rotation": {
+            "type": "Rotation",
+            "xz": 0, "xy": 0, "yz": 0
+          },
           "category": "carrier_site",
           "children": [],
           "parent_name": "tip_car",
@@ -204,7 +210,10 @@ class CarrierTests(unittest.TestCase):
             "y": 50,
             "z": 30
           },
-          "rotation": 0,
+          "rotation": {
+            "type": "Rotation",
+            "xz": 0, "xy": 0, "yz": 0
+          },
           "category": "carrier_site",
           "children": [],
           "parent_name": "tip_car",
@@ -222,7 +231,10 @@ class CarrierTests(unittest.TestCase):
             "y": 80,
             "z": 30
           },
-          "rotation": 0,
+          "rotation": {
+            "type": "Rotation",
+            "xz": 0, "xy": 0, "yz": 0
+          },
           "category": "carrier_site",
           "children": [],
           "parent_name": "tip_car",
@@ -240,7 +252,10 @@ class CarrierTests(unittest.TestCase):
             "y": 130,
             "z": 30
           },
-          "rotation": 0,
+          "rotation": {
+            "type": "Rotation",
+            "xz": 0, "xy": 0, "yz": 0
+          },
           "category": "carrier_site",
           "children": [],
           "parent_name": "tip_car",
@@ -258,7 +273,10 @@ class CarrierTests(unittest.TestCase):
             "y": 160,
             "z": 30
           },
-          "rotation": 0,
+          "rotation": {
+            "type": "Rotation",
+            "xz": 0, "xy": 0, "yz": 0
+          },
           "category": "carrier_site",
           "children": [],
           "parent_name": "tip_car",

--- a/pylabrobot/resources/carrier_tests.py
+++ b/pylabrobot/resources/carrier_tests.py
@@ -171,7 +171,7 @@ class CarrierTests(unittest.TestCase):
       "location": None,
       "rotation": {
         "type": "Rotation",
-        "xz": 0, "xy": 0, "yz": 0
+        "y": 0, "z": 0, "x": 0
       },
       "category": "tip_carrier",
       "model": None,
@@ -191,7 +191,7 @@ class CarrierTests(unittest.TestCase):
           },
           "rotation": {
             "type": "Rotation",
-            "xz": 0, "xy": 0, "yz": 0
+            "y": 0, "z": 0, "x": 0
           },
           "category": "carrier_site",
           "children": [],
@@ -212,7 +212,7 @@ class CarrierTests(unittest.TestCase):
           },
           "rotation": {
             "type": "Rotation",
-            "xz": 0, "xy": 0, "yz": 0
+            "y": 0, "z": 0, "x": 0
           },
           "category": "carrier_site",
           "children": [],
@@ -233,7 +233,7 @@ class CarrierTests(unittest.TestCase):
           },
           "rotation": {
             "type": "Rotation",
-            "xz": 0, "xy": 0, "yz": 0
+            "y": 0, "z": 0, "x": 0
           },
           "category": "carrier_site",
           "children": [],
@@ -254,7 +254,7 @@ class CarrierTests(unittest.TestCase):
           },
           "rotation": {
             "type": "Rotation",
-            "xz": 0, "xy": 0, "yz": 0
+            "y": 0, "z": 0, "x": 0
           },
           "category": "carrier_site",
           "children": [],
@@ -275,7 +275,7 @@ class CarrierTests(unittest.TestCase):
           },
           "rotation": {
             "type": "Rotation",
-            "xz": 0, "xy": 0, "yz": 0
+            "y": 0, "z": 0, "x": 0
           },
           "category": "carrier_site",
           "children": [],

--- a/pylabrobot/resources/coordinate.py
+++ b/pylabrobot/resources/coordinate.py
@@ -43,3 +43,6 @@ class Coordinate:
 
   def __neg__(self) -> Coordinate:
     return Coordinate(-self.x, -self.y, -self.z)
+
+  def vector(self) -> list[float]:
+    return [self.x, self.y, self.z]

--- a/pylabrobot/resources/corning_axygen/plates.py
+++ b/pylabrobot/resources/corning_axygen/plates.py
@@ -67,4 +67,4 @@ def Axy_24_DW_10ML_L(name: str, with_lid: bool = False) -> Plate:
 
 #: Axy_24_DW_10ML_P
 def Axy_24_DW_10ML_P(name: str, with_lid: bool = False) -> Plate:
-  return Axy_24_DW_10ML(name=name, with_lid=with_lid).rotated(90)
+  return Axy_24_DW_10ML(name=name, with_lid=with_lid).rotated(z=90)

--- a/pylabrobot/resources/corning_costar/plates.py
+++ b/pylabrobot/resources/corning_costar/plates.py
@@ -75,7 +75,7 @@ def Cos_1536_10ul_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_1536_10ul_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_1536_10ul """
-  return Cos_1536_10ul(name=name, with_lid=with_lid).rotated(90)
+  return Cos_1536_10ul(name=name, with_lid=with_lid).rotated(z=90)
 
 def _compute_volume_from_height_Cos_384_DW(h: float) -> float:
   volume = min(h, 1.0)*min(h, 1.0)*(4.3982 - 1.0472*min(h, 1.0))
@@ -134,7 +134,7 @@ def Cos_384_DW_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_384_DW_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_384_DW """
-  return Cos_384_DW(name=name, with_lid=with_lid).rotated(90)
+  return Cos_384_DW(name=name, with_lid=with_lid).rotated(z=90)
 
 def _compute_volume_from_height_Cos_384_PCR(h: float) -> float:
   volume = min(h, 9.5)*2.8510
@@ -191,7 +191,7 @@ def Cos_384_PCR_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_384_PCR_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_384_PCR """
-  return Cos_384_PCR(name=name, with_lid=with_lid).rotated(90)
+  return Cos_384_PCR(name=name, with_lid=with_lid).rotated(z=90)
 
 def _compute_volume_from_height_Cos_384_Sq(h: float) -> float:
   volume = min(h, 11.56)*12.2500
@@ -248,7 +248,7 @@ def Cos_384_Sq_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_384_Sq_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_384_Sq """
-  return Cos_384_Sq(name=name, with_lid=with_lid).rotated(90)
+  return Cos_384_Sq(name=name, with_lid=with_lid).rotated(z=90)
 
 def _compute_volume_from_height_Cos_384_Sq_Rd(h: float) -> float:
   volume = min(h, 1.0)*min(h, 1.0)*(4.3982 - 1.0472*min(h, 1.0))
@@ -307,7 +307,7 @@ def Cos_384_Sq_Rd_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_384_Sq_Rd_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_384_Sq_Rd """
-  return Cos_384_Sq_Rd(name=name, with_lid=with_lid).rotated(90)
+  return Cos_384_Sq_Rd(name=name, with_lid=with_lid).rotated(z=90)
 
 def _compute_volume_from_height_Cos_96_DW_1mL(h: float) -> float:
   volume = min(h, 2.5)*min(h, 2.5)*(10.2102 - 1.0472*min(h, 2.5))
@@ -366,7 +366,7 @@ def Cos_96_DW_1mL_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_96_DW_1mL_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_96_DW_1mL """
-  return Cos_96_DW_1mL(name=name, with_lid=with_lid).rotated(90)
+  return Cos_96_DW_1mL(name=name, with_lid=with_lid).rotated(z=90)
 
 def _compute_volume_from_height_Cos_96_DW_2mL(h: float) -> float:
   volume = min(h, 4.0)*min(h, 4.0)*(12.5664 - 1.0472*min(h, 4.0))
@@ -425,7 +425,7 @@ def Cos_96_DW_2mL_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_96_DW_2mL_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_96_DW_2mL """
-  return Cos_96_DW_2mL(name=name, with_lid=with_lid).rotated(90)
+  return Cos_96_DW_2mL(name=name, with_lid=with_lid).rotated(z=90)
 
 def _compute_volume_from_height_Cos_96_DW_500ul(h: float) -> float:
   volume = min(h, 1.5)*10.7233
@@ -484,7 +484,7 @@ def Cos_96_DW_500ul_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_96_DW_500ul_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_96_DW_500ul """
-  return Cos_96_DW_500ul(name=name, with_lid=with_lid).rotated(90)
+  return Cos_96_DW_500ul(name=name, with_lid=with_lid).rotated(z=90)
 
 def _compute_volume_from_height_Cos_96_EZWash(h: float) -> float:
   volume = min(h, 11.3)*37.3928
@@ -515,7 +515,7 @@ def Cos_96_EZWash_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_96_EZWash_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_96_EZWash """
-  return Cos_96_EZWash(name=name, with_lid=with_lid).rotated(90)
+  return Cos_96_EZWash(name=name, with_lid=with_lid).rotated(z=90)
 
 
 def _compute_volume_from_height_Cos_96_FL(h: float) -> float:
@@ -622,7 +622,7 @@ def Cos_96_Filter_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_96_Filter_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_96_Filter """
-  return Cos_96_Filter(name=name, with_lid=with_lid).rotated(90)
+  return Cos_96_Filter(name=name, with_lid=with_lid).rotated(z=90)
 
 def Cos_96_Fl_L(name: str, with_lid: bool = False) -> Plate:
   """ Cos_96_Fl """
@@ -630,7 +630,7 @@ def Cos_96_Fl_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_96_Fl_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_96_Fl """
-  return Cos_96_FL(name=name, with_lid=with_lid).rotated(90)
+  return Cos_96_FL(name=name, with_lid=with_lid).rotated(z=90)
 
 def _compute_volume_from_height_Cos_96_HalfArea(h: float) -> float:
   volume = min(h, 10.7)*17.7369
@@ -687,7 +687,7 @@ def Cos_96_HalfArea_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_96_HalfArea_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_96_HalfArea """
-  return Cos_96_HalfArea(name=name, with_lid=with_lid).rotated(90)
+  return Cos_96_HalfArea(name=name, with_lid=with_lid).rotated(z=90)
 
 def _compute_volume_from_height_Cos_96_PCR(h: float) -> float:
   volume = min(h, 11.5)*6.5450
@@ -746,7 +746,7 @@ def Cos_96_PCR_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_96_PCR_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_96_PCR """
-  return Cos_96_PCR(name=name, with_lid=with_lid).rotated(90)
+  return Cos_96_PCR(name=name, with_lid=with_lid).rotated(z=90)
 
 def _compute_volume_from_height_Cos_96_ProtCryst(h: float) -> float:
   volume = min(h, 1.6)*7.5477
@@ -803,7 +803,7 @@ def Cos_96_ProtCryst_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_96_ProtCryst_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_96_ProtCryst """
-  return Cos_96_ProtCryst(name=name, with_lid=with_lid).rotated(90)
+  return Cos_96_ProtCryst(name=name, with_lid=with_lid).rotated(z=90)
 
 def _compute_volume_from_height_Cos_96_Rd(h: float) -> float:
   volume = min(h, 0.6)*min(h, 0.6)*(10.0531 - 1.0472*min(h, 0.6))
@@ -862,7 +862,7 @@ def Cos_96_Rd_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_96_Rd_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_96_Rd """
-  return Cos_96_Rd(name=name, with_lid=with_lid).rotated(90)
+  return Cos_96_Rd(name=name, with_lid=with_lid).rotated(z=90)
 
 def _compute_volume_from_height_Cos_96_SpecOps(h: float) -> float:
   volume = min(h, 11.0)*34.7486
@@ -919,7 +919,7 @@ def Cos_96_SpecOps_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_96_SpecOps_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_96_SpecOps """
-  return Cos_96_SpecOps(name=name, with_lid=with_lid).rotated(90)
+  return Cos_96_SpecOps(name=name, with_lid=with_lid).rotated(z=90)
 
 def _compute_volume_from_height_Cos_96_UV(h: float) -> float:
   volume = min(h, 11.0)*34.7486
@@ -976,7 +976,7 @@ def Cos_96_UV_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_96_UV_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_96_UV """
-  return Cos_96_UV(name=name, with_lid=with_lid).rotated(90)
+  return Cos_96_UV(name=name, with_lid=with_lid).rotated(z=90)
 
 def _compute_volume_from_height_Cos_96_Vb(h: float) -> float:
   volume = min(h, 1.4)*10.5564
@@ -1035,7 +1035,7 @@ def Cos_96_Vb_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_96_Vb_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_96_Vb """
-  return Cos_96_Vb(name=name, with_lid=with_lid).rotated(90)
+  return Cos_96_Vb(name=name, with_lid=with_lid).rotated(z=90)
 
 
 ############ User-defined PLR Cos plates ############
@@ -1107,7 +1107,7 @@ def Cos_6_wellplate_16800ul_Fb_L(name: str, with_lid: bool = True) -> Plate:
   return Cos_6_wellplate_16800ul_Fb(name=name, with_lid=with_lid)
 
 def Cos_6_wellplate_16800ul_Fb_P(name: str, with_lid: bool = True) -> Plate:
-  return Cos_6_wellplate_16800ul_Fb(name=name, with_lid=with_lid).rotated(90)
+  return Cos_6_wellplate_16800ul_Fb(name=name, with_lid=with_lid).rotated(z=90)
 
 
 # # # # # # # # # # Cos_96_DWP_2mL_Vb # # # # # # # # # #
@@ -1183,7 +1183,7 @@ def Cos_96_DWP_2mL_Vb_L(name: str, with_lid: bool = False) -> Plate:
 
 def Cos_96_DWP_2mL_Vb_P(name: str, with_lid: bool = False) -> Plate:
   """ Cos_96_DWP_2mL_Vb """
-  return Cos_96_DWP_2mL_Vb(name=name, with_lid=with_lid).rotated(90)
+  return Cos_96_DWP_2mL_Vb(name=name, with_lid=with_lid).rotated(z=90)
 
 
 def Cor_96_wellplate_360ul_Fb_Lid(name: str) -> Lid:

--- a/pylabrobot/resources/greiner/plates.py
+++ b/pylabrobot/resources/greiner/plates.py
@@ -108,7 +108,7 @@ def Gre_1536_Sq_L(name: str, with_lid: bool = False) -> Plate:
 
 def Gre_1536_Sq_P(name: str, with_lid: bool = False) -> Plate:
   """ Gre_1536_Sq """
-  return Gre_1536_Sq(name=name, with_lid=with_lid).rotated(90)
+  return Gre_1536_Sq(name=name, with_lid=with_lid).rotated(z=90)
 def _compute_volume_from_height_Greiner96Well_655_101(h: float) -> float:
   volume = min(h, 10.9)*35.0152
   if h > 10.9:

--- a/pylabrobot/resources/ml_star/tip_racks.py
+++ b/pylabrobot/resources/ml_star/tip_racks.py
@@ -44,7 +44,7 @@ def FourmlTF_L(name: str, with_tips: bool = True) -> TipRack:
 
 #: Tip Rack 24x 4ml Tip with Filter portrait oriented
 def FourmlTF_P(name: str, with_tips: bool = True) -> TipRack:
-  return FourmlTF_L(name=name, with_tips=with_tips).rotated(90)
+  return FourmlTF_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
 #: Tip Rack 24x 5ml Tip landscape oriented
@@ -73,7 +73,7 @@ def FivemlT_L(name: str, with_tips: bool = True) -> TipRack:
 
 #: Tip Rack 24x 5ml Tip portrait oriented
 def FivemlT_P(name: str, with_tips: bool = True) -> TipRack:
-  return FivemlT_L(name=name, with_tips=with_tips).rotated(90)
+  return FivemlT_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
 #: Rack with 96 1000ul High Volume Tip with filter
@@ -102,7 +102,7 @@ def HTF_L(name: str, with_tips: bool = True) -> TipRack:
 
 #: Rack with 96 1000ul High Volume Tip with filter (portrait)
 def HTF_P(name: str, with_tips: bool = True) -> TipRack:
-  return HTF_L(name=name, with_tips=with_tips).rotated(90)
+  return HTF_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
 #: Rack with 96 1000ul High Volume Tip
@@ -131,7 +131,7 @@ def HT_L(name: str, with_tips: bool = True) -> TipRack:
 
 #: Rack with 96 1000ul High Volume Tip (portrait)
 def HT_P(name: str, with_tips: bool = True) -> TipRack:
-  return HT_L(name=name, with_tips=with_tips).rotated(90)
+  return HT_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
 #: Rack with 96 10ul Low Volume Tip with filter
@@ -160,7 +160,7 @@ def LTF_L(name: str, with_tips: bool = True) -> TipRack:
 
 #: Rack with 96 10ul Low Volume Tip with filter (portrait)
 def LTF_P(name: str, with_tips: bool = True) -> TipRack:
-  return LTF_L(name=name, with_tips=with_tips).rotated(90)
+  return LTF_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
 #: Rack with 96 10ul Low Volume Tip
@@ -189,7 +189,7 @@ def LT_L(name: str, with_tips: bool = True) -> TipRack:
 
 #: Rack with 96 10ul Low Volume Tip (portrait)
 def LT_P(name: str, with_tips: bool = True) -> TipRack:
-  return LT_L(name=name, with_tips=with_tips).rotated(90)
+  return LT_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
 #: Rack with 96 300ul Standard Volume Tip with filter
@@ -218,7 +218,7 @@ def STF_L(name: str, with_tips: bool = True) -> TipRack:
 
 #: Rack with 96 300ul Standard Volume Tip with filter (portrait)
 def STF_P(name: str, with_tips: bool = True) -> TipRack:
-  return STF_L(name=name, with_tips=with_tips).rotated(90)
+  return STF_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
 #: Rack with 96 300ul Standard Volume Tip
@@ -247,7 +247,7 @@ def ST_L(name: str, with_tips: bool = True) -> TipRack:
 
 #: Rack with 96 300ul Standard Volume Tip (portrait)
 def ST_P(name: str, with_tips: bool = True) -> TipRack:
-  return ST_L(name=name, with_tips=with_tips).rotated(90)
+  return ST_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
 #: Rack with 96 50ul Tip with filter
@@ -276,7 +276,7 @@ def TIP_50ul_w_filter_L(name: str, with_tips: bool = True) -> TipRack:
 
 #: Tip Rack 96 50ul Tip with filter portrait oriented
 def TIP_50ul_w_filter_P(name: str, with_tips: bool = True) -> TipRack:
-  return TIP_50ul_w_filter_L(name=name, with_tips=with_tips).rotated(90)
+  return TIP_50ul_w_filter_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
 #: Rack with 96 50ul Tip
@@ -305,4 +305,4 @@ def TIP_50ul_L(name: str, with_tips: bool = True) -> TipRack:
 
 #: Tip Rack 96 50ul Tip portrait oriented
 def TIP_50ul_P(name: str, with_tips: bool = True) -> TipRack:
-  return TIP_50ul_L(name=name, with_tips=with_tips).rotated(90)
+  return TIP_50ul_L(name=name, with_tips=with_tips).rotated(z=90)

--- a/pylabrobot/resources/petri_dish.py
+++ b/pylabrobot/resources/petri_dish.py
@@ -14,7 +14,8 @@ class PetriDish(Container):
     diameter: float,
     height: float,
     category: str = "petri_dish",
-    model: Optional[str] = None
+    model: Optional[str] = None,
+    max_volume: Optional[float] = None
   ):
     super().__init__(
       name=name,
@@ -23,6 +24,7 @@ class PetriDish(Container):
       size_z=height,
       category=category,
       model=model,
+      max_volume=max_volume
     )
     self.diameter = diameter
     self.height = height
@@ -60,11 +62,7 @@ class PetriDishHolder(Resource):
       model=model,
     )
 
-  def assign_child_resource(
-      self,
-      resource: Resource,
-      location: Coordinate,
-      reassign: bool = True):
+  def assign_child_resource(self, resource: Resource, location: Coordinate, reassign: bool = True):
     """ Can only assign a single PetriDish """
     if not isinstance(resource, PetriDish):
       raise TypeError("Can only assign PetriDish to PetriDishHolder")

--- a/pylabrobot/resources/petri_dish_tests.py
+++ b/pylabrobot/resources/petri_dish_tests.py
@@ -1,7 +1,7 @@
 from typing import cast
 import unittest
 
-from pylabrobot.resources import PetriDish, PetriDishHolder
+from pylabrobot.resources import Coordinate, PetriDish, PetriDishHolder
 
 
 class TestPetriDish(unittest.TestCase):
@@ -19,7 +19,10 @@ class TestPetriDish(unittest.TestCase):
       "type": "PetriDish",
       "children": [],
       "location": None,
-      "rotation": 0,
+      "rotation": {
+        "type": "Rotation",
+        "xz": 0, "xy": 0, "yz": 0
+      },
       "max_volume": 121500.0,
       "model": None,
     })
@@ -37,60 +40,26 @@ class TestPetriDish(unittest.TestCase):
       "type": "PetriDishHolder",
       "children": [],
       "location": None,
-      "rotation": 0,
+      "rotation": {
+        "type": "Rotation",
+        "xz": 0, "xy": 0, "yz": 0
+      },
       "model": None,
     })
 
   def test_petri_dish_holder_deserialization_without_dish(self):
-    petri_dish_holder = PetriDishHolder.deserialize({
-      "name": "petri_dish_holder",
-      "category": "petri_dish_holder",
-      "size_x": 127.76,
-      "size_y": 85.48,
-      "size_z": 14.5,
-      "children": [],
-      "location": None,
-      "rotation": 0,
-      "model": None,
-      "type": "PetriDishHolder",
-      "parent_name": None,
-    })
+    petri_dish_holder = PetriDishHolder("petri_dish_holder")
+    petri_dish_holder = PetriDishHolder.deserialize(petri_dish_holder.serialize())
 
     self.assertEqual(petri_dish_holder.name, "petri_dish_holder")
     self.assertEqual(petri_dish_holder.get_size_x(), 127.76)
     self.assertEqual(petri_dish_holder.get_size_y(), 85.48)
 
   def test_petri_dish_holder_deserialization_with_dish(self):
-    petri_dish_holder = PetriDishHolder.deserialize({
-      "name": "petri_dish_holder",
-      "category": "petri_dish_holder",
-      "size_x": 127.76,
-      "size_y": 85.48,
-      "size_z": 14.5,
-      "children": [
-        {
-          "name": "petri_dish",
-          "category": "petri_dish",
-          "diameter": 90.0,
-          "height": 15.0,
-          "parent_name": "petri_dish_holder",
-          "type": "PetriDish",
-          "children": [],
-          "location": {
-            "x": 0.0,
-            "y": 0.0,
-            "z": 0.0,
-          },
-          "rotation": 0,
-          "model": None,
-        }
-      ],
-      "location": None,
-      "rotation": 0,
-      "model": None,
-      "type": "PetriDishHolder",
-      "parent_name": None,
-    })
+    petri_dish_holder = PetriDishHolder("petri_dish_holder")
+    petri_dish_holder.assign_child_resource(PetriDish("petri_dish", 90.0, 15.0),
+                                            location=Coordinate.zero())
+    petri_dish_holder = PetriDishHolder.deserialize(petri_dish_holder.serialize())
 
     self.assertEqual(petri_dish_holder.name, "petri_dish_holder")
     self.assertEqual(petri_dish_holder.get_size_x(), 127.76)

--- a/pylabrobot/resources/petri_dish_tests.py
+++ b/pylabrobot/resources/petri_dish_tests.py
@@ -21,7 +21,7 @@ class TestPetriDish(unittest.TestCase):
       "location": None,
       "rotation": {
         "type": "Rotation",
-        "xz": 0, "xy": 0, "yz": 0
+        "y": 0, "z": 0, "x": 0
       },
       "max_volume": 121500.0,
       "model": None,
@@ -42,7 +42,7 @@ class TestPetriDish(unittest.TestCase):
       "location": None,
       "rotation": {
         "type": "Rotation",
-        "xz": 0, "xy": 0, "yz": 0
+        "y": 0, "z": 0, "x": 0
       },
       "model": None,
     })

--- a/pylabrobot/resources/petri_dish_tests.py
+++ b/pylabrobot/resources/petri_dish_tests.py
@@ -21,7 +21,7 @@ class TestPetriDish(unittest.TestCase):
       "location": None,
       "rotation": {
         "type": "Rotation",
-        "y": 0, "z": 0, "x": 0
+        "x": 0, "y": 0, "z": 0
       },
       "max_volume": 121500.0,
       "model": None,
@@ -42,7 +42,7 @@ class TestPetriDish(unittest.TestCase):
       "location": None,
       "rotation": {
         "type": "Rotation",
-        "y": 0, "z": 0, "x": 0
+        "x": 0, "y": 0, "z": 0
       },
       "model": None,
     })

--- a/pylabrobot/resources/porvair/plates.py
+++ b/pylabrobot/resources/porvair/plates.py
@@ -90,4 +90,4 @@ def Porvair_6_reservoir_47ml_Vb_L(name: str, with_lid: bool = False) -> Plate:
 
 #: Porvair_6_reservoir_47ml_Vb_P
 def Porvair_6_reservoir_47ml_Vb_P(name: str, with_lid: bool = False) -> Plate:
-  return Porvair_6_reservoir_47ml_Vb(name=name, with_lid=with_lid).rotated(90)
+  return Porvair_6_reservoir_47ml_Vb(name=name, with_lid=with_lid).rotated(z=90)

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -387,27 +387,23 @@ class Resource:
 
     raise ResourceNotFoundError(f"Resource with name '{name}' does not exist.")
 
-  def rotate(self, xy: float = 0, xz: float = 0, yz: float = 0):
+  def rotate(self, x: float = 0, y: float = 0, z: float = 0):
     """ Rotate counter-clockwise by the given number of degrees. """
 
-    self.rotation.xy = (self.rotation.xy + xy) % 360
-    self.rotation.xz = (self.rotation.xz + xz) % 360
-    self.rotation.yz = (self.rotation.yz + yz) % 360
+    self.rotation.x = (self.rotation.x + x) % 360
+    self.rotation.y = (self.rotation.y + y) % 360
+    self.rotation.z = (self.rotation.z + z) % 360
 
   def copy(self) -> Self:
     resource_copy = self.__class__.deserialize(self.serialize())
     resource_copy.load_all_state(self.serialize_all_state())
     return resource_copy
 
-  def rotated(self, degrees: int) -> Self:
-    """ Return a copy of this resource rotated by the given number of degrees.
-
-    Args:
-      degrees: must be a multiple of 90, but not also 360.
-    """
+  def rotated(self, x: float = 0, y: float = 0, z: float = 0) -> Self:
+    """ Return a copy of this resource rotated by the given number of degrees. """
 
     new_resource = self.copy()
-    new_resource.rotate(degrees)
+    new_resource.rotate(x=x, y=y, z=z)
     return new_resource
 
   def center(self, x: bool = True, y: bool = True, z: bool = False) -> Coordinate:

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -8,7 +8,9 @@ from typing import Any, Callable, Dict, List, Optional, cast
 
 from .coordinate import Coordinate
 from .errors import ResourceNotFoundError
+from .rotation import Rotation
 from pylabrobot.serializer import serialize, deserialize
+from pylabrobot.utils.linalg import matrix_vector_multiply_3x3
 from pylabrobot.utils.object_parsing import find_subclass
 
 if sys.version_info >= (3, 11):
@@ -45,6 +47,7 @@ class Resource:
     size_x: float,
     size_y: float,
     size_z: float,
+    rotation: Optional[Rotation] = None,
     category: Optional[str] = None,
     model: Optional[str] = None,
   ):
@@ -52,14 +55,13 @@ class Resource:
     self._size_x = size_x
     self._size_y = size_y
     self._size_z = size_z
+    self.rotation = rotation or Rotation()
     self.category = category
     self.model = model
 
     self.location: Optional[Coordinate] = None
     self.parent: Optional[Resource] = None
     self.children: List[Resource] = []
-
-    self.rotation = 0 # TODO: like location, this should be wrt parent
 
     self._will_assign_resource_callbacks: List[WillAssignResourceCallback] = []
     self._did_assign_resource_callbacks: List[DidAssignResourceCallback] = []
@@ -76,7 +78,7 @@ class Resource:
       "size_y": self._size_y,
       "size_z": self._size_z,
       "location": serialize(self.location),
-      "rotation": self.rotation,
+      "rotation": serialize(self.rotation),
       "category": self.category,
       "model": self.model,
       "children": [child.serialize() for child in self.children],
@@ -177,6 +179,12 @@ class Resource:
 
     return Coordinate(x_, y_, z_)
 
+  def get_absolute_rotation(self) -> Rotation:
+    """ Get the absolute rotation of this resource. """
+    if self.parent is None:
+      return self.rotation
+    return self.parent.get_absolute_rotation() + self.rotation
+
   def get_absolute_location(self, x: str = "l", y: str = "f", z: str = "b") -> Coordinate:
     """ Get the absolute location of this resource, probably within the
     :class:`pylabrobot.resources.Deck`. The `x`, `y`, and `z` arguments specify the anchor point
@@ -191,21 +199,40 @@ class Resource:
     assert self.location is not None, "Resource has no location."
     if self.parent is None:
       return self.location
-    return self.parent.get_absolute_location() + self.location + self.get_anchor(x=x, y=y, z=z)
+    parent_pos = self.parent.get_absolute_location()
+    parent_rotation_matrix = self.parent.get_absolute_rotation().get_rotation_matrix()
+    local_vector = (self.location + self.get_anchor(x=x, y=y, z=z)).vector()
+    rotated_position = Coordinate(*matrix_vector_multiply_3x3(parent_rotation_matrix, local_vector))
+    return parent_pos + rotated_position
+
+  def _get_rotated_corners(self) -> List[Coordinate]:
+    absolute_rotation = self.get_absolute_rotation()
+    rot_mat = absolute_rotation.get_rotation_matrix()
+    return [
+      Coordinate(*matrix_vector_multiply_3x3(rot_mat, corner.vector()))
+      for corner in [
+        Coordinate(0, 0, 0),
+        Coordinate(self._size_x, 0, 0),
+        Coordinate(0, self._size_y, 0),
+        Coordinate(self._size_x, self._size_y, 0),
+        Coordinate(0, 0, self._size_z),
+        Coordinate(self._size_x, 0, self._size_z),
+        Coordinate(0, self._size_y, self._size_z),
+        Coordinate(self._size_x, self._size_y, self._size_z)
+      ]
+    ]
 
   def get_size_x(self) -> float:
-    if self.rotation in {90, 270}:
-      return self._size_y
-    return self._size_x
+    rotated_corners = self._get_rotated_corners()
+    return max(c.x for c in rotated_corners) - min(c.x for c in rotated_corners)
 
   def get_size_y(self) -> float:
-    if self.rotation in {90, 270}:
-      return self._size_x
-    return self._size_y
+    rotated_corners = self._get_rotated_corners()
+    return max(c.y for c in rotated_corners) - min(c.y for c in rotated_corners)
 
   def get_size_z(self) -> float:
-    """ Get the size of this resource in the z-direction. """
-    return self._size_z
+    rotated_corners = self._get_rotated_corners()
+    return max(c.z for c in rotated_corners) - min(c.z for c in rotated_corners)
 
   def assign_child_resource(
     self,
@@ -360,35 +387,12 @@ class Resource:
 
     raise ResourceNotFoundError(f"Resource with name '{name}' does not exist.")
 
-  def rotate(self, degrees: int):
-    """ Rotate counter clockwise by the given number of degrees.
+  def rotate(self, xy: float = 0, xz: float = 0, yz: float = 0):
+    """ Rotate counter-clockwise by the given number of degrees. """
 
-    Args:
-      degrees: must be a multiple of 90, but not also 360.
-    """
-
-    effective_degrees = degrees % 360
-
-    if effective_degrees % 90 != 0:
-      raise ValueError(f"Invalid rotation: {degrees}")
-
-    for child in self.children:
-      assert child.location is not None, "child must have a location when it's assigned."
-
-      old_x = child.location.x
-
-      if effective_degrees == 90:
-        child.location.x = self.get_size_y() - child.location.y - child.get_size_y()
-        child.location.y = old_x
-      elif effective_degrees == 180:
-        child.location.x = self.get_size_x() - child.location.x - child.get_size_x()
-        child.location.y = self.get_size_y() - child.location.y - child.get_size_y()
-      elif effective_degrees == 270:
-        child.location.x = child.location.y
-        child.location.y = self.get_size_x() - old_x - child.get_size_x()
-      child.rotate(effective_degrees)
-
-    self.rotation = (self.rotation + degrees) % 360
+    self.rotation.xy = (self.rotation.xy + xy) % 360
+    self.rotation.xz = (self.rotation.xz + xz) % 360
+    self.rotation.yz = (self.rotation.yz + yz) % 360
 
   def copy(self) -> Self:
     resource_copy = self.__class__.deserialize(self.serialize())
@@ -534,7 +538,7 @@ class Resource:
     children_data = data_copy.pop("children")
     rotation = data_copy.pop("rotation")
     resource = subclass(**data_copy)
-    resource.rotation = rotation
+    resource.rotation = Rotation.deserialize(rotation)
 
     for child_data in children_data:
       child_cls = find_subclass(child_data["type"], cls=Resource)

--- a/pylabrobot/resources/resource_tests.py
+++ b/pylabrobot/resources/resource_tests.py
@@ -23,19 +23,19 @@ class TestResource(unittest.TestCase):
     r = Resource("test", size_x=20, size_y=10, size_z=10)
     r.rotation = Rotation(xy=45)
     width1 = 20 * math.cos(math.radians(45)) + 10 * math.cos(math.radians(45))
-    self.assertAlmostEqual(r.get_size_x(), width1)
+    self.assertAlmostEqual(r.get_size_x(), width1, places=5)
 
     height1 = 20 * math.sin(math.radians(45)) + 10 * math.sin(math.radians(45))
-    self.assertAlmostEqual(r.get_size_y(), height1)
+    self.assertAlmostEqual(r.get_size_y(), height1, places=5)
 
   def test_rotated_m45(self):
     r = Resource("test", size_x=20, size_y=10, size_z=10)
     r.rotation = Rotation(xy=-45)
     width1 = 20 * math.cos(math.radians(45)) + 10 * math.cos(math.radians(45))
-    self.assertAlmostEqual(r.get_size_x(), width1)
+    self.assertAlmostEqual(r.get_size_x(), width1, places=5)
 
     height1 = 20 * math.sin(math.radians(45)) + 10 * math.sin(math.radians(45))
-    self.assertAlmostEqual(r.get_size_y(), height1)
+    self.assertAlmostEqual(r.get_size_y(), height1, places=5)
 
   def test_get_resource(self):
     deck = Deck()

--- a/pylabrobot/resources/resource_tests.py
+++ b/pylabrobot/resources/resource_tests.py
@@ -1,6 +1,7 @@
 """ Tests for Resource """
 # pylint: disable=missing-class-docstring
 
+import math
 import unittest
 import unittest.mock
 
@@ -8,9 +9,34 @@ from .coordinate import Coordinate
 from .deck import Deck
 from .errors import ResourceNotFoundError
 from .resource import Resource
+from .rotation import Rotation
 
 
 class TestResource(unittest.TestCase):
+  def test_simple_get_size(self):
+    r = Resource("test", size_x=10, size_y=10, size_z=10)
+    self.assertEqual(r.get_size_x(), 10)
+    self.assertEqual(r.get_size_y(), 10)
+    self.assertEqual(r.get_size_z(), 10)
+
+  def test_rotated_45(self):
+    r = Resource("test", size_x=20, size_y=10, size_z=10)
+    r.rotation = Rotation(xy=45)
+    width1 = 20 * math.cos(math.radians(45)) + 10 * math.cos(math.radians(45))
+    self.assertAlmostEqual(r.get_size_x(), width1)
+
+    height1 = 20 * math.sin(math.radians(45)) + 10 * math.sin(math.radians(45))
+    self.assertAlmostEqual(r.get_size_y(), height1)
+
+  def test_rotated_m45(self):
+    r = Resource("test", size_x=20, size_y=10, size_z=10)
+    r.rotation = Rotation(xy=-45)
+    width1 = 20 * math.cos(math.radians(45)) + 10 * math.cos(math.radians(45))
+    self.assertAlmostEqual(r.get_size_x(), width1)
+
+    height1 = 20 * math.sin(math.radians(45)) + 10 * math.sin(math.radians(45))
+    self.assertAlmostEqual(r.get_size_y(), height1)
+
   def test_get_resource(self):
     deck = Deck()
     parent = Resource("parent", size_x=10, size_y=10, size_z=10)
@@ -135,7 +161,10 @@ class TestResource(unittest.TestCase):
     self.assertEqual(r.serialize(), {
       "name": "test",
       "location": None,
-      "rotation": 0,
+      "rotation": {
+        "type": "Rotation",
+        "xy": 0, "xz": 0, "yz": 0,
+      },
       "size_x": 10,
       "size_y": 10,
       "size_z": 10,
@@ -154,7 +183,10 @@ class TestResource(unittest.TestCase):
     self.assertEqual(r.serialize(), {
       "name": "test",
       "location": None,
-      "rotation": 0,
+      "rotation": {
+        "type": "Rotation",
+        "xy": 0, "xz": 0, "yz": 0,
+      },
       "size_x": 10,
       "size_y": 10,
       "size_z": 10,
@@ -166,7 +198,10 @@ class TestResource(unittest.TestCase):
             "type": "Coordinate",
             "x": 5, "y": 5, "z": 5,
           },
-          "rotation": 0,
+          "rotation": {
+            "type": "Rotation",
+            "xy": 0, "xz": 0, "yz": 0,
+          },
           "size_x": 1,
           "size_y": 1,
           "size_z": 1,
@@ -208,11 +243,11 @@ class TestResource(unittest.TestCase):
     r.assign_child_resource(c, location=Coordinate(20, 10, 10))
 
     r.rotate(90)
-    self.assertEqual(r.get_size_x(), 100)
-    self.assertEqual(r.get_size_y(), 200)
-    self.assertEqual(c.get_absolute_location(), Coordinate(70, 20, 10))
-    self.assertEqual(c.get_size_x(), 20)
-    self.assertEqual(c.get_size_y(), 10)
+    self.assertAlmostEqual(r.get_size_x(), 100)
+    self.assertAlmostEqual(r.get_size_y(), 200)
+    self.assertEqual(c.get_absolute_location(), Coordinate(-10, 20, 10))
+    self.assertAlmostEqual(c.get_size_x(), 20)
+    self.assertAlmostEqual(c.get_size_y(), 10)
 
   def test_rotation180(self):
     r = Resource("parent", size_x=200, size_y=100, size_z=100)
@@ -221,11 +256,11 @@ class TestResource(unittest.TestCase):
     r.assign_child_resource(c, location=Coordinate(20, 10, 10))
 
     r.rotate(180)
-    self.assertEqual(r.get_size_x(), 200)
-    self.assertEqual(r.get_size_y(), 100)
-    self.assertEqual(c.get_absolute_location(), Coordinate(170, 70, 10))
-    self.assertEqual(c.get_size_x(), 10)
-    self.assertEqual(c.get_size_y(), 20)
+    self.assertAlmostEqual(r.get_size_x(), 200)
+    self.assertAlmostEqual(r.get_size_y(), 100)
+    self.assertEqual(c.get_absolute_location(), Coordinate(x=-20, y=-10, z=10))
+    self.assertAlmostEqual(c.get_size_x(), 10)
+    self.assertAlmostEqual(c.get_size_y(), 20)
 
   def test_rotation270(self):
     r = Resource("parent", size_x=200, size_y=100, size_z=100)
@@ -234,17 +269,11 @@ class TestResource(unittest.TestCase):
     r.assign_child_resource(c, location=Coordinate(20, 10, 10))
 
     r.rotate(270)
-    self.assertEqual(r.get_size_x(), 100)
-    self.assertEqual(r.get_size_y(), 200)
-    self.assertEqual(c.get_absolute_location(), Coordinate(10, 170, 10))
-    self.assertEqual(c.get_size_x(), 20)
-    self.assertEqual(c.get_size_y(), 10)
-
-  def test_rotation_invalid(self):
-    r = Resource("parent", size_x=200, size_y=100, size_z=100)
-
-    with self.assertRaises(ValueError):
-      r.rotate(45)
+    self.assertAlmostEqual(r.get_size_x(), 100)
+    self.assertAlmostEqual(r.get_size_y(), 200)
+    self.assertEqual(c.get_absolute_location(), Coordinate(x=10, y=-20, z=10))
+    self.assertAlmostEqual(c.get_size_x(), 20)
+    self.assertAlmostEqual(c.get_size_y(), 10)
 
   def test_multiple_rotations(self):
     r = Resource("parent", size_x=200, size_y=100, size_z=100)
@@ -254,18 +283,18 @@ class TestResource(unittest.TestCase):
 
     r.rotate(90)
     r.rotate(90) # 180
-    self.assertEqual(r.get_size_x(), 200)
-    self.assertEqual(r.get_size_y(), 100)
-    self.assertEqual(c.get_absolute_location(), Coordinate(170, 70, 10))
+    self.assertAlmostEqual(r.get_size_x(), 200)
+    self.assertAlmostEqual(r.get_size_y(), 100)
+    self.assertEqual(c.get_absolute_location(), Coordinate(x=-20, y=-10, z=10))
 
     r.rotate(90) # 270
-    self.assertEqual(r.get_size_x(), 100)
-    self.assertEqual(r.get_size_y(), 200)
-    self.assertEqual(c.get_absolute_location(), Coordinate(10, 170, 10))
+    self.assertAlmostEqual(r.get_size_x(), 100)
+    self.assertAlmostEqual(r.get_size_y(), 200)
+    self.assertEqual(c.get_absolute_location(), Coordinate(x=10, y=-20, z=10))
 
     r.rotate(90) # 0
-    self.assertEqual(r.get_size_x(), 200)
-    self.assertEqual(r.get_size_y(), 100)
+    self.assertAlmostEqual(r.get_size_x(), 200)
+    self.assertAlmostEqual(r.get_size_y(), 100)
     self.assertEqual(c.get_absolute_location(), Coordinate(20, 10, 10))
 
 class TestResourceCallback(unittest.TestCase):

--- a/pylabrobot/resources/resource_tests.py
+++ b/pylabrobot/resources/resource_tests.py
@@ -21,7 +21,7 @@ class TestResource(unittest.TestCase):
 
   def test_rotated_45(self):
     r = Resource("test", size_x=20, size_y=10, size_z=10)
-    r.rotation = Rotation(xy=45)
+    r.rotation = Rotation(z=45)
     width1 = 20 * math.cos(math.radians(45)) + 10 * math.cos(math.radians(45))
     self.assertAlmostEqual(r.get_size_x(), width1, places=5)
 
@@ -30,7 +30,7 @@ class TestResource(unittest.TestCase):
 
   def test_rotated_m45(self):
     r = Resource("test", size_x=20, size_y=10, size_z=10)
-    r.rotation = Rotation(xy=-45)
+    r.rotation = Rotation(z=-45)
     width1 = 20 * math.cos(math.radians(45)) + 10 * math.cos(math.radians(45))
     self.assertAlmostEqual(r.get_size_x(), width1, places=5)
 
@@ -163,7 +163,7 @@ class TestResource(unittest.TestCase):
       "location": None,
       "rotation": {
         "type": "Rotation",
-        "xy": 0, "xz": 0, "yz": 0,
+        "x": 0, "y": 0, "z": 0,
       },
       "size_x": 10,
       "size_y": 10,
@@ -185,7 +185,7 @@ class TestResource(unittest.TestCase):
       "location": None,
       "rotation": {
         "type": "Rotation",
-        "xy": 0, "xz": 0, "yz": 0,
+        "x": 0, "y": 0, "z": 0,
       },
       "size_x": 10,
       "size_y": 10,
@@ -200,7 +200,7 @@ class TestResource(unittest.TestCase):
           },
           "rotation": {
             "type": "Rotation",
-            "xy": 0, "xz": 0, "yz": 0,
+            "x": 0, "y": 0, "z": 0,
           },
           "size_x": 1,
           "size_y": 1,
@@ -242,7 +242,7 @@ class TestResource(unittest.TestCase):
     c = Resource("child", size_x=10, size_y=20, size_z=10)
     r.assign_child_resource(c, location=Coordinate(20, 10, 10))
 
-    r.rotate(90)
+    r.rotate(z=90)
     self.assertAlmostEqual(r.get_size_x(), 100)
     self.assertAlmostEqual(r.get_size_y(), 200)
     self.assertEqual(c.get_absolute_location(), Coordinate(-10, 20, 10))
@@ -255,7 +255,7 @@ class TestResource(unittest.TestCase):
     c = Resource("child", size_x=10, size_y=20, size_z=10)
     r.assign_child_resource(c, location=Coordinate(20, 10, 10))
 
-    r.rotate(180)
+    r.rotate(z=180)
     self.assertAlmostEqual(r.get_size_x(), 200)
     self.assertAlmostEqual(r.get_size_y(), 100)
     self.assertEqual(c.get_absolute_location(), Coordinate(x=-20, y=-10, z=10))
@@ -268,7 +268,7 @@ class TestResource(unittest.TestCase):
     c = Resource("child", size_x=10, size_y=20, size_z=10)
     r.assign_child_resource(c, location=Coordinate(20, 10, 10))
 
-    r.rotate(270)
+    r.rotate(z=270)
     self.assertAlmostEqual(r.get_size_x(), 100)
     self.assertAlmostEqual(r.get_size_y(), 200)
     self.assertEqual(c.get_absolute_location(), Coordinate(x=10, y=-20, z=10))
@@ -281,18 +281,18 @@ class TestResource(unittest.TestCase):
     c = Resource("child", size_x=10, size_y=20, size_z=10)
     r.assign_child_resource(c, location=Coordinate(20, 10, 10))
 
-    r.rotate(90)
-    r.rotate(90) # 180
+    r.rotate(z=90)
+    r.rotate(z=90) # 180
     self.assertAlmostEqual(r.get_size_x(), 200)
     self.assertAlmostEqual(r.get_size_y(), 100)
     self.assertEqual(c.get_absolute_location(), Coordinate(x=-20, y=-10, z=10))
 
-    r.rotate(90) # 270
+    r.rotate(z=90) # 270
     self.assertAlmostEqual(r.get_size_x(), 100)
     self.assertAlmostEqual(r.get_size_y(), 200)
     self.assertEqual(c.get_absolute_location(), Coordinate(x=10, y=-20, z=10))
 
-    r.rotate(90) # 0
+    r.rotate(z=90) # 0
     self.assertAlmostEqual(r.get_size_x(), 200)
     self.assertAlmostEqual(r.get_size_y(), 100)
     self.assertEqual(c.get_absolute_location(), Coordinate(20, 10, 10))

--- a/pylabrobot/resources/rotation.py
+++ b/pylabrobot/resources/rotation.py
@@ -1,0 +1,43 @@
+import math
+
+from pylabrobot.utils.linalg import matrix_multiply_3x3
+
+
+class Rotation:
+  """ Represents a 3D rotation. """
+
+  def __init__(self, xy: float = 0, xz: float = 0, yz: float = 0):
+    self.xy = xy  # around z-axis, yaw
+    self.xz = xz  # around y-axis, pitch
+    self.yz = yz  # around x-axis, roll
+
+  def get_rotation_matrix(self):
+    # Create rotation matrices for each axis
+    Rz = ([
+      [math.cos(math.radians(self.xy)), -math.sin(math.radians(self.xy)), 0],
+      [math.sin(math.radians(self.xy)), math.cos(math.radians(self.xy)), 0],
+      [0, 0, 1]
+    ])
+    Ry = ([
+      [math.cos(math.radians(self.xz)), 0, math.sin(math.radians(self.xz))],
+      [0, 1, 0],
+      [-math.sin(math.radians(self.xz)), 0, math.cos(math.radians(self.xz))]
+    ])
+    Rx = ([
+      [1, 0, 0],
+      [0, math.cos(math.radians(self.yz)), -math.sin(math.radians(self.yz))],
+      [0, math.sin(math.radians(self.yz)), math.cos(math.radians(self.yz))]
+    ])
+    # Combine rotations: The order of multiplication matters and defines the behavior significantly.
+    # This is a common order: Rz * Ry * Rx
+    return matrix_multiply_3x3(matrix_multiply_3x3(Rz, Ry), Rx)
+
+  def __str__(self) -> str:
+    return f"Rotation(xy={self.xy}, xz={self.xz}, yz={self.yz})"
+
+  def __add__(self, other) -> 'Rotation':
+    return Rotation(self.xy + other.xy, self.xz + other.xz, self.yz + other.yz)
+
+  @staticmethod
+  def deserialize(data) -> 'Rotation':
+    return Rotation(data["xy"], data["xz"], data["yz"])

--- a/pylabrobot/resources/rotation.py
+++ b/pylabrobot/resources/rotation.py
@@ -35,9 +35,9 @@ class Rotation:
   def __str__(self) -> str:
     return f"Rotation(xy={self.xy}, xz={self.xz}, yz={self.yz})"
 
-  def __add__(self, other) -> 'Rotation':
+  def __add__(self, other) -> "Rotation":
     return Rotation(self.xy + other.xy, self.xz + other.xz, self.yz + other.yz)
 
   @staticmethod
-  def deserialize(data) -> 'Rotation':
+  def deserialize(data) -> "Rotation":
     return Rotation(data["xy"], data["xz"], data["yz"])

--- a/pylabrobot/resources/rotation.py
+++ b/pylabrobot/resources/rotation.py
@@ -6,38 +6,38 @@ from pylabrobot.utils.linalg import matrix_multiply_3x3
 class Rotation:
   """ Represents a 3D rotation. """
 
-  def __init__(self, xy: float = 0, xz: float = 0, yz: float = 0):
-    self.xy = xy  # around z-axis, yaw
-    self.xz = xz  # around y-axis, pitch
-    self.yz = yz  # around x-axis, roll
+  def __init__(self, x: float = 0, y: float = 0, z: float = 0):
+    self.x = x  # around x-axis, roll
+    self.y = y  # around y-axis, pitch
+    self.z = z  # around z-axis, yaw
 
   def get_rotation_matrix(self):
     # Create rotation matrices for each axis
     Rz = ([
-      [math.cos(math.radians(self.xy)), -math.sin(math.radians(self.xy)), 0],
-      [math.sin(math.radians(self.xy)), math.cos(math.radians(self.xy)), 0],
+      [math.cos(math.radians(self.z)), -math.sin(math.radians(self.z)), 0],
+      [math.sin(math.radians(self.z)), math.cos(math.radians(self.z)), 0],
       [0, 0, 1]
     ])
     Ry = ([
-      [math.cos(math.radians(self.xz)), 0, math.sin(math.radians(self.xz))],
+      [math.cos(math.radians(self.y)), 0, math.sin(math.radians(self.y))],
       [0, 1, 0],
-      [-math.sin(math.radians(self.xz)), 0, math.cos(math.radians(self.xz))]
+      [-math.sin(math.radians(self.y)), 0, math.cos(math.radians(self.y))]
     ])
     Rx = ([
       [1, 0, 0],
-      [0, math.cos(math.radians(self.yz)), -math.sin(math.radians(self.yz))],
-      [0, math.sin(math.radians(self.yz)), math.cos(math.radians(self.yz))]
+      [0, math.cos(math.radians(self.x)), -math.sin(math.radians(self.x))],
+      [0, math.sin(math.radians(self.x)), math.cos(math.radians(self.x))]
     ])
     # Combine rotations: The order of multiplication matters and defines the behavior significantly.
     # This is a common order: Rz * Ry * Rx
     return matrix_multiply_3x3(matrix_multiply_3x3(Rz, Ry), Rx)
 
   def __str__(self) -> str:
-    return f"Rotation(xy={self.xy}, xz={self.xz}, yz={self.yz})"
+    return f"Rotation(x={self.x}, y={self.y}, z={self.z})"
 
   def __add__(self, other) -> "Rotation":
-    return Rotation(self.xy + other.xy, self.xz + other.xz, self.yz + other.yz)
+    return Rotation(x=self.x + other.x, y=self.y + other.y, z=self.z + other.z)
 
   @staticmethod
   def deserialize(data) -> "Rotation":
-    return Rotation(data["xy"], data["xz"], data["yz"])
+    return Rotation(data["x"], data["y"], data["z"])

--- a/pylabrobot/resources/thermo_fisher/plates.py
+++ b/pylabrobot/resources/thermo_fisher/plates.py
@@ -87,4 +87,4 @@ def ThermoScientific_96_DWP_1200ul_Rd_L(name: str, with_lid: bool = False) -> Pl
   return ThermoScientific_96_DWP_1200ul_Rd(name=name, with_lid=with_lid)
 
 def ThermoScientific_96_DWP_1200ul_Rd_P(name: str, with_lid: bool = False) -> Plate:
-  return ThermoScientific_96_DWP_1200ul_Rd(name=name, with_lid=with_lid).rotated(90)
+  return ThermoScientific_96_DWP_1200ul_Rd(name=name, with_lid=with_lid).rotated(z=90)

--- a/pylabrobot/resources/well_tests.py
+++ b/pylabrobot/resources/well_tests.py
@@ -26,7 +26,7 @@ class TestWell(unittest.TestCase):
       "location": None,
       "rotation": {
         "type": "Rotation",
-        "xz": 0, "xy": 0, "yz": 0
+        "y": 0, "z": 0, "x": 0
       },
     })
 

--- a/pylabrobot/resources/well_tests.py
+++ b/pylabrobot/resources/well_tests.py
@@ -24,7 +24,10 @@ class TestWell(unittest.TestCase):
       "type": "Well",
       "parent_name": None,
       "location": None,
-      "rotation": 0,
+      "rotation": {
+        "type": "Rotation",
+        "xz": 0, "xy": 0, "yz": 0
+      },
     })
 
     self.assertEqual(Well.deserialize(well.serialize()), well)

--- a/pylabrobot/resources/well_tests.py
+++ b/pylabrobot/resources/well_tests.py
@@ -26,7 +26,7 @@ class TestWell(unittest.TestCase):
       "location": None,
       "rotation": {
         "type": "Rotation",
-        "y": 0, "z": 0, "x": 0
+        "x": 0, "y": 0, "z": 0
       },
     })
 

--- a/pylabrobot/utils/linalg.py
+++ b/pylabrobot/utils/linalg.py
@@ -1,0 +1,7 @@
+def matrix_multiply_3x3(A, B):
+  """Multiplies two 3x3 matrices A and B."""
+  return [[sum(A[i][k] * B[k][j] for k in range(3)) for j in range(3)] for i in range(3)]
+
+def matrix_vector_multiply_3x3(A, v):
+  """Multiplies a 3x3 matrix A with a 3x1 vector v."""
+  return [sum(A[i][j] * v[j] for j in range(3)) for i in range(3)]

--- a/pylabrobot/utils/linalg_tests.py
+++ b/pylabrobot/utils/linalg_tests.py
@@ -1,0 +1,35 @@
+import unittest
+
+
+from .linalg import matrix_multiply_3x3, matrix_vector_multiply_3x3
+
+
+class TestLinalg(unittest.TestCase):
+  """ Test the linalg functions """
+  def test_matrix_multiply_3x3(self):
+    A = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9]
+    ]
+    B = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9]
+    ]
+    C = matrix_multiply_3x3(A, B)
+    assert C == [
+      [30, 36, 42],
+      [66, 81, 96],
+      [102, 126, 150]
+    ]
+
+  def test_matrix_vector_multiply_3x3(self):
+    A = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9]
+    ]
+    B = [1, 2, 3]
+    C = matrix_vector_multiply_3x3(A, B)
+    assert C == [14, 32, 50]


### PR DESCRIPTION
support full rotations on the xy, xz and yz planes.

rotations, like locations, are with respect to the parent. introduce `get_absolute_rotation`.

origin is fixed wrt the resource, which is also the origin of rotation. (before we updated the resource's origin after the rotation to be the lfb always & we re-located the direct children. this was all silly)

implement two simple lin alg functions matrix_multiply_3x3, matrix_vector_multiply_3x3 to avoid numpy dependency.