### PR TITLE
allow STAR firmware planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Serialize code cells and closures (https://github.com/PyLabRobot/pylabrobot/pull/220)
 - `Container.get_anchor()` now supports `"cavity_bottom"` as an argument for `z` (https://github.com/PyLabRobot/pylabrobot/pull/205/)
 - `pylabrobot.resources.utils.query` for basic querying (https://github.com/PyLabRobot/pylabrobot/commit/4a07f6a32a9a33d0370eb9c29015567c98aea002)
+- `HamiltonLiquidHandler.allow_firmware_planning` to allow STAR/Vantage to plan complex liquid handling operations automatically (may break hardware agnosticity unexpectedly) (https://github.com/PyLabRobot/pylabrobot/pull/224)
 
 ### Deprecated
 


### PR DESCRIPTION
As @BioCam and I discussed today: STAR is actually capable of planning aspirations/dispenses to/from a single resource when passed times in a single firmware command. For example, aspirate from well A1 with channel 0 and 1, and B1 with Channel 2 and 3. However, when there is any combination of resources causing a collision when y's are not the same (i.e. the abs diff between any two elements is <9mm), the channels might still crash into each other.

Previously, getting the automated firmware planning behavior was not possible through plr:main without modifications. Here, I implement the discussed solution: a flag to allow firmware planning. This will allow you to get the STAR to plan certain movements, but will still raise an error when it would cause a hardware collision on STAR.

The reason I am opposed to making this the default behavior is that that would make it very easy to write protocols that are unexpectedly not hardware agnostic: while passing wells A1,A1,B1,B2 might work fine on STAR, we can't guarantee that EVO or future robots will support the same behavior. With a flag on the backend, the user at least acknowledges that they know their protocol might not work on other robots. Hardware agnosticism is something we need to encourage and support to improve reproducibility in science.