### PR TITLE
Fix Aspirate & Dispense Arguments

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -1694,16 +1694,9 @@ class STAR(HamiltonLiquidHandler):
         ratio_liquid_rise_to_tip_deep_in=ratio_liquid_rise_to_tip_deep_in,
         immersion_depth_2nd_section=[round(id_*10) for id_ in immersion_depth_2nd_section],
 
-        minimum_traverse_height_at_beginning_of_a_command = (
-            round(minimum_traverse_height_at_beginning_of_a_command * 10)
-            if minimum_traverse_height_at_beginning_of_a_command is not None
-            else round(self._traversal_height * 10)
-        ),
-        min_z_endpos = (
-            round(min_z_endpos * 10)
-            if min_z_endpos is not None
-            else round(self._traversal_height * 10)
-        )
+        minimum_traverse_height_at_beginning_of_a_command=
+          round((minimum_traverse_height_at_beginning_of_a_command or self._traversal_height) * 10),
+        min_z_endpos=round((min_z_endpos or self._traversal_height) * 10),
       )
     except STARFirmwareError as e:
       if plr_e := convert_star_firmware_error_to_plr_error(e):
@@ -1934,16 +1927,9 @@ class STAR(HamiltonLiquidHandler):
         mix_surface_following_distance=[round(msfd*10) for msfd in mix_surface_following_distance],
         limit_curve_index=limit_curve_index,
 
-        minimum_traverse_height_at_beginning_of_a_command = (
-            round(minimum_traverse_height_at_beginning_of_a_command * 10)
-            if minimum_traverse_height_at_beginning_of_a_command is not None
-            else round(self._traversal_height * 10)
-        ),
-        min_z_endpos = (
-            round(min_z_endpos * 10)
-            if min_z_endpos is not None
-            else round(self._traversal_height * 10)
-        ),
+        minimum_traverse_height_at_beginning_of_a_command=
+          round((minimum_traverse_height_at_beginning_of_a_command or self._traversal_height) * 10),
+        min_z_endpos=round((min_z_endpos or self._traversal_height) * 10),
         side_touch_off_distance=side_touch_off_distance,
       )
     except STARFirmwareError as e:

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -1694,9 +1694,16 @@ class STAR(HamiltonLiquidHandler):
         ratio_liquid_rise_to_tip_deep_in=ratio_liquid_rise_to_tip_deep_in,
         immersion_depth_2nd_section=[round(id_*10) for id_ in immersion_depth_2nd_section],
 
-        minimum_traverse_height_at_beginning_of_a_command=\
-          minimum_traverse_height_at_beginning_of_a_command or round(self._traversal_height * 10),
-        min_z_endpos=min_z_endpos or round(self._traversal_height * 10),
+        minimum_traverse_height_at_beginning_of_a_command = (
+            round(minimum_traverse_height_at_beginning_of_a_command * 10)
+            if minimum_traverse_height_at_beginning_of_a_command is not None
+            else round(self._traversal_height * 10)
+        ),
+        min_z_endpos = (
+            round(min_z_endpos * 10)
+            if min_z_endpos is not None
+            else round(self._traversal_height * 10)
+        )
       )
     except STARFirmwareError as e:
       if plr_e := convert_star_firmware_error_to_plr_error(e):
@@ -1927,9 +1934,16 @@ class STAR(HamiltonLiquidHandler):
         mix_surface_following_distance=[round(msfd*10) for msfd in mix_surface_following_distance],
         limit_curve_index=limit_curve_index,
 
-        minimum_traverse_height_at_beginning_of_a_command=
-          minimum_traverse_height_at_beginning_of_a_command or round(self._traversal_height * 10),
-        min_z_endpos=min_z_endpos or round(self._traversal_height * 10),
+        minimum_traverse_height_at_beginning_of_a_command = (
+            round(minimum_traverse_height_at_beginning_of_a_command * 10)
+            if minimum_traverse_height_at_beginning_of_a_command is not None
+            else round(self._traversal_height * 10)
+        ),
+        min_z_endpos = (
+            round(min_z_endpos * 10)
+            if min_z_endpos is not None
+            else round(self._traversal_height * 10)
+        ),
         side_touch_off_distance=side_touch_off_distance,
       )
     except STARFirmwareError as e:


### PR DESCRIPTION
Hi everyone,

It appears that two arguments have slipped through making all liquid-handler commands take standardised units (i.e. mm and uL) in #191.

- `minimum_traverse_height_at_beginning_of_a_command` &
- `min_z_endpos`

for both `lh.aspirate()` and `lh.dispense()`

In this mini-PR I added a round(argument*10) statement if the argument is not `None`.

This rescued the correct behaviour of these arguments.