### PR TITLE
Create NestedTipRack Class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `pylabrobot.resources.utils.query` for basic querying (https://github.com/PyLabRobot/pylabrobot/commit/4a07f6a32a9a33d0370eb9c29015567c98aea002)
 - `HamiltonLiquidHandler.allow_firmware_planning` to allow STAR/Vantage to plan complex liquid handling operations automatically (may break hardware agnosticity unexpectedly) (https://github.com/PyLabRobot/pylabrobot/pull/224)
 - `size_z` and `nesting_z_height` for `Cor_96_wellplate_360ul_Fb_Lid` (https://github.com/PyLabRobot/pylabrobot/pull/226)
+- `NestedTipRack` (https://github.com/PyLabRobot/pylabrobot/pull/228)
 
 ### Deprecated
 

--- a/pylabrobot/resources/ml_star/tip_racks.py
+++ b/pylabrobot/resources/ml_star/tip_racks.py
@@ -3,7 +3,7 @@
 # pylint: skip-file
 
 from pylabrobot.resources.utils import create_ordered_items_2d
-from pylabrobot.resources.tip_rack import TipRack, TipSpot
+from pylabrobot.resources.tip_rack import TipSpot, TipRack, NestedTipRack
 from .tip_creators import (
   low_volume_tip_no_filter,
   low_volume_tip_with_filter,
@@ -362,14 +362,15 @@ def TIP_50ul_P(name: str, with_tips: bool = True) -> TipRack:
   return TIP_50ul_L(name=name, with_tips=with_tips).rotated(z=90)
 
 
-def Hamilton_96_tiprack_50ul_NTR(name: str, with_tips: bool = True) -> TipRack:
+def Hamilton_96_tiprack_50ul_NTR(name: str, with_tips: bool = True) -> NestedTipRack:
   """ Nested Tip Rack with 96 50ul Tip """
-  return TipRack(
+  return NestedTipRack(
     name=name,
     size_x=127.76,
     size_y=85.48,
     size_z=56.0, # Hamilton_96_tiprack_50ul_NTR + TIP_50ul_L.fitting_depth
     model="Hamilton_96_tiprack_50ul_NTR",
+    stacking_z_height=16.0,
     ordered_items=create_ordered_items_2d(TipSpot,
       num_items_x=12,
       num_items_y=8,
@@ -386,10 +387,10 @@ def Hamilton_96_tiprack_50ul_NTR(name: str, with_tips: bool = True) -> TipRack:
     with_tips=with_tips
   )
 
-def Hamilton_96_tiprack_50ul_NTR_L(name: str, with_tips: bool = True) -> TipRack:
+def Hamilton_96_tiprack_50ul_NTR_L(name: str, with_tips: bool = True) -> NestedTipRack:
   """ Nested Tip Rack with 96 50ul Tip (landscape, i.e. default) """
   return Hamilton_96_tiprack_50ul_NTR(name=name, with_tips=with_tips)
 
-def Hamilton_96_tiprack_50ul_NTR_P(name: str, with_tips: bool = True) -> TipRack:
+def Hamilton_96_tiprack_50ul_NTR_P(name: str, with_tips: bool = True) -> NestedTipRack:
   """ Nested Tip Rack with 96 50ul Tip (portrait) """
   return Hamilton_96_tiprack_50ul_NTR(name=name, with_tips=with_tips).rotated(z=90)

--- a/pylabrobot/resources/tip_rack.py
+++ b/pylabrobot/resources/tip_rack.py
@@ -228,7 +228,7 @@ class NestedTipRack(TipRack):
     return (f"{self.__class__.__name__}(name={self.name}, size_x={self._size_x}, "
             f"size_y={self._size_y}, size_z={self._size_z}, "
             f"stacking_z_height={self.stacking_z_height}, location={self.location})")
-  
+
   def assign_child_resource(
     self,
     resource: Resource,

--- a/pylabrobot/resources/tip_rack.py
+++ b/pylabrobot/resources/tip_rack.py
@@ -185,3 +185,46 @@ class TipRack(ItemizedResource[TipSpot], metaclass=ABCMeta):
   def get_all_tips(self) -> List[Tip]:
     """ Get all tips in the tip rack. """
     return [ts.get_tip() for ts in self.get_all_items()]
+
+
+class NestedTipRack(TipRack):
+  """ A nested tip rack. """
+  def __init__(
+    self,
+    name: str,
+    size_x: float,
+    size_y: float,
+    size_z: float,
+    stacking_z_height: float,
+    ordered_items: Optional[Dict[str, TipSpot]] = None,
+    ordering: Optional[List[str]] = None,
+    items: Optional[List[List[TipSpot]]] = None,
+    num_items_x: Optional[int] = None,
+    num_items_y: Optional[int] = None,
+    category: str = "tip_rack",
+    model: Optional[str] = None,
+    with_tips: bool = True,
+  ):
+  # Call the superclass constructor
+  super().__init__(
+    name=name,
+    size_x=size_x,
+    size_y=size_y,
+    size_z=size_z,
+    ordered_items=ordered_items,
+    ordering=ordering,
+    items=items,
+    num_items_x=num_items_x,
+    num_items_y=num_items_y,
+    category=category,
+    model=model,
+    with_tips=with_tips
+  )
+
+  # Initialize the new attribute
+  self.stacking_z_height = stacking_z_height
+
+  def __repr__(self) -> str:
+    return (f"{self.__class__.__name__}(name={self.name}, size_x={self._size_x}, "
+            f"size_y={self._size_y}, size_z={self._size_z}, "
+            f"stacking_z_height={self.stacking_z_height}, location={self.location})")

--- a/pylabrobot/resources/tip_rack.py
+++ b/pylabrobot/resources/tip_rack.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABCMeta
 from typing import Any, Dict, List, Union, Optional, Sequence, cast
 
+from pylabrobot.resources.coordinate import Coordinate
 from pylabrobot.resources.tip import Tip, TipCreator
 from pylabrobot.resources.tip_tracker import TipTracker, does_tip_tracking
 from pylabrobot.serializer import deserialize
@@ -205,26 +206,38 @@ class NestedTipRack(TipRack):
     model: Optional[str] = None,
     with_tips: bool = True,
   ):
-  # Call the superclass constructor
-  super().__init__(
-    name=name,
-    size_x=size_x,
-    size_y=size_y,
-    size_z=size_z,
-    ordered_items=ordered_items,
-    ordering=ordering,
-    items=items,
-    num_items_x=num_items_x,
-    num_items_y=num_items_y,
-    category=category,
-    model=model,
-    with_tips=with_tips
-  )
+    # Call the superclass constructor
+    super().__init__(
+      name=name,
+      size_x=size_x,
+      size_y=size_y,
+      size_z=size_z,
+      ordered_items=ordered_items,
+      ordering=ordering,
+      items=items,
+      num_items_x=num_items_x,
+      num_items_y=num_items_y,
+      category=category,
+      model=model,
+      with_tips=with_tips
+    )
 
-  # Initialize the new attribute
-  self.stacking_z_height = stacking_z_height
+    self.stacking_z_height = stacking_z_height
 
   def __repr__(self) -> str:
     return (f"{self.__class__.__name__}(name={self.name}, size_x={self._size_x}, "
             f"size_y={self._size_y}, size_z={self._size_z}, "
             f"stacking_z_height={self.stacking_z_height}, location={self.location})")
+  
+  def assign_child_resource(
+    self,
+    resource: Resource,
+    location: Optional[Coordinate] = None,
+    reassign: bool = True
+  ):
+    if isinstance(resource, NestedTipRack):
+      location = location or Coordinate(0, 0, self.stacking_z_height)
+    else:
+      assert location is not None, "Location must be specified if " + \
+        "resource is not a NestedTipRack."
+    return super().assign_child_resource(resource, location=location, reassign=reassign)


### PR DESCRIPTION
 Hi everyone,

in this little PR I created a new PLR `Resource` class, the `NestedTipRack`, a direct subclass of `TipRack`.

`NestedTipRack` is almost identical to `TipRack` but distinguishes itself with the required specification of the attribute `stacking_z_height`.

<img src="https://github.com/user-attachments/assets/cc012348-1fb1-43f6-a7bc-c72d09d4176a" alt="NTR_stacking_explainer" width="500"/>

This is needed to establish a new management system for stacking of NTRs and bigger-picture tip (access) management in a subsequent PR.
For this purpose, we should discuss whether we want to establish the management capabilities inside the existing management `Resource` `ResourceStack` or in a new management `Resource` which we could call `TipRackStack`.
