### PR TITLE
unassign from parent if resource is re-assigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - volume tracking on channel 1-n (https://github.com/PyLabRobot/pylabrobot/pull/273)
 - correct trash location on Vantage (https://github.com/PyLabRobot/pylabrobot/pull/285)
 - `Resource.get_absolute_location` includes anchor even if parent is None
+- unassign from parent if resource is re-assigned (https://github.com/PyLabRobot/pylabrobot/pull/333)
 
 ### Removed
 

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -296,6 +296,8 @@ class Resource:
       callback(resource)
 
     # Modify the tree structure
+    if resource.parent is not None:
+      resource.parent.unassign_child_resource(resource)
     resource.parent = self
     resource.location = location
     self.children.append(resource)
@@ -401,6 +403,7 @@ class Resource:
 
     # Update the tree structure
     resource.parent = None
+    resource.location = None
     self.children.remove(resource)
 
     # Delete callbacks on the child resource so that they are not propagated up the tree.

--- a/pylabrobot/resources/resource_tests.py
+++ b/pylabrobot/resources/resource_tests.py
@@ -173,6 +173,18 @@ class TestResource(unittest.TestCase):
     with self.assertRaises(ResourceNotFoundError):
       parent.get_resource("child")
 
+  def test_reassign_child(self):
+    child = Resource("child", size_x=5, size_y=5, size_z=5)
+    parent1 = Resource("parent1", size_x=10, size_y=10, size_z=10)
+    parent2 = Resource("parent2", size_x=10, size_y=10, size_z=10)
+
+    parent1.assign_child_resource(child, location=Coordinate(5, 5, 5))
+    parent2.assign_child_resource(child, location=Coordinate(5, 5, 5))
+
+    self.assertEqual(child.parent, parent2)
+    self.assertEqual(parent1.children, [])
+    self.assertEqual(parent2.children, [child])
+
   def test_get_all_children(self):
     deck = Deck()
     parent = Resource("parent", size_x=10, size_y=10, size_z=10)


### PR DESCRIPTION
if a child resource was assigned to parent1, and then we assign it to parent2, it would already set the location and parent of the child. However, it would still be in the list of children of parent1. See test. This PR fixes that.