### PR TITLE
Serialize functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `create_ordered_items_2d`, similar to `create_equally_spaced_2d`, but a dictionary keyed by the item's position identifier in the grid (https://github.com/PyLabRobot/pylabrobot/pull/201/)
 - `CellTreat_96_DWP_350ul_Ub` and `CellTreat_6_DWP_16300ul_Fb` (https://github.com/PyLabRobot/pylabrobot/pull/200)
 - `Opentrons_96_adapter_Vb` to integrate Opentrons Aluminum 96-well plate adapter (part of the "Aluminum Block Set") and `README.md` for Opentrons resource folder
+- Serialization of functions. Serialize `compute_volume_from_height` and `compute_height_from_volume` functions in `Container`s (https://github.com/PyLabRobot/pylabrobot/pull/215)
 
 ### Deprecated
 

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1892,7 +1892,7 @@ class LiquidHandler(Machine):
     return self._callbacks
 
   @classmethod
-  def deserialize(cls, data: dict) -> LiquidHandler:
+  def deserialize(cls, data: dict, allow_marshal: bool = False) -> LiquidHandler:
     """ Deserialize a liquid handler from a dictionary.
 
     Args:
@@ -1900,7 +1900,7 @@ class LiquidHandler(Machine):
     """
 
     deck_data = data["children"][0]
-    deck = Deck.deserialize(data=deck_data)
+    deck = Deck.deserialize(data=deck_data, allow_marshal=allow_marshal)
     backend = LiquidHandlerBackend.deserialize(data=data["backend"])
     return cls(deck=deck, backend=backend)
 

--- a/pylabrobot/machines/machine.py
+++ b/pylabrobot/machines/machine.py
@@ -52,12 +52,12 @@ class Machine(Resource, metaclass=ABCMeta):
     return {**super().serialize(), "backend": self.backend.serialize()}
 
   @classmethod
-  def deserialize(cls, data: dict):
+  def deserialize(cls, data: dict, allow_marshal: bool = False):
     data_copy = data.copy() # copy data because we will be modifying it
     backend_data = data_copy.pop("backend")
     backend = MachineBackend.deserialize(backend_data)
     data_copy["backend"] = backend
-    return super().deserialize(data_copy)
+    return super().deserialize(data_copy, allow_marshal=allow_marshal)
 
   async def setup(self, **backend_kwargs):
     await self.backend.setup(**backend_kwargs)

--- a/pylabrobot/machines/machine_tests.py
+++ b/pylabrobot/machines/machine_tests.py
@@ -54,4 +54,3 @@ class TestMachine(unittest.TestCase):
                          size_z=10,
                          backend=self.MockBackend("mock_param"))
     self.assertEqual(Machine.deserialize(m.serialize()), m)
-

--- a/pylabrobot/pumps/pump.py
+++ b/pylabrobot/pumps/pump.py
@@ -39,13 +39,13 @@ class Pump(Machine):
     return {**super().serialize(), "calibration": self.calibration.serialize()}
 
   @classmethod
-  def deserialize(cls, data: dict):
+  def deserialize(cls, data: dict, allow_marshal: bool = False):
     data_copy = data.copy()
     calibration_data = data_copy.pop("calibration", None)
     if calibration_data is not None:
       calibration = PumpCalibration.deserialize(calibration_data)
       data_copy["calibration"] = calibration
-    return super().deserialize(data_copy)
+    return super().deserialize(data_copy, allow_marshal=allow_marshal)
 
   async def run_revolutions(self, num_revolutions: float):
     """ Run a given number of revolutions. This method will return after the command has been sent,

--- a/pylabrobot/pumps/pumparray.py
+++ b/pylabrobot/pumps/pumparray.py
@@ -57,13 +57,13 @@ class PumpArray(Machine):
     return {**super().serialize(), "calibration": self.calibration.serialize()}
 
   @classmethod
-  def deserialize(cls, data: dict):
+  def deserialize(cls, data: dict, allow_marshal: bool = False):
     data_copy = data.copy()
     calibration_data = data_copy.pop("calibration", None)
     if calibration_data is not None:
       calibration = PumpCalibration.deserialize(calibration_data)
       data_copy["calibration"] = calibration
-    return super().deserialize(data_copy)
+    return super().deserialize(data_copy, allow_marshal=allow_marshal)
 
   async def run_revolutions(self, num_revolutions: Union[float, List[float]],
                             use_channels: Union[int, List[int]]):

--- a/pylabrobot/resources/container.py
+++ b/pylabrobot/resources/container.py
@@ -1,3 +1,4 @@
+import marshal
 from typing import Any, Callable, Dict, Optional
 
 from .resource import Resource
@@ -49,6 +50,10 @@ class Container(Resource):
       **super().serialize(),
       "max_volume": self.max_volume,
       "material_z_thickness": self._material_z_thickness,
+      "compute_volume_from_height": marshal.dumps(self._compute_volume_from_height.__code__)
+        if self._compute_volume_from_height is not None else None,
+      "compute_height_from_volume": marshal.dumps(self._compute_height_from_volume.__code__)
+        if self._compute_height_from_volume is not None else None,
     }
 
   def serialize_state(self) -> Dict[str, Any]:

--- a/pylabrobot/resources/container.py
+++ b/pylabrobot/resources/container.py
@@ -1,8 +1,9 @@
-import marshal
 from typing import Any, Callable, Dict, Optional
 
 from .resource import Resource
 from .volume_tracker import VolumeTracker
+
+from pylabrobot.serializer import serialize
 
 
 class Container(Resource):
@@ -50,10 +51,8 @@ class Container(Resource):
       **super().serialize(),
       "max_volume": self.max_volume,
       "material_z_thickness": self._material_z_thickness,
-      "compute_volume_from_height": marshal.dumps(self._compute_volume_from_height.__code__)
-        if self._compute_volume_from_height is not None else None,
-      "compute_height_from_volume": marshal.dumps(self._compute_height_from_volume.__code__)
-        if self._compute_height_from_volume is not None else None,
+      "compute_volume_from_height": serialize(self._compute_volume_from_height),
+      "compute_height_from_volume": serialize(self._compute_height_from_volume),
     }
 
   def serialize_state(self) -> Dict[str, Any]:

--- a/pylabrobot/resources/container_tests.py
+++ b/pylabrobot/resources/container_tests.py
@@ -1,0 +1,47 @@
+# pylint: disable=missing-class-docstring
+
+import unittest
+
+from .container import Container
+from pylabrobot.serializer import serialize
+
+
+class TestContainer(unittest.TestCase):
+  def test_serialize(self):
+    def compute_volume_from_height(height):
+      return height
+    def compute_height_from_volume(volume):
+      return volume
+    c = Container(
+      name="container",
+      size_x=10,
+      size_y=10,
+      size_z=10,
+      material_z_thickness=1,
+      max_volume=1000,
+      compute_height_from_volume=compute_height_from_volume,
+      compute_volume_from_height=compute_volume_from_height,
+    )
+
+    self.assertEqual(c.serialize(), {
+      "name": "container",
+      "size_x": 10,
+      "size_y": 10,
+      "size_z": 10,
+      "material_z_thickness": 1,
+      "category": None,
+      "model": None,
+      "max_volume": 1000,
+      "compute_volume_from_height": serialize(compute_volume_from_height),
+      "compute_height_from_volume": serialize(compute_height_from_volume),
+      "parent_name": None,
+      "rotation": {"type": "Rotation", "x": 0, "y": 0, "z": 0},
+      "type": "Container",
+      "children": [],
+      "location": None,
+    })
+
+    d = Container.deserialize(c.serialize(), allow_marshal=True)
+    self.assertEqual(c, d)
+    self.assertEqual(d.compute_height_from_volume(10), 10)
+    self.assertEqual(d.compute_volume_from_height(10), 10)

--- a/pylabrobot/resources/petri_dish.py
+++ b/pylabrobot/resources/petri_dish.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import Callable, Optional, cast
 
 from .container import Container
 from .coordinate import Coordinate
@@ -16,7 +16,9 @@ class PetriDish(Container):
     material_z_thickness: Optional[float] = None,
     category: str = "petri_dish",
     model: Optional[str] = None,
-    max_volume: Optional[float] = None
+    max_volume: Optional[float] = None,
+    compute_volume_from_height: Optional[Callable[[float], float]] = None,
+    compute_height_from_volume: Optional[Callable[[float], float]] = None,
   ):
     super().__init__(
       name=name,
@@ -26,7 +28,9 @@ class PetriDish(Container):
       material_z_thickness=material_z_thickness,
       category=category,
       model=model,
-      max_volume=max_volume
+      max_volume=max_volume,
+      compute_volume_from_height=compute_volume_from_height,
+      compute_height_from_volume=compute_height_from_volume,
     )
     self.diameter = diameter
     self.height = height

--- a/pylabrobot/resources/petri_dish_tests.py
+++ b/pylabrobot/resources/petri_dish_tests.py
@@ -62,7 +62,6 @@ class TestPetriDish(unittest.TestCase):
     petri_dish_holder = PetriDishHolder("petri_dish_holder")
     petri_dish_holder.assign_child_resource(PetriDish("petri_dish", 90.0, 15.0),
                                             location=Coordinate.zero())
-    print(petri_dish_holder.serialize())
     petri_dish_holder = PetriDishHolder.deserialize(petri_dish_holder.serialize())
 
     self.assertEqual(petri_dish_holder.name, "petri_dish_holder")

--- a/pylabrobot/resources/petri_dish_tests.py
+++ b/pylabrobot/resources/petri_dish_tests.py
@@ -16,6 +16,8 @@ class TestPetriDish(unittest.TestCase):
       "diameter": 90.0,
       "height": 15.0,
       "material_z_thickness": None,
+      "compute_volume_from_height": None,
+      "compute_height_from_volume": None,
       "parent_name": None,
       "type": "PetriDish",
       "children": [],
@@ -60,6 +62,7 @@ class TestPetriDish(unittest.TestCase):
     petri_dish_holder = PetriDishHolder("petri_dish_holder")
     petri_dish_holder.assign_child_resource(PetriDish("petri_dish", 90.0, 15.0),
                                             location=Coordinate.zero())
+    print(petri_dish_holder.serialize())
     petri_dish_holder = PetriDishHolder.deserialize(petri_dish_holder.serialize())
 
     self.assertEqual(petri_dish_holder.name, "petri_dish_holder")

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -538,6 +538,7 @@ class Resource:
     children_data = data_copy.pop("children")
     rotation = data_copy.pop("rotation")
     resource = subclass(**deserialize(data_copy, allow_marshal=allow_marshal))
+    # resource = subclass(**data_copy)
     resource.rotation = Rotation.deserialize(rotation) # not pretty, should be done in init.
 
     for child_data in children_data:

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -395,7 +395,7 @@ class Resource:
     self.rotation.z = (self.rotation.z + z) % 360
 
   def copy(self) -> Self:
-    resource_copy = self.__class__.deserialize(self.serialize())
+    resource_copy = self.__class__.deserialize(self.serialize(), allow_marshal=True)
     resource_copy.load_all_state(self.serialize_all_state())
     return resource_copy
 
@@ -510,8 +510,12 @@ class Resource:
       json.dump(serialized, f, indent=indent)
 
   @classmethod
-  def deserialize(cls, data: dict) -> Self:
+  def deserialize(cls, data: dict, allow_marshal: bool = False) -> Self:
     """ Deserialize a resource from a dictionary.
+
+    Args:
+      allow_marshal: If `True`, the `marshal` module will be used to deserialize functions. This
+        can be a security risk if the data is not trusted. Defaults to `False`.
 
     Examples:
       Loading a resource from a json file:
@@ -533,14 +537,14 @@ class Resource:
       del data_copy[key]
     children_data = data_copy.pop("children")
     rotation = data_copy.pop("rotation")
-    resource = subclass(**data_copy)
-    resource.rotation = Rotation.deserialize(rotation)
+    resource = subclass(**deserialize(data_copy, allow_marshal=allow_marshal))
+    resource.rotation = Rotation.deserialize(rotation) # not pretty, should be done in init.
 
     for child_data in children_data:
       child_cls = find_subclass(child_data["type"], cls=Resource)
       if child_cls is None:
         raise ValueError(f"Could not find subclass with name {child_data['type']}")
-      child = child_cls.deserialize(child_data)
+      child = child_cls.deserialize(child_data, allow_marshal=allow_marshal)
       location_data = child_data.get("location", None)
       if location_data is not None:
         location = cast(Coordinate, deserialize(location_data))

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -538,7 +538,6 @@ class Resource:
     children_data = data_copy.pop("children")
     rotation = data_copy.pop("rotation")
     resource = subclass(**deserialize(data_copy, allow_marshal=allow_marshal))
-    # resource = subclass(**data_copy)
     resource.rotation = Rotation.deserialize(rotation) # not pretty, should be done in init.
 
     for child_data in children_data:

--- a/pylabrobot/resources/tip_rack.py
+++ b/pylabrobot/resources/tip_rack.py
@@ -62,11 +62,11 @@ class TipSpot(Resource):
     }
 
   @classmethod
-  def deserialize(cls, data: dict) -> TipSpot:
+  def deserialize(cls, data: dict, allow_marshal: bool = False) -> TipSpot:
     """ Deserialize a tip spot. """
     tip_data = data["prototype_tip"]
     def make_tip() -> Tip:
-      return cast(Tip, deserialize(tip_data))
+      return cast(Tip, deserialize(tip_data, allow_marshal=allow_marshal))
 
     return cls(
       name=data["name"],

--- a/pylabrobot/resources/well_tests.py
+++ b/pylabrobot/resources/well_tests.py
@@ -29,6 +29,8 @@ class TestWell(unittest.TestCase):
         "type": "Rotation",
         "x": 0, "y": 0, "z": 0
       },
+      "compute_volume_from_height": None,
+      "compute_height_from_volume": None,
     })
 
     self.assertEqual(Well.deserialize(well.serialize()), well)

--- a/pylabrobot/serializer.py
+++ b/pylabrobot/serializer.py
@@ -38,7 +38,7 @@ def serialize(obj: Any) -> JSON:
   if isinstance(obj, enum.Enum):
     return obj.name
   if inspect.isfunction(obj):
-    return {"type": "function", "code": marshal.dumps(obj.__code__)}
+    return {"type": "function", "code": marshal.dumps(obj.__code__).hex()}
   if isinstance(obj, object):
     if hasattr(obj, "serialize"): # if the object has a custom serialize method
       return cast(JSON, obj.serialize())
@@ -65,7 +65,8 @@ def deserialize(data: JSON, allow_marshal: bool = False) -> Any:
       data = data.copy()
       klass_type = cast(str, data.pop("type"))
       if klass_type == "function" and allow_marshal:
-        code = marshal.loads(data["code"])
+        assert isinstance(data["code"], str)
+        code = marshal.loads(bytes.fromhex(data["code"]))
         return types.FunctionType(code, globals())
       klass = get_plr_class_from_string(klass_type)
       params = {k: deserialize(v, allow_marshal=allow_marshal) for k, v in data.items()}

--- a/pylabrobot/serializer.py
+++ b/pylabrobot/serializer.py
@@ -4,6 +4,7 @@ import enum
 import inspect
 import marshal
 import sys
+import types
 from typing import Any, Dict, List, Union, cast
 
 if sys.version_info >= (3, 10):
@@ -36,6 +37,8 @@ def serialize(obj: Any) -> JSON:
     return {k: serialize(v) for k, v in obj.items()}
   if isinstance(obj, enum.Enum):
     return obj.name
+  if inspect.isfunction(obj):
+    return {"type": "function", "code": marshal.dumps(obj.__code__)}
   if isinstance(obj, object):
     if hasattr(obj, "serialize"): # if the object has a custom serialize method
       return cast(JSON, obj.serialize())
@@ -62,9 +65,12 @@ def deserialize(data: JSON, allow_marshal: bool = False) -> Any:
       data = data.copy()
       klass_type = cast(str, data.pop("type"))
       if klass_type == "function" and allow_marshal:
-        return marshal.loads(data["code"])
+        code = marshal.loads(data["code"])
+        return types.FunctionType(code, globals())
       klass = get_plr_class_from_string(klass_type)
       params = {k: deserialize(v, allow_marshal=allow_marshal) for k, v in data.items()}
       return klass(**params)
     return {k: deserialize(v, allow_marshal=allow_marshal) for k, v in data.items()}
+  if isinstance(data, object):
+    return data
   raise TypeError(f"Cannot deserialize {data} of type {type(data)}")


### PR DESCRIPTION
Alternative to https://github.com/PyLabRobot/pylabrobot/pull/213

Currently used by compute_volume_from_height and compute_height_from_volume. Introduces `allow_marshal` flag on `deserialize` because this is unsafe for untrusted data.