### PR TITLE
Machine no longer a Resource, ResourceHolder is a Resource

### DIFF
--- a/pylabrobot/centrifuge/centrifuge.py
+++ b/pylabrobot/centrifuge/centrifuge.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pylabrobot.machines.machine import Machine
 from pylabrobot.centrifuge.backend import CentrifugeBackend
 
@@ -8,29 +6,9 @@ class Centrifuge(Machine):
   """The front end for centrifuges.
   Centrifuges are devices that can spin samples at high speeds."""
 
-  def __init__(
-    self,
-    name: str,
-    size_x: float,
-    size_y: float,
-    size_z: float,
-    backend: CentrifugeBackend,
-    category: Optional[str] = None,
-    model: Optional[str] = None,
-  ) -> None:
-    super().__init__(
-      name=name,
-      size_x=size_x,
-      size_y=size_y,
-      size_z=size_z,
-      backend=backend,
-      category=category,
-      model=model,
-    )
+  def __init__(self, backend: CentrifugeBackend) -> None:
+    super().__init__(backend=backend)
     self.backend: CentrifugeBackend = backend  # fix type
-
-  async def stop(self) -> None:
-    await self.backend.stop()
 
   async def open_door(self) -> None:
     await self.backend.open_door()

--- a/pylabrobot/liquid_handling/liquid_classes/hamilton/star.py
+++ b/pylabrobot/liquid_handling/liquid_classes/hamilton/star.py
@@ -3311,37 +3311,37 @@ star_mapping[(5000, False, True, False, Liquid.DMSO, True, False)] = (
 )
 
 
-star_mapping[(5000, False, True, False, Liquid.DMSO, True, True)] = (
-  _5mlT_DMSO_DispenseJet_Empty
-) = HamiltonLiquidClass(
-  curve={
-    500.0: 540.0,
-    50.0: 62.0,
-    5000.0: 5095.0,
-    4000.0: 4075.0,
-    0.0: 0.0,
-    3000.0: 3065.0,
-    100.0: 117.0,
-    2000.0: 2060.0,
-    1000.0: 1060.0,
-  },
-  aspiration_flow_rate=2000.0,
-  aspiration_mix_flow_rate=500.0,
-  aspiration_air_transport_volume=20.0,
-  aspiration_blow_out_volume=50.0,
-  aspiration_swap_speed=2.0,
-  aspiration_settling_time=1.0,
-  aspiration_over_aspirate_volume=0.0,
-  aspiration_clot_retract_height=0.0,
-  dispense_flow_rate=1000.0,
-  dispense_mode=3.0,
-  dispense_mix_flow_rate=100.0,
-  dispense_air_transport_volume=20.0,
-  dispense_blow_out_volume=50.0,
-  dispense_swap_speed=1.0,
-  dispense_settling_time=0.0,
-  dispense_stop_flow_rate=400.0,
-  dispense_stop_back_volume=0.0,
+star_mapping[(5000, False, True, False, Liquid.DMSO, True, True)] = _5mlT_DMSO_DispenseJet_Empty = (
+  HamiltonLiquidClass(
+    curve={
+      500.0: 540.0,
+      50.0: 62.0,
+      5000.0: 5095.0,
+      4000.0: 4075.0,
+      0.0: 0.0,
+      3000.0: 3065.0,
+      100.0: 117.0,
+      2000.0: 2060.0,
+      1000.0: 1060.0,
+    },
+    aspiration_flow_rate=2000.0,
+    aspiration_mix_flow_rate=500.0,
+    aspiration_air_transport_volume=20.0,
+    aspiration_blow_out_volume=50.0,
+    aspiration_swap_speed=2.0,
+    aspiration_settling_time=1.0,
+    aspiration_over_aspirate_volume=0.0,
+    aspiration_clot_retract_height=0.0,
+    dispense_flow_rate=1000.0,
+    dispense_mode=3.0,
+    dispense_mix_flow_rate=100.0,
+    dispense_air_transport_volume=20.0,
+    dispense_blow_out_volume=50.0,
+    dispense_swap_speed=1.0,
+    dispense_settling_time=0.0,
+    dispense_stop_flow_rate=400.0,
+    dispense_stop_back_volume=0.0,
+  )
 )
 
 
@@ -4123,36 +4123,36 @@ star_mapping[(1000, False, True, False, Liquid.ACETONITRILE, False, False)] = (
 # -  Submerge depth: Aspiration 2.0mm
 #    (bei Schaumbildung durch mischen/vorbenetzen evtl.5mm, LLD-Erkennung)
 # -  Mischen 3-5 x 950µl, mix position 0.5mm, je nach Volumen im Tube
-star_mapping[(1000, False, True, False, Liquid.BLOOD, True, False)] = (
-  HighVolumeBloodDispenseJet
-) = HamiltonLiquidClass(
-  curve={
-    500.0: 536.3,
-    250.0: 275.6,
-    50.0: 59.8,
-    0.0: 0.0,
-    20.0: 26.2,
-    100.0: 115.3,
-    10.0: 12.2,
-    1000.0: 1061.6,
-  },
-  aspiration_flow_rate=250.0,
-  aspiration_mix_flow_rate=250.0,
-  aspiration_air_transport_volume=5.0,
-  aspiration_blow_out_volume=50.0,
-  aspiration_swap_speed=2.0,
-  aspiration_settling_time=2.0,
-  aspiration_over_aspirate_volume=0.0,
-  aspiration_clot_retract_height=0.0,
-  dispense_flow_rate=400.0,
-  dispense_mode=0.0,
-  dispense_mix_flow_rate=250.0,
-  dispense_air_transport_volume=5.0,
-  dispense_blow_out_volume=50.0,
-  dispense_swap_speed=2.0,
-  dispense_settling_time=0.0,
-  dispense_stop_flow_rate=300.0,
-  dispense_stop_back_volume=0.0,
+star_mapping[(1000, False, True, False, Liquid.BLOOD, True, False)] = HighVolumeBloodDispenseJet = (
+  HamiltonLiquidClass(
+    curve={
+      500.0: 536.3,
+      250.0: 275.6,
+      50.0: 59.8,
+      0.0: 0.0,
+      20.0: 26.2,
+      100.0: 115.3,
+      10.0: 12.2,
+      1000.0: 1061.6,
+    },
+    aspiration_flow_rate=250.0,
+    aspiration_mix_flow_rate=250.0,
+    aspiration_air_transport_volume=5.0,
+    aspiration_blow_out_volume=50.0,
+    aspiration_swap_speed=2.0,
+    aspiration_settling_time=2.0,
+    aspiration_over_aspirate_volume=0.0,
+    aspiration_clot_retract_height=0.0,
+    dispense_flow_rate=400.0,
+    dispense_mode=0.0,
+    dispense_mix_flow_rate=250.0,
+    dispense_air_transport_volume=5.0,
+    dispense_blow_out_volume=50.0,
+    dispense_swap_speed=2.0,
+    dispense_settling_time=0.0,
+    dispense_stop_flow_rate=300.0,
+    dispense_stop_back_volume=0.0,
+  )
 )
 
 
@@ -4269,37 +4269,37 @@ star_mapping[(1000, False, True, False, Liquid.CHLOROFORM, True, False)] = (
 #     100  (  9 Aliquots)          0.25                  -4.81
 #
 #
-star_mapping[(1000, False, True, False, Liquid.DMSO, True, False)] = (
-  HighVolumeDMSOAliquotJet
-) = HamiltonLiquidClass(
-  curve={
-    500.0: 500.0,
-    250.0: 250.0,
-    0.0: 0.0,
-    30.0: 30.0,
-    20.0: 20.0,
-    100.0: 100.0,
-    10.0: 10.0,
-    750.0: 750.0,
-    1000.0: 1000.0,
-  },
-  aspiration_flow_rate=250.0,
-  aspiration_mix_flow_rate=250.0,
-  aspiration_air_transport_volume=0.0,
-  aspiration_blow_out_volume=50.0,
-  aspiration_swap_speed=2.0,
-  aspiration_settling_time=1.0,
-  aspiration_over_aspirate_volume=0.0,
-  aspiration_clot_retract_height=0.0,
-  dispense_flow_rate=300.0,
-  dispense_mode=0.0,
-  dispense_mix_flow_rate=250.0,
-  dispense_air_transport_volume=0.0,
-  dispense_blow_out_volume=50.0,
-  dispense_swap_speed=2.0,
-  dispense_settling_time=0.0,
-  dispense_stop_flow_rate=200.0,
-  dispense_stop_back_volume=10.0,
+star_mapping[(1000, False, True, False, Liquid.DMSO, True, False)] = HighVolumeDMSOAliquotJet = (
+  HamiltonLiquidClass(
+    curve={
+      500.0: 500.0,
+      250.0: 250.0,
+      0.0: 0.0,
+      30.0: 30.0,
+      20.0: 20.0,
+      100.0: 100.0,
+      10.0: 10.0,
+      750.0: 750.0,
+      1000.0: 1000.0,
+    },
+    aspiration_flow_rate=250.0,
+    aspiration_mix_flow_rate=250.0,
+    aspiration_air_transport_volume=0.0,
+    aspiration_blow_out_volume=50.0,
+    aspiration_swap_speed=2.0,
+    aspiration_settling_time=1.0,
+    aspiration_over_aspirate_volume=0.0,
+    aspiration_clot_retract_height=0.0,
+    dispense_flow_rate=300.0,
+    dispense_mode=0.0,
+    dispense_mix_flow_rate=250.0,
+    dispense_air_transport_volume=0.0,
+    dispense_blow_out_volume=50.0,
+    dispense_swap_speed=2.0,
+    dispense_settling_time=0.0,
+    dispense_stop_flow_rate=200.0,
+    dispense_stop_back_volume=10.0,
+  )
 )
 
 
@@ -6218,37 +6218,37 @@ star_mapping[(1000, False, True, False, Liquid.DMSO, True, False)] = (
 
 
 # V1.1: Set mix flow rate to 250
-star_mapping[(1000, False, True, False, Liquid.DMSO, True, False)] = (
-  HighVolume_DMSO_DispenseJet
-) = HamiltonLiquidClass(
-  curve={
-    5.0: 5.1,
-    500.0: 511.2,
-    250.0: 256.2,
-    50.0: 52.2,
-    0.0: 0.0,
-    20.0: 21.3,
-    100.0: 103.4,
-    10.0: 10.7,
-    1000.0: 1021.0,
-  },
-  aspiration_flow_rate=250.0,
-  aspiration_mix_flow_rate=250.0,
-  aspiration_air_transport_volume=5.0,
-  aspiration_blow_out_volume=40.0,
-  aspiration_swap_speed=2.0,
-  aspiration_settling_time=1.0,
-  aspiration_over_aspirate_volume=0.0,
-  aspiration_clot_retract_height=0.0,
-  dispense_flow_rate=400.0,
-  dispense_mode=0.0,
-  dispense_mix_flow_rate=250.0,
-  dispense_air_transport_volume=5.0,
-  dispense_blow_out_volume=40.0,
-  dispense_swap_speed=2.0,
-  dispense_settling_time=0.0,
-  dispense_stop_flow_rate=250.0,
-  dispense_stop_back_volume=0.0,
+star_mapping[(1000, False, True, False, Liquid.DMSO, True, False)] = HighVolume_DMSO_DispenseJet = (
+  HamiltonLiquidClass(
+    curve={
+      5.0: 5.1,
+      500.0: 511.2,
+      250.0: 256.2,
+      50.0: 52.2,
+      0.0: 0.0,
+      20.0: 21.3,
+      100.0: 103.4,
+      10.0: 10.7,
+      1000.0: 1021.0,
+    },
+    aspiration_flow_rate=250.0,
+    aspiration_mix_flow_rate=250.0,
+    aspiration_air_transport_volume=5.0,
+    aspiration_blow_out_volume=40.0,
+    aspiration_swap_speed=2.0,
+    aspiration_settling_time=1.0,
+    aspiration_over_aspirate_volume=0.0,
+    aspiration_clot_retract_height=0.0,
+    dispense_flow_rate=400.0,
+    dispense_mode=0.0,
+    dispense_mix_flow_rate=250.0,
+    dispense_air_transport_volume=5.0,
+    dispense_blow_out_volume=40.0,
+    dispense_swap_speed=2.0,
+    dispense_settling_time=0.0,
+    dispense_stop_flow_rate=250.0,
+    dispense_stop_back_volume=0.0,
+  )
 )
 
 
@@ -7423,27 +7423,27 @@ star_mapping[(10, False, False, False, Liquid.WATER, False, False)] = (
 )
 
 
-star_mapping[(10, False, False, False, Liquid.WATER, True, False)] = (
-  LowNeedle_Water_DispenseJet
-) = HamiltonLiquidClass(
-  curve={50.0: 52.7, 30.0: 31.7, 0.0: 0.0, 20.0: 20.5, 10.0: 10.3},
-  aspiration_flow_rate=100.0,
-  aspiration_mix_flow_rate=100.0,
-  aspiration_air_transport_volume=15.0,
-  aspiration_blow_out_volume=30.0,
-  aspiration_swap_speed=2.0,
-  aspiration_settling_time=1.0,
-  aspiration_over_aspirate_volume=0.0,
-  aspiration_clot_retract_height=0.0,
-  dispense_flow_rate=200.0,
-  dispense_mode=0.0,
-  dispense_mix_flow_rate=100.0,
-  dispense_air_transport_volume=15.0,
-  dispense_blow_out_volume=30.0,
-  dispense_swap_speed=2.0,
-  dispense_settling_time=0.0,
-  dispense_stop_flow_rate=150.0,
-  dispense_stop_back_volume=0.0,
+star_mapping[(10, False, False, False, Liquid.WATER, True, False)] = LowNeedle_Water_DispenseJet = (
+  HamiltonLiquidClass(
+    curve={50.0: 52.7, 30.0: 31.7, 0.0: 0.0, 20.0: 20.5, 10.0: 10.3},
+    aspiration_flow_rate=100.0,
+    aspiration_mix_flow_rate=100.0,
+    aspiration_air_transport_volume=15.0,
+    aspiration_blow_out_volume=30.0,
+    aspiration_swap_speed=2.0,
+    aspiration_settling_time=1.0,
+    aspiration_over_aspirate_volume=0.0,
+    aspiration_clot_retract_height=0.0,
+    dispense_flow_rate=200.0,
+    dispense_mode=0.0,
+    dispense_mix_flow_rate=100.0,
+    dispense_air_transport_volume=15.0,
+    dispense_blow_out_volume=30.0,
+    dispense_swap_speed=2.0,
+    dispense_settling_time=0.0,
+    dispense_stop_flow_rate=150.0,
+    dispense_stop_back_volume=0.0,
+  )
 )
 
 
@@ -9739,34 +9739,34 @@ star_mapping[(300, True, True, False, Liquid.DMSO, True, False)] = (
 )
 
 
-star_mapping[(300, True, True, False, Liquid.DMSO, True, True)] = (
-  SlimTip_DMSO_DispenseJet_Empty
-) = HamiltonLiquidClass(
-  curve={
-    300.0: 309.5,
-    50.0: 54.7,
-    0.0: 0.0,
-    100.0: 107.2,
-    20.0: 22.5,
-    200.0: 209.7,
-  },
-  aspiration_flow_rate=250.0,
-  aspiration_mix_flow_rate=250.0,
-  aspiration_air_transport_volume=5.0,
-  aspiration_blow_out_volume=10.0,
-  aspiration_swap_speed=2.0,
-  aspiration_settling_time=1.0,
-  aspiration_over_aspirate_volume=0.0,
-  aspiration_clot_retract_height=0.0,
-  dispense_flow_rate=250.0,
-  dispense_mode=3.0,
-  dispense_mix_flow_rate=1.0,
-  dispense_air_transport_volume=5.0,
-  dispense_blow_out_volume=10.0,
-  dispense_swap_speed=1.0,
-  dispense_settling_time=0.0,
-  dispense_stop_flow_rate=100.0,
-  dispense_stop_back_volume=0.0,
+star_mapping[(300, True, True, False, Liquid.DMSO, True, True)] = SlimTip_DMSO_DispenseJet_Empty = (
+  HamiltonLiquidClass(
+    curve={
+      300.0: 309.5,
+      50.0: 54.7,
+      0.0: 0.0,
+      100.0: 107.2,
+      20.0: 22.5,
+      200.0: 209.7,
+    },
+    aspiration_flow_rate=250.0,
+    aspiration_mix_flow_rate=250.0,
+    aspiration_air_transport_volume=5.0,
+    aspiration_blow_out_volume=10.0,
+    aspiration_swap_speed=2.0,
+    aspiration_settling_time=1.0,
+    aspiration_over_aspirate_volume=0.0,
+    aspiration_clot_retract_height=0.0,
+    dispense_flow_rate=250.0,
+    dispense_mode=3.0,
+    dispense_mix_flow_rate=1.0,
+    dispense_air_transport_volume=5.0,
+    dispense_blow_out_volume=10.0,
+    dispense_swap_speed=1.0,
+    dispense_settling_time=0.0,
+    dispense_stop_flow_rate=100.0,
+    dispense_stop_back_volume=0.0,
+  )
 )
 
 
@@ -10588,27 +10588,27 @@ star_mapping[(300, False, True, False, Liquid.ACETONITRILE, False, False)] = (
 #       20  (12 Aliquots)          2.53                 -2.97
 #       50  (  4 Aliquots)          0.84                 -2.57
 #
-star_mapping[(300, False, True, False, Liquid.DMSO, True, False)] = (
-  StandardVolumeDMSOAliquotJet
-) = HamiltonLiquidClass(
-  curve={350.0: 350.0, 30.0: 30.0, 0.0: 0.0, 20.0: 20.0, 10.0: 10.0},
-  aspiration_flow_rate=100.0,
-  aspiration_mix_flow_rate=100.0,
-  aspiration_air_transport_volume=0.0,
-  aspiration_blow_out_volume=0.0,
-  aspiration_swap_speed=2.0,
-  aspiration_settling_time=1.0,
-  aspiration_over_aspirate_volume=0.0,
-  aspiration_clot_retract_height=0.0,
-  dispense_flow_rate=250.0,
-  dispense_mode=0.0,
-  dispense_mix_flow_rate=100.0,
-  dispense_air_transport_volume=0.0,
-  dispense_blow_out_volume=0.0,
-  dispense_swap_speed=0.3,
-  dispense_settling_time=0.0,
-  dispense_stop_flow_rate=200.0,
-  dispense_stop_back_volume=10.0,
+star_mapping[(300, False, True, False, Liquid.DMSO, True, False)] = StandardVolumeDMSOAliquotJet = (
+  HamiltonLiquidClass(
+    curve={350.0: 350.0, 30.0: 30.0, 0.0: 0.0, 20.0: 20.0, 10.0: 10.0},
+    aspiration_flow_rate=100.0,
+    aspiration_mix_flow_rate=100.0,
+    aspiration_air_transport_volume=0.0,
+    aspiration_blow_out_volume=0.0,
+    aspiration_swap_speed=2.0,
+    aspiration_settling_time=1.0,
+    aspiration_over_aspirate_volume=0.0,
+    aspiration_clot_retract_height=0.0,
+    dispense_flow_rate=250.0,
+    dispense_mode=0.0,
+    dispense_mix_flow_rate=100.0,
+    dispense_air_transport_volume=0.0,
+    dispense_blow_out_volume=0.0,
+    dispense_swap_speed=0.3,
+    dispense_settling_time=0.0,
+    dispense_stop_flow_rate=200.0,
+    dispense_stop_back_volume=10.0,
+  )
 )
 
 

--- a/pylabrobot/liquid_handling/liquid_classes/hamilton/star.py
+++ b/pylabrobot/liquid_handling/liquid_classes/hamilton/star.py
@@ -3311,37 +3311,37 @@ star_mapping[(5000, False, True, False, Liquid.DMSO, True, False)] = (
 )
 
 
-star_mapping[(5000, False, True, False, Liquid.DMSO, True, True)] = _5mlT_DMSO_DispenseJet_Empty = (
-  HamiltonLiquidClass(
-    curve={
-      500.0: 540.0,
-      50.0: 62.0,
-      5000.0: 5095.0,
-      4000.0: 4075.0,
-      0.0: 0.0,
-      3000.0: 3065.0,
-      100.0: 117.0,
-      2000.0: 2060.0,
-      1000.0: 1060.0,
-    },
-    aspiration_flow_rate=2000.0,
-    aspiration_mix_flow_rate=500.0,
-    aspiration_air_transport_volume=20.0,
-    aspiration_blow_out_volume=50.0,
-    aspiration_swap_speed=2.0,
-    aspiration_settling_time=1.0,
-    aspiration_over_aspirate_volume=0.0,
-    aspiration_clot_retract_height=0.0,
-    dispense_flow_rate=1000.0,
-    dispense_mode=3.0,
-    dispense_mix_flow_rate=100.0,
-    dispense_air_transport_volume=20.0,
-    dispense_blow_out_volume=50.0,
-    dispense_swap_speed=1.0,
-    dispense_settling_time=0.0,
-    dispense_stop_flow_rate=400.0,
-    dispense_stop_back_volume=0.0,
-  )
+star_mapping[(5000, False, True, False, Liquid.DMSO, True, True)] = (
+  _5mlT_DMSO_DispenseJet_Empty
+) = HamiltonLiquidClass(
+  curve={
+    500.0: 540.0,
+    50.0: 62.0,
+    5000.0: 5095.0,
+    4000.0: 4075.0,
+    0.0: 0.0,
+    3000.0: 3065.0,
+    100.0: 117.0,
+    2000.0: 2060.0,
+    1000.0: 1060.0,
+  },
+  aspiration_flow_rate=2000.0,
+  aspiration_mix_flow_rate=500.0,
+  aspiration_air_transport_volume=20.0,
+  aspiration_blow_out_volume=50.0,
+  aspiration_swap_speed=2.0,
+  aspiration_settling_time=1.0,
+  aspiration_over_aspirate_volume=0.0,
+  aspiration_clot_retract_height=0.0,
+  dispense_flow_rate=1000.0,
+  dispense_mode=3.0,
+  dispense_mix_flow_rate=100.0,
+  dispense_air_transport_volume=20.0,
+  dispense_blow_out_volume=50.0,
+  dispense_swap_speed=1.0,
+  dispense_settling_time=0.0,
+  dispense_stop_flow_rate=400.0,
+  dispense_stop_back_volume=0.0,
 )
 
 
@@ -4123,36 +4123,36 @@ star_mapping[(1000, False, True, False, Liquid.ACETONITRILE, False, False)] = (
 # -  Submerge depth: Aspiration 2.0mm
 #    (bei Schaumbildung durch mischen/vorbenetzen evtl.5mm, LLD-Erkennung)
 # -  Mischen 3-5 x 950µl, mix position 0.5mm, je nach Volumen im Tube
-star_mapping[(1000, False, True, False, Liquid.BLOOD, True, False)] = HighVolumeBloodDispenseJet = (
-  HamiltonLiquidClass(
-    curve={
-      500.0: 536.3,
-      250.0: 275.6,
-      50.0: 59.8,
-      0.0: 0.0,
-      20.0: 26.2,
-      100.0: 115.3,
-      10.0: 12.2,
-      1000.0: 1061.6,
-    },
-    aspiration_flow_rate=250.0,
-    aspiration_mix_flow_rate=250.0,
-    aspiration_air_transport_volume=5.0,
-    aspiration_blow_out_volume=50.0,
-    aspiration_swap_speed=2.0,
-    aspiration_settling_time=2.0,
-    aspiration_over_aspirate_volume=0.0,
-    aspiration_clot_retract_height=0.0,
-    dispense_flow_rate=400.0,
-    dispense_mode=0.0,
-    dispense_mix_flow_rate=250.0,
-    dispense_air_transport_volume=5.0,
-    dispense_blow_out_volume=50.0,
-    dispense_swap_speed=2.0,
-    dispense_settling_time=0.0,
-    dispense_stop_flow_rate=300.0,
-    dispense_stop_back_volume=0.0,
-  )
+star_mapping[(1000, False, True, False, Liquid.BLOOD, True, False)] = (
+  HighVolumeBloodDispenseJet
+) = HamiltonLiquidClass(
+  curve={
+    500.0: 536.3,
+    250.0: 275.6,
+    50.0: 59.8,
+    0.0: 0.0,
+    20.0: 26.2,
+    100.0: 115.3,
+    10.0: 12.2,
+    1000.0: 1061.6,
+  },
+  aspiration_flow_rate=250.0,
+  aspiration_mix_flow_rate=250.0,
+  aspiration_air_transport_volume=5.0,
+  aspiration_blow_out_volume=50.0,
+  aspiration_swap_speed=2.0,
+  aspiration_settling_time=2.0,
+  aspiration_over_aspirate_volume=0.0,
+  aspiration_clot_retract_height=0.0,
+  dispense_flow_rate=400.0,
+  dispense_mode=0.0,
+  dispense_mix_flow_rate=250.0,
+  dispense_air_transport_volume=5.0,
+  dispense_blow_out_volume=50.0,
+  dispense_swap_speed=2.0,
+  dispense_settling_time=0.0,
+  dispense_stop_flow_rate=300.0,
+  dispense_stop_back_volume=0.0,
 )
 
 
@@ -4269,37 +4269,37 @@ star_mapping[(1000, False, True, False, Liquid.CHLOROFORM, True, False)] = (
 #     100  (  9 Aliquots)          0.25                  -4.81
 #
 #
-star_mapping[(1000, False, True, False, Liquid.DMSO, True, False)] = HighVolumeDMSOAliquotJet = (
-  HamiltonLiquidClass(
-    curve={
-      500.0: 500.0,
-      250.0: 250.0,
-      0.0: 0.0,
-      30.0: 30.0,
-      20.0: 20.0,
-      100.0: 100.0,
-      10.0: 10.0,
-      750.0: 750.0,
-      1000.0: 1000.0,
-    },
-    aspiration_flow_rate=250.0,
-    aspiration_mix_flow_rate=250.0,
-    aspiration_air_transport_volume=0.0,
-    aspiration_blow_out_volume=50.0,
-    aspiration_swap_speed=2.0,
-    aspiration_settling_time=1.0,
-    aspiration_over_aspirate_volume=0.0,
-    aspiration_clot_retract_height=0.0,
-    dispense_flow_rate=300.0,
-    dispense_mode=0.0,
-    dispense_mix_flow_rate=250.0,
-    dispense_air_transport_volume=0.0,
-    dispense_blow_out_volume=50.0,
-    dispense_swap_speed=2.0,
-    dispense_settling_time=0.0,
-    dispense_stop_flow_rate=200.0,
-    dispense_stop_back_volume=10.0,
-  )
+star_mapping[(1000, False, True, False, Liquid.DMSO, True, False)] = (
+  HighVolumeDMSOAliquotJet
+) = HamiltonLiquidClass(
+  curve={
+    500.0: 500.0,
+    250.0: 250.0,
+    0.0: 0.0,
+    30.0: 30.0,
+    20.0: 20.0,
+    100.0: 100.0,
+    10.0: 10.0,
+    750.0: 750.0,
+    1000.0: 1000.0,
+  },
+  aspiration_flow_rate=250.0,
+  aspiration_mix_flow_rate=250.0,
+  aspiration_air_transport_volume=0.0,
+  aspiration_blow_out_volume=50.0,
+  aspiration_swap_speed=2.0,
+  aspiration_settling_time=1.0,
+  aspiration_over_aspirate_volume=0.0,
+  aspiration_clot_retract_height=0.0,
+  dispense_flow_rate=300.0,
+  dispense_mode=0.0,
+  dispense_mix_flow_rate=250.0,
+  dispense_air_transport_volume=0.0,
+  dispense_blow_out_volume=50.0,
+  dispense_swap_speed=2.0,
+  dispense_settling_time=0.0,
+  dispense_stop_flow_rate=200.0,
+  dispense_stop_back_volume=10.0,
 )
 
 
@@ -6218,37 +6218,37 @@ star_mapping[(1000, False, True, False, Liquid.DMSO, True, False)] = (
 
 
 # V1.1: Set mix flow rate to 250
-star_mapping[(1000, False, True, False, Liquid.DMSO, True, False)] = HighVolume_DMSO_DispenseJet = (
-  HamiltonLiquidClass(
-    curve={
-      5.0: 5.1,
-      500.0: 511.2,
-      250.0: 256.2,
-      50.0: 52.2,
-      0.0: 0.0,
-      20.0: 21.3,
-      100.0: 103.4,
-      10.0: 10.7,
-      1000.0: 1021.0,
-    },
-    aspiration_flow_rate=250.0,
-    aspiration_mix_flow_rate=250.0,
-    aspiration_air_transport_volume=5.0,
-    aspiration_blow_out_volume=40.0,
-    aspiration_swap_speed=2.0,
-    aspiration_settling_time=1.0,
-    aspiration_over_aspirate_volume=0.0,
-    aspiration_clot_retract_height=0.0,
-    dispense_flow_rate=400.0,
-    dispense_mode=0.0,
-    dispense_mix_flow_rate=250.0,
-    dispense_air_transport_volume=5.0,
-    dispense_blow_out_volume=40.0,
-    dispense_swap_speed=2.0,
-    dispense_settling_time=0.0,
-    dispense_stop_flow_rate=250.0,
-    dispense_stop_back_volume=0.0,
-  )
+star_mapping[(1000, False, True, False, Liquid.DMSO, True, False)] = (
+  HighVolume_DMSO_DispenseJet
+) = HamiltonLiquidClass(
+  curve={
+    5.0: 5.1,
+    500.0: 511.2,
+    250.0: 256.2,
+    50.0: 52.2,
+    0.0: 0.0,
+    20.0: 21.3,
+    100.0: 103.4,
+    10.0: 10.7,
+    1000.0: 1021.0,
+  },
+  aspiration_flow_rate=250.0,
+  aspiration_mix_flow_rate=250.0,
+  aspiration_air_transport_volume=5.0,
+  aspiration_blow_out_volume=40.0,
+  aspiration_swap_speed=2.0,
+  aspiration_settling_time=1.0,
+  aspiration_over_aspirate_volume=0.0,
+  aspiration_clot_retract_height=0.0,
+  dispense_flow_rate=400.0,
+  dispense_mode=0.0,
+  dispense_mix_flow_rate=250.0,
+  dispense_air_transport_volume=5.0,
+  dispense_blow_out_volume=40.0,
+  dispense_swap_speed=2.0,
+  dispense_settling_time=0.0,
+  dispense_stop_flow_rate=250.0,
+  dispense_stop_back_volume=0.0,
 )
 
 
@@ -7423,27 +7423,27 @@ star_mapping[(10, False, False, False, Liquid.WATER, False, False)] = (
 )
 
 
-star_mapping[(10, False, False, False, Liquid.WATER, True, False)] = LowNeedle_Water_DispenseJet = (
-  HamiltonLiquidClass(
-    curve={50.0: 52.7, 30.0: 31.7, 0.0: 0.0, 20.0: 20.5, 10.0: 10.3},
-    aspiration_flow_rate=100.0,
-    aspiration_mix_flow_rate=100.0,
-    aspiration_air_transport_volume=15.0,
-    aspiration_blow_out_volume=30.0,
-    aspiration_swap_speed=2.0,
-    aspiration_settling_time=1.0,
-    aspiration_over_aspirate_volume=0.0,
-    aspiration_clot_retract_height=0.0,
-    dispense_flow_rate=200.0,
-    dispense_mode=0.0,
-    dispense_mix_flow_rate=100.0,
-    dispense_air_transport_volume=15.0,
-    dispense_blow_out_volume=30.0,
-    dispense_swap_speed=2.0,
-    dispense_settling_time=0.0,
-    dispense_stop_flow_rate=150.0,
-    dispense_stop_back_volume=0.0,
-  )
+star_mapping[(10, False, False, False, Liquid.WATER, True, False)] = (
+  LowNeedle_Water_DispenseJet
+) = HamiltonLiquidClass(
+  curve={50.0: 52.7, 30.0: 31.7, 0.0: 0.0, 20.0: 20.5, 10.0: 10.3},
+  aspiration_flow_rate=100.0,
+  aspiration_mix_flow_rate=100.0,
+  aspiration_air_transport_volume=15.0,
+  aspiration_blow_out_volume=30.0,
+  aspiration_swap_speed=2.0,
+  aspiration_settling_time=1.0,
+  aspiration_over_aspirate_volume=0.0,
+  aspiration_clot_retract_height=0.0,
+  dispense_flow_rate=200.0,
+  dispense_mode=0.0,
+  dispense_mix_flow_rate=100.0,
+  dispense_air_transport_volume=15.0,
+  dispense_blow_out_volume=30.0,
+  dispense_swap_speed=2.0,
+  dispense_settling_time=0.0,
+  dispense_stop_flow_rate=150.0,
+  dispense_stop_back_volume=0.0,
 )
 
 
@@ -9739,34 +9739,34 @@ star_mapping[(300, True, True, False, Liquid.DMSO, True, False)] = (
 )
 
 
-star_mapping[(300, True, True, False, Liquid.DMSO, True, True)] = SlimTip_DMSO_DispenseJet_Empty = (
-  HamiltonLiquidClass(
-    curve={
-      300.0: 309.5,
-      50.0: 54.7,
-      0.0: 0.0,
-      100.0: 107.2,
-      20.0: 22.5,
-      200.0: 209.7,
-    },
-    aspiration_flow_rate=250.0,
-    aspiration_mix_flow_rate=250.0,
-    aspiration_air_transport_volume=5.0,
-    aspiration_blow_out_volume=10.0,
-    aspiration_swap_speed=2.0,
-    aspiration_settling_time=1.0,
-    aspiration_over_aspirate_volume=0.0,
-    aspiration_clot_retract_height=0.0,
-    dispense_flow_rate=250.0,
-    dispense_mode=3.0,
-    dispense_mix_flow_rate=1.0,
-    dispense_air_transport_volume=5.0,
-    dispense_blow_out_volume=10.0,
-    dispense_swap_speed=1.0,
-    dispense_settling_time=0.0,
-    dispense_stop_flow_rate=100.0,
-    dispense_stop_back_volume=0.0,
-  )
+star_mapping[(300, True, True, False, Liquid.DMSO, True, True)] = (
+  SlimTip_DMSO_DispenseJet_Empty
+) = HamiltonLiquidClass(
+  curve={
+    300.0: 309.5,
+    50.0: 54.7,
+    0.0: 0.0,
+    100.0: 107.2,
+    20.0: 22.5,
+    200.0: 209.7,
+  },
+  aspiration_flow_rate=250.0,
+  aspiration_mix_flow_rate=250.0,
+  aspiration_air_transport_volume=5.0,
+  aspiration_blow_out_volume=10.0,
+  aspiration_swap_speed=2.0,
+  aspiration_settling_time=1.0,
+  aspiration_over_aspirate_volume=0.0,
+  aspiration_clot_retract_height=0.0,
+  dispense_flow_rate=250.0,
+  dispense_mode=3.0,
+  dispense_mix_flow_rate=1.0,
+  dispense_air_transport_volume=5.0,
+  dispense_blow_out_volume=10.0,
+  dispense_swap_speed=1.0,
+  dispense_settling_time=0.0,
+  dispense_stop_flow_rate=100.0,
+  dispense_stop_back_volume=0.0,
 )
 
 
@@ -10588,27 +10588,27 @@ star_mapping[(300, False, True, False, Liquid.ACETONITRILE, False, False)] = (
 #       20  (12 Aliquots)          2.53                 -2.97
 #       50  (  4 Aliquots)          0.84                 -2.57
 #
-star_mapping[(300, False, True, False, Liquid.DMSO, True, False)] = StandardVolumeDMSOAliquotJet = (
-  HamiltonLiquidClass(
-    curve={350.0: 350.0, 30.0: 30.0, 0.0: 0.0, 20.0: 20.0, 10.0: 10.0},
-    aspiration_flow_rate=100.0,
-    aspiration_mix_flow_rate=100.0,
-    aspiration_air_transport_volume=0.0,
-    aspiration_blow_out_volume=0.0,
-    aspiration_swap_speed=2.0,
-    aspiration_settling_time=1.0,
-    aspiration_over_aspirate_volume=0.0,
-    aspiration_clot_retract_height=0.0,
-    dispense_flow_rate=250.0,
-    dispense_mode=0.0,
-    dispense_mix_flow_rate=100.0,
-    dispense_air_transport_volume=0.0,
-    dispense_blow_out_volume=0.0,
-    dispense_swap_speed=0.3,
-    dispense_settling_time=0.0,
-    dispense_stop_flow_rate=200.0,
-    dispense_stop_back_volume=10.0,
-  )
+star_mapping[(300, False, True, False, Liquid.DMSO, True, False)] = (
+  StandardVolumeDMSOAliquotJet
+) = HamiltonLiquidClass(
+  curve={350.0: 350.0, 30.0: 30.0, 0.0: 0.0, 20.0: 20.0, 10.0: 10.0},
+  aspiration_flow_rate=100.0,
+  aspiration_mix_flow_rate=100.0,
+  aspiration_air_transport_volume=0.0,
+  aspiration_blow_out_volume=0.0,
+  aspiration_swap_speed=2.0,
+  aspiration_settling_time=1.0,
+  aspiration_over_aspirate_volume=0.0,
+  aspiration_clot_retract_height=0.0,
+  dispense_flow_rate=250.0,
+  dispense_mode=0.0,
+  dispense_mix_flow_rate=100.0,
+  dispense_air_transport_volume=0.0,
+  dispense_blow_out_volume=0.0,
+  dispense_swap_speed=0.3,
+  dispense_settling_time=0.0,
+  dispense_stop_flow_rate=200.0,
+  dispense_stop_back_volume=10.0,
 )
 
 

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -2022,6 +2022,5 @@ class LiquidHandler(Resource, Machine):
 
 
 class OperationCallback(Protocol):
-  def __call__(
-    self, handler: "LiquidHandler", *args: Any, **kwargs: Any
-  ) -> None: ...  # pragma: no cover
+  def __call__(self, handler: "LiquidHandler", *args: Any, **kwargs: Any) -> None:
+    ...  # pragma: no cover

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -97,7 +97,7 @@ class BlowOutVolumeError(Exception):
   pass
 
 
-class LiquidHandler(Machine):
+class LiquidHandler(Resource, Machine):
   """
   Front end for liquid handlers.
 
@@ -126,14 +126,15 @@ class LiquidHandler(Machine):
       deck: Deck to use.
     """
 
-    super().__init__(
+    Resource.__init__(
+      self,
       name=f"lh_{deck.name}",
       size_x=deck._size_x,
       size_y=deck._size_y,
       size_z=deck._size_z,
-      backend=backend,
       category="liquid_handler",
     )
+    Machine.__init__(self, backend=backend)
 
     self.backend: LiquidHandlerBackend = backend  # fix type
     self._callbacks: Dict[str, OperationCallback] = {}
@@ -1978,6 +1979,9 @@ class LiquidHandler(Machine):
   def callbacks(self):
     return self._callbacks
 
+  def serialize(self):
+    return {**Resource.serialize(self), **Machine.serialize(self)}
+
   @classmethod
   def deserialize(cls, data: dict, allow_marshal: bool = False) -> LiquidHandler:
     """Deserialize a liquid handler from a dictionary.
@@ -2018,5 +2022,6 @@ class LiquidHandler(Machine):
 
 
 class OperationCallback(Protocol):
-  def __call__(self, handler: "LiquidHandler", *args: Any, **kwargs: Any) -> None:
-    ...  # pragma: no cover
+  def __call__(
+    self, handler: "LiquidHandler", *args: Any, **kwargs: Any
+  ) -> None: ...  # pragma: no cover

--- a/pylabrobot/machines/machine_tests.py
+++ b/pylabrobot/machines/machine_tests.py
@@ -22,27 +22,10 @@ class TestMachine(unittest.TestCase):
     pass
 
   def test_serialize(self):
-    m = self.MockMachine(
-      name="test",
-      size_x=10,
-      size_y=10,
-      size_z=10,
-      backend=self.MockBackend("mock_param"),
-    )
+    m = self.MockMachine(backend=self.MockBackend("mock_param"))
     self.assertEqual(
       m.serialize(),
       {
-        "name": "test",
-        "size_x": 10,
-        "size_y": 10,
-        "size_z": 10,
-        "location": None,
-        "rotation": {"type": "Rotation", "x": 0, "y": 0, "z": 0},
-        "type": "MockMachine",
-        "children": [],
-        "category": None,
-        "parent_name": None,
-        "model": None,
         "backend": {
           "mock_param": "mock_param",
           "type": "MockBackend",
@@ -51,11 +34,5 @@ class TestMachine(unittest.TestCase):
     )
 
   def test_deserialize(self):
-    m = self.MockMachine(
-      name="test",
-      size_x=10,
-      size_y=10,
-      size_z=10,
-      backend=self.MockBackend("mock_param"),
-    )
-    self.assertEqual(Machine.deserialize(m.serialize()), m)
+    m = self.MockMachine(backend=self.MockBackend("mock_param"))
+    Machine.deserialize(m.serialize())  # shouldn't raise

--- a/pylabrobot/only_fans/fan.py
+++ b/pylabrobot/only_fans/fan.py
@@ -1,7 +1,6 @@
 import asyncio
 
 from pylabrobot.machines.machine import Machine
-
 from .backend import FanBackend
 
 
@@ -10,26 +9,12 @@ class Fan(Machine):
   Front end for Fans.
   """
 
-  def __init__(self, backend: FanBackend, name):
-    """Initialize a Fan.
-
-    Args:
-      backend: Backend to use.
-    """
-
-    super().__init__(
-      name=name,
-      size_x=1830,
-      size_y=900,
-      size_z=400,
-      backend=backend,
-      category="fan",
-    )
-
+  def __init__(self, backend: FanBackend):
+    super().__init__(backend=backend)
     self.backend: FanBackend = backend  # fix type
 
   async def stop(self):
-    """Stop the fan and close the connection."""
+    await super().stop()
     await self.backend.turn_off()
     await self.backend.stop()
 

--- a/pylabrobot/plate_reading/imager.py
+++ b/pylabrobot/plate_reading/imager.py
@@ -6,7 +6,7 @@ from pylabrobot.machines import Machine
 from pylabrobot.resources import Plate, Resource, Well
 
 
-class Imager(Machine):
+class Imager(Resource, Machine):
   """Microscope"""
 
   def __init__(
@@ -19,15 +19,16 @@ class Imager(Machine):
     category: Optional[str] = None,
     model: Optional[str] = None,
   ):
-    super().__init__(
+    Resource.__init__(
+      self,
       name=name,
       size_x=size_x,
       size_y=size_y,
       size_z=size_z,
-      backend=backend,
       category=category,
       model=model,
     )
+    Machine.__init__(self, backend=backend)
     self.backend: ImagerBackend = backend  # fix type
     self.plate: Optional[Plate] = None
 

--- a/pylabrobot/plate_reading/plate_reader.py
+++ b/pylabrobot/plate_reading/plate_reader.py
@@ -3,14 +3,14 @@ from typing import List, Optional, cast
 from pylabrobot.machines.machine import Machine, need_setup_finished
 from pylabrobot.resources import Coordinate, Plate, Resource
 from pylabrobot.plate_reading.backend import PlateReaderBackend
-from pylabrobot.resources.resource_holder import ResourceHolderMixin
+from pylabrobot.resources.resource_holder import ResourceHolder
 
 
 class NoPlateError(Exception):
   pass
 
 
-class PlateReader(ResourceHolderMixin, Machine):
+class PlateReader(ResourceHolder, Machine):
   """The front end for plate readers. Plate readers are devices that can read luminescence,
   absorbance, or fluorescence from a plate.
 
@@ -36,15 +36,16 @@ class PlateReader(ResourceHolderMixin, Machine):
     category: Optional[str] = None,
     model: Optional[str] = None,
   ) -> None:
-    super().__init__(
+    ResourceHolder.__init__(
+      self,
       name=name,
       size_x=size_x,
       size_y=size_y,
       size_z=size_z,
-      backend=backend,
       category=category,
       model=model,
     )
+    Machine.__init__(self, backend=backend)
     self.backend: PlateReaderBackend = backend  # fix type
 
   def assign_child_resource(

--- a/pylabrobot/powder_dispensing/powder_dispenser.py
+++ b/pylabrobot/powder_dispensing/powder_dispenser.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Sequence, Union, cast
+from typing import Any, Dict, List, Sequence, Union, cast
 from pylabrobot.machines.machine import Machine, need_setup_finished
 from .backend import PowderDispenserBackend, PowderDispense
 from pylabrobot.resources import Resource, Powder
@@ -10,7 +10,7 @@ class PowderDispenser(Machine):
   into containers such as mtp's placed on a deck.
 
   Here's an example of how to use this class:
-  >>> pd = PowderDispenser(backend=YourPowderDispenserBackend(), deck=Deck())
+  >>> pd = PowderDispenser(backend=YourPowderDispenserBackend())
   >>> pd.setup()
   >>> result = pd.dispense_powder(plate["A1"], powders='NaCl', amount=0.005)
   >>> print(result)
@@ -19,24 +19,10 @@ class PowderDispenser(Machine):
 
   def __init__(
     self,
-    name: str,
-    size_x: float,
-    size_y: float,
-    size_z: float,
     backend: PowderDispenserBackend,
-    category: Optional[str] = None,
-    model: Optional[str] = None,
     # deck: Deck
   ) -> None:
-    super().__init__(
-      name=name,
-      size_x=size_x,
-      size_y=size_y,
-      size_z=size_z,
-      backend=backend,
-      category=category,
-      model=model,
-    )
+    super().__init__(backend=backend)
     self.backend: PowderDispenserBackend = backend
 
   @need_setup_finished

--- a/pylabrobot/powder_dispensing/powder_dispenser_tests.py
+++ b/pylabrobot/powder_dispensing/powder_dispenser_tests.py
@@ -41,7 +41,7 @@ class TestPowderDispenser(unittest.IsolatedAsyncioTestCase):
 
   async def asyncSetUp(self) -> None:
     self.backend = AsyncMock(spec=MockPowderDispenserBackend)
-    self.dispenser = PowderDispenser(name="pd", backend=self.backend, size_x=1, size_y=1, size_z=1)
+    self.dispenser = PowderDispenser(backend=self.backend)
     await self.dispenser.setup()
 
   async def test_dispense_single_resource(self):

--- a/pylabrobot/pumps/agrowpumps/agrowdosepump_tests.py
+++ b/pylabrobot/pumps/agrowpumps/agrowdosepump_tests.py
@@ -52,14 +52,7 @@ class TestAgrowPumps(unittest.IsolatedAsyncioTestCase):
 
     self.agrow_backend._setup_modbus = _mock_setup_modbus  # type: ignore[method-assign]
 
-    self.pump_array = PumpArray(
-      backend=self.agrow_backend,
-      name="test_pump_array",
-      size_x=0,
-      size_y=0,
-      size_z=0,
-      calibration=None,
-    )
+    self.pump_array = PumpArray(backend=self.agrow_backend, calibration=None)
     await self.pump_array.setup()
 
   async def asyncTearDown(self):

--- a/pylabrobot/pumps/pump.py
+++ b/pylabrobot/pumps/pump.py
@@ -11,24 +11,10 @@ class Pump(Machine):
 
   def __init__(
     self,
-    name: str,
-    size_x: float,
-    size_y: float,
-    size_z: float,
     backend: PumpBackend,
-    category: Optional[str] = None,
-    model: Optional[str] = None,
     calibration: Optional[PumpCalibration] = None,
   ):
-    super().__init__(
-      name=name,
-      size_x=size_x,
-      size_y=size_y,
-      size_z=size_z,
-      backend=backend,
-      category=category,
-      model=model,
-    )
+    super().__init__(backend=backend)
     self.backend: PumpBackend = backend  # fix type
     if calibration is not None and len(calibration) != 1:
       raise ValueError("Calibration may only have a single item for this pump")
@@ -43,13 +29,13 @@ class Pump(Machine):
     }
 
   @classmethod
-  def deserialize(cls, data: dict, allow_marshal: bool = False):
+  def deserialize(cls, data: dict):
     data_copy = data.copy()
     calibration_data = data_copy.pop("calibration", None)
     if calibration_data is not None:
       calibration = PumpCalibration.deserialize(calibration_data)
       data_copy["calibration"] = calibration
-    return super().deserialize(data_copy, allow_marshal=allow_marshal)
+    return super().deserialize(data_copy)
 
   async def run_revolutions(self, num_revolutions: float):
     """Run a given number of revolutions. This method will return after the command has been sent,

--- a/pylabrobot/pumps/pump_tests.py
+++ b/pylabrobot/pumps/pump_tests.py
@@ -20,26 +20,13 @@ class TestPump(unittest.IsolatedAsyncioTestCase):
 
   async def test_setup(self):
     """Test that the Pump class can be initialized."""
-    async with Pump(
-      backend=self.mock_backend,
-      size_x=0,
-      size_y=0,
-      size_z=0,
-      name="pump",
-    ) as pump:
+    async with Pump(backend=self.mock_backend) as pump:
       self.assertIsNone(pump.calibration)
       self.assertEqual(pump.backend, self.mock_backend)
 
   async def test_run_revolutions(self):
     """Test that the Pump class can run for a specified number of revolutions."""
-    async with Pump(
-      backend=self.mock_backend,
-      calibration=self.test_calibration,
-      size_x=0,
-      size_y=0,
-      size_z=0,
-      name="pump",
-    ) as pump:
+    async with Pump(backend=self.mock_backend) as pump:
       await pump.run_revolutions(num_revolutions=1)
 
 
@@ -53,14 +40,7 @@ class TestPumpArray(unittest.IsolatedAsyncioTestCase):
 
   async def asyncSetUp(self) -> None:
     await super().asyncSetUp()
-    self.pump_array = PumpArray(
-      backend=self.mock_backend,
-      calibration=None,
-      size_x=0,
-      size_y=0,
-      size_z=0,
-      name="pump_array",
-    )
+    self.pump_array = PumpArray(backend=self.mock_backend, calibration=None)
     await self.pump_array.setup()
 
   async def asyncTearDown(self) -> None:

--- a/pylabrobot/pumps/pumparray.py
+++ b/pylabrobot/pumps/pumparray.py
@@ -20,24 +20,10 @@ class PumpArray(Machine):
 
   def __init__(
     self,
-    name: str,
-    size_x: float,
-    size_y: float,
-    size_z: float,
     backend: PumpArrayBackend,
-    category: Optional[str] = None,
-    model: Optional[str] = None,
     calibration: Optional[PumpCalibration] = None,
   ):
-    super().__init__(
-      name=name,
-      size_x=size_x,
-      size_y=size_y,
-      size_z=size_z,
-      backend=backend,
-      category=category,
-      model=model,
-    )
+    super().__init__(backend=backend)
     self.backend: PumpArrayBackend = backend  # fix type
     self.calibration = calibration
 
@@ -60,13 +46,13 @@ class PumpArray(Machine):
     }
 
   @classmethod
-  def deserialize(cls, data: dict, allow_marshal: bool = False):
+  def deserialize(cls, data: dict):
     data_copy = data.copy()
     calibration_data = data_copy.pop("calibration", None)
     if calibration_data is not None:
       calibration = PumpCalibration.deserialize(calibration_data)
       data_copy["calibration"] = calibration
-    return super().deserialize(data_copy, allow_marshal=allow_marshal)
+    return super().deserialize(data_copy)
 
   async def run_revolutions(
     self,

--- a/pylabrobot/resources/carrier.py
+++ b/pylabrobot/resources/carrier.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Generic, List, Optional, Type, TypeVar, Union
 
-from pylabrobot.resources.resource_holder import ResourceHolderMixin
+from pylabrobot.resources.resource_holder import ResourceHolder
 
 from .coordinate import Coordinate
 from .plate import Plate
@@ -14,7 +14,7 @@ from .plate_adapter import PlateAdapter
 logger = logging.getLogger("pylabrobot")
 
 
-class CarrierSite(ResourceHolderMixin, Resource):
+class CarrierSite(ResourceHolder, Resource):
   """A single site within a carrier."""
 
   def __init__(

--- a/pylabrobot/resources/plate.py
+++ b/pylabrobot/resources/plate.py
@@ -13,7 +13,7 @@ from typing import (
   Literal,
 )
 
-from pylabrobot.resources.resource_holder import ResourceHolderMixin
+from pylabrobot.resources.resource_holder import ResourceHolder
 
 
 from .liquid import Liquid
@@ -63,7 +63,7 @@ class Lid(Resource):
     }
 
 
-class Plate(ResourceHolderMixin, ItemizedResource[Well]):
+class Plate(ResourceHolder, ItemizedResource[Well]):
   """Base class for Plate resources."""
 
   def __init__(

--- a/pylabrobot/resources/resource_holder.py
+++ b/pylabrobot/resources/resource_holder.py
@@ -22,7 +22,7 @@ def get_child_location(resource: Resource) -> Coordinate:
   return location
 
 
-class ResourceHolderMixin:
+class ResourceHolder(Resource):
   """
   A mixin class for resources that can hold other resources, like a plate or a lid.
 

--- a/pylabrobot/resources/resource_stack.py
+++ b/pylabrobot/resources/resource_stack.py
@@ -1,7 +1,7 @@
 import logging
 from typing import List, Optional
 
-from pylabrobot.resources.resource_holder import ResourceHolderMixin
+from pylabrobot.resources.resource_holder import ResourceHolder
 from pylabrobot.resources.resource import Resource
 from pylabrobot.resources.coordinate import Coordinate
 from pylabrobot.resources.plate import Plate
@@ -9,7 +9,7 @@ from pylabrobot.resources.plate import Plate
 logger = logging.getLogger("pylabrobot")
 
 
-class ResourceStack(ResourceHolderMixin, Resource):
+class ResourceStack(ResourceHolder, Resource):
   """ResourceStack represent a group of resources that are stacked together and act as a single
   unit. Stacks can grow be configured to be able to grow in x, y, or z direction. Stacks growing
   in the x direction are from left to right. Stacks growing in the y direction are from front to

--- a/pylabrobot/scales/scale.py
+++ b/pylabrobot/scales/scale.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pylabrobot.machines.machine import Machine
 from pylabrobot.scales.scale_backend import ScaleBackend
 
@@ -7,25 +5,8 @@ from pylabrobot.scales.scale_backend import ScaleBackend
 class Scale(Machine):
   """Base class for a scale"""
 
-  def __init__(
-    self,
-    backend: ScaleBackend,
-    name: str,
-    size_x: float,
-    size_y: float,
-    size_z: float,
-    cateogry: str = "scale",
-    model: Optional[str] = None,
-  ):
-    super().__init__(
-      name=name,
-      backend=backend,
-      size_x=size_x,
-      size_y=size_y,
-      size_z=size_z,
-      category=cateogry,
-      model=model,
-    )
+  def __init__(self, backend: ScaleBackend):
+    super().__init__(backend=backend)
     self.backend: ScaleBackend = backend  # fix type
 
   async def tare(self, **backend_kwargs):

--- a/pylabrobot/scales/scale_backend.py
+++ b/pylabrobot/scales/scale_backend.py
@@ -6,11 +6,13 @@ class ScaleBackend(MachineBackend, metaclass=ABCMeta):
   """Backend for a scale"""
 
   @abstractmethod
-  async def tare(self): ...
+  async def tare(self):
+    ...
 
   @abstractmethod
   async def get_weight(self) -> float:
     """Get the weight in grams"""
 
   @abstractmethod
-  async def zero(self): ...
+  async def zero(self):
+    ...

--- a/pylabrobot/scales/scale_backend.py
+++ b/pylabrobot/scales/scale_backend.py
@@ -6,13 +6,11 @@ class ScaleBackend(MachineBackend, metaclass=ABCMeta):
   """Backend for a scale"""
 
   @abstractmethod
-  async def tare(self):
-    ...
+  async def tare(self): ...
 
   @abstractmethod
   async def get_weight(self) -> float:
     """Get the weight in grams"""
 
   @abstractmethod
-  async def zero(self):
-    ...
+  async def zero(self): ...

--- a/pylabrobot/shaking/shaker.py
+++ b/pylabrobot/shaking/shaker.py
@@ -2,12 +2,12 @@ import asyncio
 from typing import Optional
 
 from pylabrobot.machines.machine import Machine
-from pylabrobot.resources.resource_holder import ResourceHolderMixin
+from pylabrobot.resources.resource_holder import ResourceHolder
 
 from .backend import ShakerBackend
 
 
-class Shaker(ResourceHolderMixin, Machine):
+class Shaker(ResourceHolder, Machine):
   """A shaker machine"""
 
   def __init__(
@@ -20,15 +20,16 @@ class Shaker(ResourceHolderMixin, Machine):
     category: str = "shaker",
     model: Optional[str] = None,
   ):
-    super().__init__(
+    ResourceHolder.__init__(
+      self,
       name=name,
       size_x=size_x,
       size_y=size_y,
       size_z=size_z,
-      backend=backend,
       category=category,
       model=model,
     )
+    Machine.__init__(self, backend=backend)
     self.backend: ShakerBackend = backend  # fix type
 
   async def shake(self, speed: float, duration: Optional[float] = None):
@@ -49,5 +50,4 @@ class Shaker(ResourceHolderMixin, Machine):
 
   async def stop_shaking(self):
     """Stop shaking the shaker"""
-
     await self.backend.stop_shaking()

--- a/pylabrobot/temperature_controlling/temperature_controller.py
+++ b/pylabrobot/temperature_controlling/temperature_controller.py
@@ -3,11 +3,11 @@ import time
 from typing import Optional
 
 from pylabrobot.machines.machine import Machine
-from pylabrobot.resources.resource_holder import ResourceHolderMixin
+from pylabrobot.resources.resource_holder import ResourceHolder
 from .backend import TemperatureControllerBackend
 
 
-class TemperatureController(ResourceHolderMixin, Machine):
+class TemperatureController(ResourceHolder, Machine):
   """Temperature controller, for heating or for cooling."""
 
   def __init__(
@@ -20,15 +20,16 @@ class TemperatureController(ResourceHolderMixin, Machine):
     category: str = "temperature_controller",
     model: Optional[str] = None,
   ):
-    super().__init__(
+    ResourceHolder.__init__(
+      self,
       name=name,
       size_x=size_x,
       size_y=size_y,
       size_z=size_z,
-      backend=backend,
       category=category,
       model=model,
     )
+    Machine.__init__(self, backend=backend)
     self.backend: TemperatureControllerBackend = backend  # fix type
     self.target_temperature: Optional[float] = None
 

--- a/pylabrobot/tilting/tilter.py
+++ b/pylabrobot/tilting/tilter.py
@@ -4,11 +4,11 @@ from typing import List, Optional
 from pylabrobot.machines import Machine
 from pylabrobot.resources import Coordinate, Plate
 from pylabrobot.resources.well import CrossSectionType, Well
-from pylabrobot.resources.resource_holder import ResourceHolderMixin
+from pylabrobot.resources.resource_holder import ResourceHolder
 from .tilter_backend import TilterBackend
 
 
-class Tilter(ResourceHolderMixin, Machine):
+class Tilter(ResourceHolder, Machine):
   """Resources that tilt plates."""
 
   def __init__(
@@ -23,15 +23,16 @@ class Tilter(ResourceHolderMixin, Machine):
     category: Optional[str] = None,
     model: Optional[str] = None,
   ):
-    super().__init__(
+    ResourceHolder.__init__(
+      self,
       name=name,
       size_x=size_x,
       size_y=size_y,
       size_z=size_z,
-      backend=backend,
       category=category,
       model=model,
     )
+    Machine.__init__(self, backend=backend)
     self.backend: TilterBackend = backend  # fix type
     self._absolute_angle: float = 0
     self._hinge_coordinate = hinge_coordinate


### PR DESCRIPTION
- simplifies:
  - don't need fake numbers for machine sizes where the size doesn't actually matter
  - remove 163 loc
- allow ResourceHolder to be used instead of CarrierSite in https://github.com/PyLabRobot/pylabrobot/pull/280, simplifying things even further

ResourceHolderMixin was introduced in https://github.com/PyLabRobot/pylabrobot/pull/239 to avoid a diamond inheritance pattern with Machine for objects like Tilter. This was in a sense a mistake, as it turns out Machine should just not be a Resource. By having `Machine` not inherit from `Resource`, `ResourceHolderMixin` can now inherit from `Resource`. Rename to `ResourceHolder` because it is no longer a mixin.