### PR TITLE
fixed read_timeout for vantage

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/vantage.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/vantage.py
@@ -328,7 +328,7 @@ class Vantage(HamiltonLiquidHandler):
     device_address: Optional[int] = None,
     serial_number: Optional[str] = None,
     packet_read_timeout: int = 3,
-    read_timeout: int = 30,
+    read_timeout: int = 60,
     write_timeout: int = 30,
   ):
     """ Create a new STAR interface.


### PR DESCRIPTION
I was trying to pick up the row of pipet tips and then place. There was the timeout error so the timeout was extended from 30 to 60 seconds. 