### PR TITLE
[Resource] Add slim 300 uL tips

### DIFF
--- a/pylabrobot/resources/ml_star/tip_creators.py
+++ b/pylabrobot/resources/ml_star/tip_creators.py
@@ -119,7 +119,7 @@ def standard_volume_tip_no_filter() -> HamiltonTip:
   )
 
 def standard_volume_tip_with_filter() -> HamiltonTip:
-  """ Low volume tip without a filter (`tt01` in venus) """
+  """ Standard volume tip without a filter (`tt01` in venus) """
   return HamiltonTip(
     has_filter=True,
     total_tip_length=59.9, # 60 in the ctr file, but 59.9 in the log file (519+80)/10
@@ -128,8 +128,18 @@ def standard_volume_tip_with_filter() -> HamiltonTip:
     pickup_method=TipPickupMethod.OUT_OF_RACK
   )
 
+def slim_standard_volume_tip_with_filter() -> HamiltonTip:
+  """ Slim standard volume tip without a filter """
+  return HamiltonTip(
+    has_filter=True,
+    total_tip_length=94.8, # 60 in the ctr file, but 59.9 in the log file (519+80)/10
+    maximal_volume=360,
+    tip_size=TipSize.HIGH_VOLUME,
+    pickup_method=TipPickupMethod.OUT_OF_RACK
+  )
+
 def low_volume_tip_no_filter() -> HamiltonTip:
-  """ Standard volume tip with a filter (`tt02` in venus) """
+  """ Low volume tip with a filter (`tt02` in venus) """
   return HamiltonTip(
     has_filter=False,
     total_tip_length=29.9,

--- a/pylabrobot/resources/ml_star/tip_creators.py
+++ b/pylabrobot/resources/ml_star/tip_creators.py
@@ -132,7 +132,7 @@ def slim_standard_volume_tip_with_filter() -> HamiltonTip:
   """ Slim standard volume tip without a filter """
   return HamiltonTip(
     has_filter=True,
-    total_tip_length=94.8, # 60 in the ctr file, but 59.9 in the log file (519+80)/10
+    total_tip_length=94.8,
     maximal_volume=360,
     tip_size=TipSize.HIGH_VOLUME,
     pickup_method=TipPickupMethod.OUT_OF_RACK

--- a/pylabrobot/resources/ml_star/tip_racks.py
+++ b/pylabrobot/resources/ml_star/tip_racks.py
@@ -19,8 +19,8 @@ from .tip_creators import (
 )
 
 
-#: Tip Rack 24x 4ml Tip with Filter landscape oriented
 def FourmlTF_L(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack 24x 4ml Tip with Filter landscape oriented """
   return TipRack(
     name=name,
     size_x=122.4,
@@ -43,13 +43,13 @@ def FourmlTF_L(name: str, with_tips: bool = True) -> TipRack:
   )
 
 
-#: Tip Rack 24x 4ml Tip with Filter portrait oriented
 def FourmlTF_P(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack 24x 4ml Tip with Filter portrait oriented """
   return FourmlTF_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
-#: Tip Rack 24x 5ml Tip landscape oriented
 def FivemlT_L(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack 24x 5ml Tip landscape oriented """
   return TipRack(
     name=name,
     size_x=122.4,
@@ -72,13 +72,13 @@ def FivemlT_L(name: str, with_tips: bool = True) -> TipRack:
   )
 
 
-#: Tip Rack 24x 5ml Tip portrait oriented
 def FivemlT_P(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack 24x 5ml Tip portrait oriented """
   return FivemlT_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
-#: Rack with 96 1000ul High Volume Tip with filter
 def HTF_L(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 1000ul High Volume Tip with filter """
   return TipRack(
     name=name,
     size_x=122.4,
@@ -101,13 +101,13 @@ def HTF_L(name: str, with_tips: bool = True) -> TipRack:
   )
 
 
-#: Rack with 96 1000ul High Volume Tip with filter (portrait)
 def HTF_P(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 1000ul High Volume Tip with filter (portrait) """
   return HTF_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
-#: Rack with 96 1000ul High Volume Tip
 def HT_L(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 1000ul High Volume Tip """
   return TipRack(
     name=name,
     size_x=122.4,
@@ -130,13 +130,13 @@ def HT_L(name: str, with_tips: bool = True) -> TipRack:
   )
 
 
-#: Rack with 96 1000ul High Volume Tip (portrait)
 def HT_P(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 1000ul High Volume Tip (portrait) """
   return HT_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
-#: Rack with 96 10ul Low Volume Tip with filter
 def LTF_L(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 10ul Low Volume Tip with filter """
   return TipRack(
     name=name,
     size_x=122.4,
@@ -159,13 +159,13 @@ def LTF_L(name: str, with_tips: bool = True) -> TipRack:
   )
 
 
-#: Rack with 96 10ul Low Volume Tip with filter (portrait)
 def LTF_P(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 10ul Low Volume Tip with filter (portrait) """
   return LTF_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
-#: Rack with 96 10ul Low Volume Tip
 def LT_L(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 10ul Low Volume Tip """
   return TipRack(
     name=name,
     size_x=122.4,
@@ -188,13 +188,13 @@ def LT_L(name: str, with_tips: bool = True) -> TipRack:
   )
 
 
-#: Rack with 96 10ul Low Volume Tip (portrait)
 def LT_P(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 10ul Low Volume Tip (portrait) """
   return LT_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
-#: Rack with 96 300ul Standard Volume Tip with filter
 def STF_L(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 300ul Standard Volume Tip with filter """
   return TipRack(
     name=name,
     size_x=122.4,
@@ -217,13 +217,13 @@ def STF_L(name: str, with_tips: bool = True) -> TipRack:
   )
 
 
-#: Rack with 96 300ul Standard Volume Tip with filter (portrait)
 def STF_P(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 300ul Standard Volume Tip with filter (portrait) """
   return STF_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
-#: Rack with 96 300ul Slim Standard Volume Tip with filter
 def STF_Slim_L(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 300ul Slim Standard Volume Tip with filter """
   return TipRack(
     name=name,
     size_x=122.4,
@@ -245,13 +245,13 @@ def STF_Slim_L(name: str, with_tips: bool = True) -> TipRack:
     with_tips=with_tips
   )
 
-#: Rack with 96 300ul Standard Volume Tip with filter (portrait)
 def STF_Slim_P(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 300ul Slim Standard Volume Tip with filter (portrait) """
   return STF_Slim_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
-#: Rack with 96 300ul Standard Volume Tip
 def ST_L(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 300ul Standard Volume Tip """
   return TipRack(
     name=name,
     size_x=122.4,
@@ -274,13 +274,13 @@ def ST_L(name: str, with_tips: bool = True) -> TipRack:
   )
 
 
-#: Rack with 96 300ul Standard Volume Tip (portrait)
 def ST_P(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 300ul Standard Volume Tip (portrait) """
   return ST_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
-#: Rack with 96 50ul Tip with filter
 def TIP_50ul_w_filter_L(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 50ul Tip with filter """
   return TipRack(
     name=name,
     size_x=122.4,
@@ -303,13 +303,13 @@ def TIP_50ul_w_filter_L(name: str, with_tips: bool = True) -> TipRack:
   )
 
 
-#: Tip Rack 96 50ul Tip with filter portrait oriented
 def TIP_50ul_w_filter_P(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 50ul Tip with filter (portrait) """
   return TIP_50ul_w_filter_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
-#: Rack with 96 50ul Tip
 def TIP_50ul_L(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 50ul Tip """
   return TipRack(
     name=name,
     size_x=122.4,
@@ -332,6 +332,6 @@ def TIP_50ul_L(name: str, with_tips: bool = True) -> TipRack:
   )
 
 
-#: Tip Rack 96 50ul Tip portrait oriented
 def TIP_50ul_P(name: str, with_tips: bool = True) -> TipRack:
+  """ Tip Rack with 96 50ul Tip (portrait) """
   return TIP_50ul_L(name=name, with_tips=with_tips).rotated(z=90)

--- a/pylabrobot/resources/ml_star/tip_racks.py
+++ b/pylabrobot/resources/ml_star/tip_racks.py
@@ -7,6 +7,7 @@ from pylabrobot.resources.tip_rack import TipRack, TipSpot
 from .tip_creators import (
   low_volume_tip_no_filter,
   low_volume_tip_with_filter,
+  slim_standard_volume_tip_with_filter,
   standard_volume_tip_no_filter,
   standard_volume_tip_with_filter,
   high_volume_tip_no_filter,
@@ -219,6 +220,34 @@ def STF_L(name: str, with_tips: bool = True) -> TipRack:
 #: Rack with 96 300ul Standard Volume Tip with filter (portrait)
 def STF_P(name: str, with_tips: bool = True) -> TipRack:
   return STF_L(name=name, with_tips=with_tips).rotated(z=90)
+
+
+#: Rack with 96 300ul Slim Standard Volume Tip with filter
+def STF_Slim_L(name: str, with_tips: bool = True) -> TipRack:
+  return TipRack(
+    name=name,
+    size_x=122.4,
+    size_y=82.6,
+    size_z=20.0,
+    model=STF_Slim_L.__name__,
+    ordered_items=create_ordered_items_2d(TipSpot,
+      num_items_x=12,
+      num_items_y=8,
+      dx=7.2,
+      dy=5.3,
+      dz=-83.5,
+      item_dx=9.0,
+      item_dy=9.0,
+      size_x=9.0,
+      size_y=9.0,
+      make_tip=slim_standard_volume_tip_with_filter,
+    ),
+    with_tips=with_tips
+  )
+
+#: Rack with 96 300ul Standard Volume Tip with filter (portrait)
+def STF_Slim_P(name: str, with_tips: bool = True) -> TipRack:
+  return STF_Slim_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
 #: Rack with 96 300ul Standard Volume Tip


### PR DESCRIPTION
Hamilton sells [300 uL CORE-II tips with a slim diameter](https://www.hamiltoncompany.com/automated-liquid-handling/disposable-tips/300-%C2%B5l-slim-conductive-filter-tips). `STF_L` failed to pick these tips up, I assume because of the collar type. `HTF_L` worked but does not handle maximum volume properly. I added a definition for the slim 300 uL tips: `slim_standard_volume_tip_with_filter`. Let us know if there's a better way to do this.  
  
I also transferred the comments to the rack creator docstrings, feel free to leave that commit out.