### PR TITLE
configure trash on decks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - put_direction -> drop_direction
 - `location` parameter of `assign_child_resource` is not optional (https://github.com/PyLabRobot/pylabrobot/pull/336)
 - `Resource.get_absolute_location` raises `NoLocationError` instead of `AssertionError` when absolute location is not defined (https://github.com/PyLabRobot/pylabrobot/pull/338)
+- `no_trash` and `no_teaching_rack` were renamed to `with_trash` and `with_teaching_rack` to avoid double negatives (https://github.com/PyLabRobot/pylabrobot/pull/347)
 
 ### Added
 
@@ -143,6 +144,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - `hotel_high_speed=False`
     - `use_unsafe_hotel: bool = False`
     - `iswap_collision_control_level: int = 0`
+- `with_trash96` on `HamiltonSTARDeck` so there is more fine grained control (https://github.com/PyLabRobot/pylabrobot/pull/347)
 
 ### Deprecated
 

--- a/pylabrobot/resources/hamilton/hamilton_decks.py
+++ b/pylabrobot/resources/hamilton/hamilton_decks.py
@@ -378,7 +378,9 @@ class HamiltonSTARDeck(HamiltonDeck):
     if no_trash is not None:
       raise NotImplementedError("no_trash is deprecated. Use with_trash=False instead.")
     if no_teaching_rack is not None:
-      raise NotImplementedError("no_teaching_rack is deprecated. Use with_teaching_rack=False instead.")
+      raise NotImplementedError(
+        "no_teaching_rack is deprecated. Use with_teaching_rack=False instead."
+      )
 
     # assign trash area
     if with_trash:
@@ -443,7 +445,9 @@ class HamiltonSTARDeck(HamiltonDeck):
 
   def get_trash_area96(self) -> Trash:
     if self._trash96 is None:
-      raise RuntimeError("Trash area for 96-well plates was not created. Initialize with `with_trash96=True`.")
+      raise RuntimeError(
+        "Trash area for 96-well plates was not created. Initialize with `with_trash96=True`."
+      )
     return self._trash96
 
 

--- a/pylabrobot/resources/hamilton/hamilton_decks.py
+++ b/pylabrobot/resources/hamilton/hamilton_decks.py
@@ -360,8 +360,8 @@ class HamiltonSTARDeck(HamiltonDeck):
     with_trash: bool = True,
     with_trash96: bool = True,
     with_teaching_rack: bool = True,
-    no_trash: Optional[bool] = False,
-    no_teaching_rack: Optional[bool] = False,
+    no_trash: Optional[bool] = None,
+    no_teaching_rack: Optional[bool] = None,
   ) -> None:
     """Create a new STAR(let) deck of the given size."""
 

--- a/pylabrobot/resources/hamilton/vantage_decks.py
+++ b/pylabrobot/resources/hamilton/vantage_decks.py
@@ -15,7 +15,7 @@ class VantageDeck(HamiltonDeck):
     name="deck",
     category: str = "deck",
     origin: Coordinate = Coordinate.zero(),
-    no_trash: bool = False,
+    with_trash: bool = True,
   ) -> None:
     """Create a new Vantage deck of the given size.
 
@@ -41,7 +41,7 @@ class VantageDeck(HamiltonDeck):
       )
       self.size = 1.3
 
-      if not no_trash:
+      if with_trash:
         trash_x = size_x - 480  # works with vantage 1.3 (480) (used to be 460)
 
         # an experimentally informed guess.

--- a/pylabrobot/resources/opentrons/deck.py
+++ b/pylabrobot/resources/opentrons/deck.py
@@ -16,7 +16,7 @@ class OTDeck(Deck):
     size_y: float = 565.2,
     size_z: float = 900,
     origin: Coordinate = Coordinate(0, 0, 0),
-    no_trash: bool = False,
+    with_trash: bool = True,
     name: str = "deck",
   ):
     # size_z is probably wrong
@@ -40,7 +40,7 @@ class OTDeck(Deck):
       Coordinate(x=265.0, y=271.5, z=0.0),
     ]
 
-    if not no_trash:
+    if with_trash:
       self._assign_trash()
 
   def _assign_trash(self):

--- a/pylabrobot/visualizer/lib.js
+++ b/pylabrobot/visualizer/lib.js
@@ -469,7 +469,8 @@ class HamiltonSTARDeck extends Deck {
       ...super.serialize(),
       ...{
         num_rails: this.num_rails,
-        no_trash: true,
+        with_trash: false,
+        with_trash96: false,
       },
     };
   }
@@ -547,7 +548,7 @@ class OTDeck extends Deck {
     return {
       ...super.serialize(),
       ...{
-        no_trash: true,
+        with_trash: false,
       },
     };
   }


### PR DESCRIPTION
- no_trash was renamed to with_trash to avoid double negatives
- with_trash96 on HamiltonSTARDeck so there is more fine grained control (before this was also under no_trash)