### PR TITLE
remove init cytomat from setup, increase timeout on init when called directly

### DIFF
--- a/pylabrobot/incubators/cytomat/cytomat.py
+++ b/pylabrobot/incubators/cytomat/cytomat.py
@@ -71,7 +71,9 @@ class Cytomat(IncubatorBackend):
       raise e
 
     await self.wait_for_task_completion()
-    await self.initialize()
+    res = await self.get_overview_register()
+    print("res", res)
+    # await self.initialize()
 
   async def set_racks(self, racks: List[PlateCarrier]):
     await super().set_racks(racks)
@@ -170,7 +172,7 @@ class Cytomat(IncubatorBackend):
     await self.send_command("rs", "be", "")
 
   async def initialize(self) -> None:
-    await self.send_action("ll", "in", "")
+    await self.send_action("ll", "in", "", timeout=120)  # this command sometimes times out
 
   async def open_door(self):
     return await self.send_action("ll", "gp", "002")
@@ -347,7 +349,7 @@ class Cytomat(IncubatorBackend):
 class CytomatChatterbox(Cytomat):
   async def setup(self):
     await self.wait_for_task_completion()
-    await self.initialize()
+    # await self.initialize()
 
   async def stop(self):
     print("closing connection to cytomat")

--- a/pylabrobot/incubators/cytomat/cytomat.py
+++ b/pylabrobot/incubators/cytomat/cytomat.py
@@ -347,7 +347,6 @@ class Cytomat(IncubatorBackend):
 class CytomatChatterbox(Cytomat):
   async def setup(self):
     await self.wait_for_task_completion()
-    # await self.initialize()
 
   async def stop(self):
     print("closing connection to cytomat")

--- a/pylabrobot/incubators/cytomat/cytomat.py
+++ b/pylabrobot/incubators/cytomat/cytomat.py
@@ -71,9 +71,7 @@ class Cytomat(IncubatorBackend):
       raise e
 
     await self.wait_for_task_completion()
-    res = await self.get_overview_register()
-    print("res", res)
-    # await self.initialize()
+    await self.get_overview_register()
 
   async def set_racks(self, racks: List[PlateCarrier]):
     await super().set_racks(racks)

--- a/pylabrobot/incubators/cytomat/cytomat.py
+++ b/pylabrobot/incubators/cytomat/cytomat.py
@@ -71,7 +71,6 @@ class Cytomat(IncubatorBackend):
       raise e
 
     await self.wait_for_task_completion()
-    await self.get_overview_register()
 
   async def set_racks(self, racks: List[PlateCarrier]):
     await super().set_racks(racks)

--- a/pylabrobot/incubators/incubator.py
+++ b/pylabrobot/incubators/incubator.py
@@ -53,7 +53,7 @@ class Incubator(Machine, Resource):
 
     self._racks = racks
     for rack in self._racks:
-      self.assign_child_resource(rack, location=Coordinate(0, 0, 0))
+      self.assign_child_resource(rack, location=None)
 
   @property
   def racks(self) -> List[PlateCarrier]:

--- a/pylabrobot/incubators/incubator.py
+++ b/pylabrobot/incubators/incubator.py
@@ -53,7 +53,7 @@ class Incubator(Machine, Resource):
 
     self._racks = racks
     for rack in self._racks:
-      self.assign_child_resource(rack, location=None)
+      self.assign_child_resource(rack, location=Coordinate(0, 0, 0))
 
   @property
   def racks(self) -> List[PlateCarrier]:


### PR DESCRIPTION
cytomats are typically configured to self-initialize on power-up. this means we don't typically need to call init() on startup. plus, this unnnec. init adds 1-2 minutes every time the jupyter kernel is refreshed and the device needs to be connected

on some cytomats, init can take longer, so i doubled the default timeout to 2 minutes