### PR TITLE
ignore_collision on HamiltonDeck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `STAR.ztouch_probe_z_height_using_channel` for getting z-height by probing without cLLD (https://github.com/PyLabRobot/pylabrobot/pull/260)
 - `nest_8_troughplate_22000uL_Vb` and `nest_12_troughplate_15000uL_Vb` (https://github.com/PyLabRobot/pylabrobot/pull/312)
 - `Cor_12_wellplate_6900ul_Fb`, `Cor_24_wellplate_3470ul_Fb` and `Cor_48_wellplate_1620ul_Fb` (https://github.com/PyLabRobot/pylabrobot/pull/311)
+- `ignore_collision` parameter to `HamiltonDeck.assign_child_resource` (https://github.com/PyLabRobot/pylabrobot/pull/317)
 
 ### Deprecated
 

--- a/pylabrobot/resources/hamilton/hamilton_decks.py
+++ b/pylabrobot/resources/hamilton/hamilton_decks.py
@@ -106,6 +106,7 @@ class HamiltonDeck(Deck, metaclass=ABCMeta):
     reassign: bool = False,
     rails: Optional[int] = None,
     replace=False,
+    ignore_collision=False,
   ):
     """Assign a new deck resource.
 
@@ -133,6 +134,7 @@ class HamiltonDeck(Deck, metaclass=ABCMeta):
       replace: Replace the resource with the same name that was previously assigned, if it exists.
         If a resource is assigned with the same name and replace is False, a ValueError
         will be raised.
+      ignore_collision: If True, ignore collision detection.
 
     Raises:
       ValueError: If a resource is assigned with the same name and replace is `False`.
@@ -158,42 +160,43 @@ class HamiltonDeck(Deck, metaclass=ABCMeta):
     else:
       resource_location = None  # unknown resource location
 
-    if resource_location is not None:  # collision detection
-      if (
-        resource_location.x + resource.get_absolute_size_x()
-        > self.rails_to_location(self.num_rails + 1).x
-        and rails is not None
-      ):
-        raise ValueError(
-          f"Resource with width {resource.get_absolute_size_x()} does not fit at rails {rails}."
-        )
-
-      # Check if there is space for this new resource.
-      for og_resource in self.children:
-        og_x = cast(Coordinate, og_resource.location).x
-        og_y = cast(Coordinate, og_resource.location).y
-
-        # A resource is not allowed to overlap with another resource. Resources overlap when a
-        # corner of one resource is inside the boundaries of another resource.
-        if any(
-          [
-            og_x <= resource_location.x < og_x + og_resource.get_absolute_size_x(),
-            og_x
-            < resource_location.x + resource.get_absolute_size_x()
-            < og_x + og_resource.get_absolute_size_x(),
-          ]
-        ) and any(
-          [
-            og_y <= resource_location.y < og_y + og_resource.get_absolute_size_y(),
-            og_y
-            < resource_location.y + resource.get_absolute_size_y()
-            < og_y + og_resource.get_absolute_size_y(),
-          ]
+    if not ignore_collision:
+      if resource_location is not None:  # collision detection
+        if (
+          resource_location.x + resource.get_absolute_size_x()
+          > self.rails_to_location(self.num_rails + 1).x
+          and rails is not None
         ):
           raise ValueError(
-            f"Location {resource_location} is already occupied by resource "
-            f"'{og_resource.name}'."
+            f"Resource with width {resource.get_absolute_size_x()} does not fit at rails {rails}."
           )
+
+        # Check if there is space for this new resource.
+        for og_resource in self.children:
+          og_x = cast(Coordinate, og_resource.location).x
+          og_y = cast(Coordinate, og_resource.location).y
+
+          # A resource is not allowed to overlap with another resource. Resources overlap when a
+          # corner of one resource is inside the boundaries of another resource.
+          if any(
+            [
+              og_x <= resource_location.x < og_x + og_resource.get_absolute_size_x(),
+              og_x
+              < resource_location.x + resource.get_absolute_size_x()
+              < og_x + og_resource.get_absolute_size_x(),
+            ]
+          ) and any(
+            [
+              og_y <= resource_location.y < og_y + og_resource.get_absolute_size_y(),
+              og_y
+              < resource_location.y + resource.get_absolute_size_y()
+              < og_y + og_resource.get_absolute_size_y(),
+            ]
+          ):
+            raise ValueError(
+              f"Location {resource_location} is already occupied by resource "
+              f"'{og_resource.name}'."
+            )
 
     return super().assign_child_resource(resource, location=resource_location, reassign=reassign)
 

--- a/pylabrobot/resources/hamilton/hamilton_decks.py
+++ b/pylabrobot/resources/hamilton/hamilton_decks.py
@@ -158,7 +158,7 @@ class HamiltonDeck(Deck, metaclass=ABCMeta):
     elif location is not None:
       resource_location = location
     else:
-      resource_location = None  # unknown resource location
+      raise ValueError("Either rails or location must be provided.")
 
     if not ignore_collision:
       if resource_location is not None:  # collision detection


### PR DESCRIPTION
default by False, but sometimes we want to ignore collision detection, eg when assigning liquid_trash near the default trash location