### PR TITLE
location of child resources is optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - resource_offset -> pickup_offset
   - get_direction -> pickup_direction
   - put_direction -> drop_direction
+- `location` parameter of `assign_child_resource` is not optional (https://github.com/PyLabRobot/pylabrobot/pull/336)
 
 ### Added
 

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -2172,7 +2172,7 @@ class LiquidHandler(Resource, Machine):
   def assign_child_resource(
     self,
     resource: Resource,
-    location: Coordinate,
+    location: Optional[Coordinate],
     reassign: bool = True,
   ):
     """Not implement on LiquidHandler, since the deck is managed by the :attr:`deck` attribute."""

--- a/pylabrobot/resources/carrier.py
+++ b/pylabrobot/resources/carrier.py
@@ -55,7 +55,7 @@ class Carrier(Resource, Generic[S]):
   def assign_child_resource(
     self,
     resource: Resource,
-    location: Coordinate,
+    location: Optional[Coordinate],
     reassign: bool = True,
     spot: Optional[int] = None,
   ):

--- a/pylabrobot/resources/opentrons/deck.py
+++ b/pylabrobot/resources/opentrons/deck.py
@@ -75,7 +75,7 @@ class OTDeck(Deck):
   def assign_child_resource(
     self,
     resource: Resource,
-    location: Coordinate,
+    location: Optional[Coordinate],
     reassign: bool = True,
   ):
     """Assign a resource to a slot.
@@ -83,6 +83,9 @@ class OTDeck(Deck):
     ..warning:: This method exists only for deserialization. You should use
     :meth:`assign_child_at_slot` instead.
     """
+
+    if location is None:
+      raise ValueError("location must be provided for resources on the deck")
 
     if location not in self.slot_locations:
       super().assign_child_resource(resource, location=location)

--- a/pylabrobot/resources/petri_dish.py
+++ b/pylabrobot/resources/petri_dish.py
@@ -71,7 +71,7 @@ class PetriDishHolder(Resource):
   def assign_child_resource(
     self,
     resource: Resource,
-    location: Coordinate,
+    location: Optional[Coordinate],
     reassign: bool = True,
   ):
     """Can only assign a single PetriDish"""

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -268,7 +268,7 @@ class Resource:
   def assign_child_resource(
     self,
     resource: Resource,
-    location: Coordinate,
+    location: Optional[Coordinate],
     reassign: bool = True,
   ):
     """Assign a child resource to this resource.
@@ -282,7 +282,7 @@ class Resource:
 
     Args:
       resource: The resource to assign.
-      location: The location of the resource, relative to this resource.
+      location: The location of the resource, relative to this resource. None if undefined.
       reassign: If `False`, an error will be raised if the resource to be assigned is already
         assigned to this resource. Defaults to `True`.
     """


### PR DESCRIPTION
before, a child resource needed to have a location defined when being assigned.

with this pr, this is no longer required: location as a parameter of assign_child_resource is now an optional. this means resources can have a parent, without having a location wrt that parent. Checking whether `parent is None` is no longer equivalent to checking whether `location is None`.

some examples where it makes sense to use this:

- racks in an incubator that rotate
- plates in a centrifuge
- resources like pumps where the location in the workcell is arbitrary and inconsequential

obviously, getting the absolute location and some other things may not work when the location is None. This was mostly already checked for (is the location defined?) in plr. That's why this pr is a +9-6 edit.