### PR TITLE
Resource Update: PLT_CAR_L5AC_A00 pedestal_size_z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `Resource.center` now returns the center of the resource in local space, not absolute space (https://github.com/PyLabRobot/pylabrobot/pull/235)
 - Rename `ChatterBoxBackend` to `LiquidHandlerChatterboxBackend` (https://github.com/PyLabRobot/pylabrobot/pull/242)
 - Move `LiquidHandlerChatterboxBackend` from `liquid_handling.backends.chatterbox_backend` to `liquid_handling.backends.chatterbox` (https://github.com/PyLabRobot/pylabrobot/pull/242)
+- Changed `pedestal_size_z=-5` to `pedestal_size_z=-4.74` for `PLT_CAR_L5AC_A00` (https://github.com/PyLabRobot/pylabrobot/pull/255)
 
 ### Added
 

--- a/pylabrobot/resources/ml_star/plate_carriers.py
+++ b/pylabrobot/resources/ml_star/plate_carriers.py
@@ -109,7 +109,7 @@ def PLT_CAR_L5AC_A00(name: str) -> PlateCarrier:
       ],
       site_size_x=127.0,
       site_size_y=86.0,
-      pedestal_size_z=-5.0
+      pedestal_size_z=-4.74
     ),
     model="PLT_CAR_L5AC_A00"
   )


### PR DESCRIPTION
Hi everyone,

This is an update PR for resource `PLT_CAR_L5AC_A00` based on the data I gathered and showcase in this video:

<a href="https://www.youtube.com/watch?v=_uPf9hyTBog" target="_blank">
  <img src="https://github.com/user-attachments/assets/4632d4b6-1a67-4920-8eac-c1a37cd2cb62" alt="Video Title" width="450" >
</a>

Old `pedestal_size_z = -5.0` mm.

The data shows a 95% confidence interval between 4.68 - 4.78 mm.

I therefore change it to the mean `pedestal_size_z = -4.74`.

