### PR TITLE
ray/make_chatterbox_pretty

### DIFF
--- a/pylabrobot/liquid_handling/backends/chatterbox_backend.py
+++ b/pylabrobot/liquid_handling/backends/chatterbox_backend.py
@@ -53,11 +53,49 @@ class ChatterBoxBackend(LiquidHandlerBackend):
   async def drop_tips(self, ops: List[Drop], use_channels: List[int], **backend_kwargs):
     print(f"Dropping tips {ops}.")
 
-  async def aspirate(self, ops: List[Aspiration], use_channels: List[int], **backend_kwargs):
-    print(f"Aspirating {ops}.")
+  async def aspirate(self, ops: List[Aspiration], use_channels: List[int], hamilton_liquid_classes = None, **backend_kwargs):
+    print(backend_kwargs)
+    print("Aspirating:")
+    header = f"{'pip#':<5} {'vol(ul)':<8} {'resource':<20} {'offset':<16} {'flowrate':<10} {'blowout':<10} {'liq_height':<10}  " #{'liquids':<20}" #TODO: add liquids
+    for key in backend_kwargs.keys():
+      header += f"{key:<15} "[-16:]
+    print(header)
+    for o, p in zip(ops, use_channels):
+      flow_rate = o.flow_rate if o.flow_rate is not None else (hamilton_liquid_classes[p].aspiration_flow_rate if hamilton_liquid_classes is not None else 'none')
+      row = (
+        f"  p{p}: {o.volume:<8} "
+        f"{o.resource.name[-20:]:<20} "
+        f"{f'{round(o.offset.x, 1)},{round(o.offset.y, 1)},{round(o.offset.z, 1)}':<16} "
+        f"{flow_rate:<10} "
+        f"{o.blow_out_air_volume if o.blow_out_air_volume is not None else 'none':<10} "
+        f"{o.liquid_height if o.liquid_height is not None else 'none':<10} "
+        # f"{o.liquids if o.liquids is not None else 'none'}"
+      )
+      for key, value in backend_kwargs.items():
+        row += f" {value:<15}"
+      print(row)
 
-  async def dispense(self, ops: List[Dispense], use_channels: List[int], **backend_kwargs):
-    print(f"Dispensing {ops}.")
+
+  async def dispense(self, ops: List[Dispense], use_channels: List[int], hamilton_liquid_classes = None, **backend_kwargs):
+    print("Dispensing:")
+    header = f"{'pip#':<5} {'vol(ul)':<8} {'resource':<20} {'offset':<16} {'flowrate':<10} {'blowout':<10} {'liq_height':<10}  " #{'liquids':<20}" #TODO: add liquids
+    for key in backend_kwargs.keys():
+      header += f"{key:<15} "[-16:]
+    print(header)
+    for o, p in zip(ops, use_channels):
+      flow_rate = o.flow_rate if o.flow_rate is not None else (hamilton_liquid_classes[p].dispense_flow_rate if hamilton_liquid_classes is not None else 'none')
+      row = (
+        f"  p{p}: {o.volume:<8} "
+        f"{o.resource.name[-20:]:<20} "
+        f"{f'{round(o.offset.x, 1)},{round(o.offset.y, 1)},{round(o.offset.z, 1)}':<16} "
+        f"{flow_rate:<10} "
+        f"{o.blow_out_air_volume if o.blow_out_air_volume is not None else 'none':<10} "
+        f"{o.liquid_height if o.liquid_height is not None else 'none':<10} "
+        # f"{o.liquids if o.liquids is not None else 'none'}"
+      )
+      for key, value in backend_kwargs.items():
+        row += f" {value:<15}"
+      print(row)
 
   async def pick_up_tips96(self, pickup: PickupTipRack, **backend_kwargs):
     print(f"Picking up tips from {pickup.resource.name}.")

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -715,7 +715,7 @@ class LiquidHandler(Machine):
         raise ValueError("Aspirating from a well with a lid is not supported.")
 
     self._make_sure_channels_exist(use_channels)
-    assert len(resources) == len(vols) == len(offsets) == len(flow_rates) == len(liquid_height)
+    assert len(vols) == len(offsets) == len(flow_rates) == len(liquid_height)
 
     # If the user specified a single resource, but multiple channels to use, we will assume they
     # want to space the channels evenly across the resource. Note that offsets are relative to the
@@ -761,8 +761,8 @@ class LiquidHandler(Machine):
 
     extras = self._check_args(self.backend.aspirate, backend_kwargs,
       default={"ops", "use_channels"})
-    for extra in extras:
-      del backend_kwargs[extra]
+    # for extra in extras:
+    #   del backend_kwargs[extra]
 
     # actually aspirate the liquid
     error: Optional[Exception] = None
@@ -901,7 +901,6 @@ class LiquidHandler(Machine):
     if isinstance(blow_out_air_volume, numbers.Number):
       raise NotImplementedError("Single blow out air volume is deprecated, use a list of volumes.")
 
-    self._blow_out_air_volume = None
     tips = [self.head[channel].get_tip() for channel in use_channels]
 
     # Check the blow out air volume with what was aspirated
@@ -947,8 +946,8 @@ class LiquidHandler(Machine):
     # fix the backend kwargs
     extras = self._check_args(self.backend.dispense, backend_kwargs,
       default={"ops", "use_channels"})
-    for extra in extras:
-      del backend_kwargs[extra]
+    # for extra in extras:
+    #   del backend_kwargs[extra]
 
     # actually dispense the liquid
     error: Optional[Exception] = None


### PR DESCRIPTION
very often, I will develop using the chatterbox backend, then switch to the STAR backend for physical testing

right now, the chatterbox backend strips hamilton-specific kwargs from Aspiration ops, which stops us from being able to print them using the chatterbox backend

I made the chatterbox more hamiltony (still machine-agnistic) so I could simulate my protocol in a more readable way, like this:
```
Aspirating:
pip#  vol(ul)  resource             offset           flowrate   blowout    liq_height  e_transport_air swap_speed      
  p0: 1000.0   MACS_res_well_0_0    0,0,10.0         250.0      40.0       none        30              50             
  p1: 1000.0   MACS_res_well_0_1    0,0,10.0         250.0      40.0       none        30              50             
  p2: 1000.0   MACS_res_well_0_2    0,0,10.0         250.0      40.0       none        30              50             
  p3: 1000.0   MACS_res_well_0_3    0,0,10.0         250.0      40.0       none        30              50             
  p4: 1000.0   MACS_res_well_0_4    0,0,10.0         250.0      40.0       none        30              50             
  p5: 1000.0   MACS_res_well_0_5    0,0,10.0         250.0      40.0       none        30              50             
  p6: 1000.0   MACS_res_well_0_6    0,0,10.0         250.0      40.0       none        30              50             
  p7: 1000.0   MACS_res_well_0_7    0,0,10.0         250.0      40.0       none        30              50             
{'pull_out_distance_transport_air': 30, 'swap_speed': 50}
Dispensing:
pip#  vol(ul)  resource             offset           flowrate   blowout    liq_height  e_transport_air swap_speed      
  p0: 1000.0   reag_plt_well_3_0    0,0,0            400.0      40.0       none        30              50             
  p1: 1000.0   reag_plt_well_3_1    0,0,0            400.0      40.0       none        30              50             
  p2: 1000.0   reag_plt_well_3_2    0,0,0            400.0      40.0       none        30              50             
  p3: 1000.0   reag_plt_well_3_3    0,0,0            400.0      40.0       none        30              50             
  p4: 1000.0   reag_plt_well_3_4    0,0,0            400.0      40.0       none        30              50             
  p5: 1000.0   reag_plt_well_3_5    0,0,0            400.0      40.0       none        30              50             
  p6: 1000.0   reag_plt_well_3_6    0,0,0            400.0      40.0       none        30              50             
  p7: 1000.0   reag_plt_well_3_7    0,0,0            400.0      40.0       none        30              50             

```

Is there a better way to get this type of hot-swappability & easy readability?