### PR TITLE
enable dispense blowout on STAR backend

### DIFF
--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -901,7 +901,6 @@ class LiquidHandler(Machine):
     if isinstance(blow_out_air_volume, numbers.Number):
       raise NotImplementedError("Single blow out air volume is deprecated, use a list of volumes.")
 
-    self._blow_out_air_volume = None
     tips = [self.head[channel].get_tip() for channel in use_channels]
 
     # Check the blow out air volume with what was aspirated

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -968,6 +968,8 @@ class LiquidHandler(Machine):
           (op.resource.tracker.commit if success else op.resource.tracker.rollback)()
         (self.head[channel].get_tip().tracker.commit if success else self.head[channel].rollback)()
 
+    self._blow_out_air_volume = None
+
     # trigger callback
     self._trigger_callback(
       "dispense",


### PR DESCRIPTION
I noticed this one line was triggering a `BlowOutVolumeError("No blowout volume was aspirated.")` error, and this seems to fix things