### PR TITLE
- added setup method that calls LiquidHandlerBackend and USBBackend

### DIFF
--- a/pylabrobot/liquid_handling/backends/tecan/EVO.py
+++ b/pylabrobot/liquid_handling/backends/tecan/EVO.py
@@ -146,6 +146,10 @@ class TecanLiquidHandler(LiquidHandlerBackend, USBBackend, metaclass=ABCMeta):
 
     resp = self.read(timeout=read_timeout)
     return self.parse_response(resp)
+  
+  async def setup(self):
+    await LiquidHandlerBackend.setup(self)
+    await USBBackend.setup(self)
 
 
 class EVO(TecanLiquidHandler):


### PR DESCRIPTION
I think that the changes to the Hamilton backend caused the setup cascade to break for the EVO backend.  