### PR TITLE
[resource] fix to deep copy on rotation

### DIFF
--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import itertools
 import json
 import logging
@@ -402,7 +403,7 @@ class Resource:
   def rotated(self, x: float = 0, y: float = 0, z: float = 0) -> Self:
     """ Return a copy of this resource rotated by the given number of degrees. """
 
-    new_resource = self.copy()
+    new_resource = copy.deepcopy(self)
     new_resource.rotate(x=x, y=y, z=z)
     return new_resource
 


### PR DESCRIPTION
without this, the functions, e.g. `_compute_height_from_volume` aren't preserved.

Perhaps there is a different way you want to approach this?