### PR TITLE
Fix ztouch Probing

### DIFF
--- a/docs/user_guide/centrifuge.md
+++ b/docs/user_guide/centrifuge.md
@@ -137,15 +137,12 @@ To interact with the centrifuge programmatically, you need its FTDI device ID. U
 Use the following code to configure the centrifuge in Python:
 
 ```python
-from pylabrobot.centrifuge import Centrifuge, VSpin
+from pylabrobot import Centrifuge
+from pylabrobot.backends.vspin import VSpin
 
 # Replace with your specific FTDI device ID and bucket position for profile in Agilent Centrifuge Config Tool.
 backend = VSpin(bucket_1_position=6969, device_id="XXXXXXXX")
-centrifuge = Centrifuge(
-   backend=backend,
-   name="centrifuge",
-   size_x=1, size_y=1, size_z=1
-)
+centrifuge = Centrifuge(backend=backend)
 
 # Initialize the centrifuge.
 await centrifuge.setup()

--- a/docs/user_guide/centrifuge.md
+++ b/docs/user_guide/centrifuge.md
@@ -137,12 +137,15 @@ To interact with the centrifuge programmatically, you need its FTDI device ID. U
 Use the following code to configure the centrifuge in Python:
 
 ```python
-from pylabrobot import Centrifuge
-from pylabrobot.backends.vspin import VSpin
+from pylabrobot.centrifuge import Centrifuge, VSpin
 
 # Replace with your specific FTDI device ID and bucket position for profile in Agilent Centrifuge Config Tool.
 backend = VSpin(bucket_1_position=6969, device_id="XXXXXXXX")
-centrifuge = Centrifuge(backend=backend)
+centrifuge = Centrifuge(
+   backend=backend,
+   name="centrifuge",
+   size_x=1, size_y=1, size_z=1
+)
 
 # Initialize the centrifuge.
 await centrifuge.setup()

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -7382,9 +7382,10 @@ class STAR(HamiltonLiquidHandler):
       tip_len = await self.request_tip_len_on_channel(channel_idx=channel_idx)
 
     tip_len_used_in_increments = (tip_len - fitting_depth) / STAR.z_drive_mm_per_increment
+    tip_adjusted_start_pos = start_pos_search + tip_len # start_pos of the head itself!
 
     lowest_immers_pos_increments = STAR.mm_to_z_drive_increment(lowest_immers_pos)
-    start_pos_search_increments = STAR.mm_to_z_drive_increment(start_pos_search)
+    start_pos_search_increments = STAR.mm_to_z_drive_increment(tip_adjusted_start_pos)
     channel_speed_increments = STAR.mm_to_z_drive_increment(channel_speed)
     channel_acceleration_thousand_increments = STAR.mm_to_z_drive_increment(
       channel_acceleration / 1000

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -7384,8 +7384,12 @@ class STAR(HamiltonLiquidHandler):
       start_pos_search = 334.7 - tip_len + fitting_depth
 
     tip_len_used_in_increments = (tip_len - fitting_depth) / STAR.z_drive_mm_per_increment
-    channel_head_start_pos = start_pos_search + tip_len - fitting_depth # start_pos of the head itself!
-    safe_head_bottom_z_pos = 99.98 + tip_len - fitting_depth # 99.98 == STAR.z_drive_increment_to_mm(9_320)
+    channel_head_start_pos = (
+      start_pos_search + tip_len - fitting_depth
+    )  # start_pos of the head itself!
+    safe_head_bottom_z_pos = (
+      99.98 + tip_len - fitting_depth
+    )  # 99.98 == STAR.z_drive_increment_to_mm(9_320)
     safe_head_top_z_pos = 334.7  # 334.7 == STAR.z_drive_increment_to_mm(31_200)
 
     lowest_immers_pos_increments = STAR.mm_to_z_drive_increment(lowest_immers_pos)

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -7381,11 +7381,11 @@ class STAR(HamiltonLiquidHandler):
     if tip_len is None:
       tip_len = await self.request_tip_len_on_channel(channel_idx=channel_idx)
     if start_pos_search is None:
-      start_pos_search = 334.7 - tip_len
+      start_pos_search = 334.7 - tip_len + fitting_depth
 
     tip_len_used_in_increments = (tip_len - fitting_depth) / STAR.z_drive_mm_per_increment
-    channel_head_start_pos = start_pos_search + tip_len # start_pos of the head itself!
-    safe_head_bottom_z_pos = 99.98 + tip_len # 99.98 == STAR.z_drive_increment_to_mm(9_320) 
+    channel_head_start_pos = start_pos_search + tip_len - fitting_depth # start_pos of the head itself!
+    safe_head_bottom_z_pos = 99.98 + tip_len - fitting_depth # 99.98 == STAR.z_drive_increment_to_mm(9_320)
     safe_head_top_z_pos = 334.7  # 334.7 == STAR.z_drive_increment_to_mm(31_200)
 
     lowest_immers_pos_increments = STAR.mm_to_z_drive_increment(lowest_immers_pos)

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -7336,7 +7336,7 @@ class STAR(HamiltonLiquidHandler):
     channel_idx: int,  # 0-based indexing of channels!
     tip_len: Optional[float] = None,  # mm
     lowest_immers_pos: float = 99.98,  # mm
-    start_pos_search: float = 330.0,  # mm
+    start_pos_search: Optional[float] = None,  # mm
     channel_speed: float = 10.0,  # mm/sec
     channel_acceleration: float = 800.0,  # mm/sec**2
     channel_speed_upwards: float = 125.0,  # mm
@@ -7380,12 +7380,16 @@ class STAR(HamiltonLiquidHandler):
 
     if tip_len is None:
       tip_len = await self.request_tip_len_on_channel(channel_idx=channel_idx)
+    if start_pos_search is None:
+      start_pos_search = 334.7 - tip_len
 
     tip_len_used_in_increments = (tip_len - fitting_depth) / STAR.z_drive_mm_per_increment
-    tip_adjusted_start_pos = start_pos_search + tip_len # start_pos of the head itself!
+    channel_head_start_pos = start_pos_search + tip_len # start_pos of the head itself!
+    safe_head_bottom_z_pos = 99.98 + tip_len # 99.98 == STAR.z_drive_increment_to_mm(9_320) 
+    safe_head_top_z_pos = 334.7  # 334.7 == STAR.z_drive_increment_to_mm(31_200)
 
     lowest_immers_pos_increments = STAR.mm_to_z_drive_increment(lowest_immers_pos)
-    start_pos_search_increments = STAR.mm_to_z_drive_increment(tip_adjusted_start_pos)
+    start_pos_search_increments = STAR.mm_to_z_drive_increment(channel_head_start_pos)
     channel_speed_increments = STAR.mm_to_z_drive_increment(channel_speed)
     channel_acceleration_thousand_increments = STAR.mm_to_z_drive_increment(
       channel_acceleration / 1000
@@ -7396,12 +7400,12 @@ class STAR(HamiltonLiquidHandler):
     assert 20 <= tip_len <= 120, "Total tip length must be between 20 and 120"
 
     assert 9320 <= lowest_immers_pos_increments <= 31_200, (
-      f"Lowest immersion position must be between \n{STAR.z_drive_increment_to_mm(9_320)}"
-      + f" and {STAR.z_drive_increment_to_mm(31_200)} mm, is {lowest_immers_pos} mm"
+      "Lowest immersion position must be between \n99.98"
+      + f" and 334.7 mm, is {lowest_immers_pos} mm"
     )
-    assert 9320 <= start_pos_search_increments <= 31_200, (
-      f"Start position of LLD search must be between \n{STAR.z_drive_increment_to_mm(9_320)}"
-      + f" and {STAR.z_drive_increment_to_mm(31_200)} mm, is {start_pos_search} mm"
+    assert safe_head_bottom_z_pos <= channel_head_start_pos <= safe_head_top_z_pos, (
+      f"Start position of LLD search must be between \n{safe_head_bottom_z_pos}"
+      + f" and {safe_head_top_z_pos} mm, is {channel_head_start_pos} mm"
     )
     assert 20 <= channel_speed_increments <= 15_000, (
       f"Z-touch search speed must be between \n{STAR.z_drive_increment_to_mm(20)}"


### PR DESCRIPTION
Hi everyone,

In PR #260  I created `STAR.ztouch_probe_z_height_using_channel()`.

This function had a hidden bug that I missed which is being fixed in this PR:

## Problem Statement

The previous implementation of `STAR.ztouch_probe_z_height_using_channel()` does return the correct z-height of the material it detects.

**But** its `start_pos_search` attribute has been incorrect:
I believed that he firmware commands for this attribute represent the z_position of the tip_bottom because the `STAR.request_z_pos_channel_n(channel_idx)` returns the tip_bottom.
I now figured out this is false -> the firmware commands expect the z_position of the channel_head_bottom!

This means that every time `start_pos_search`, and we assume the tip_bottom to go to that z_coordinate to start the search, the tip actually moves at default speed (i.e. very fast) 59.9 mm further down in the z-dimension!
(59.9 mm when using a 300ul or a standard teaching needle)

This will most likely result in a crash of the tip into the item it is aimed at measuring.
Interestingly, this crash does not hinder the ztouch method, it still works. But the potential crash is not intended and probably not very good for the channels!

The most likely reason as to why this issue has stayed undetected thus far is that people haven't extensively specified `start_pos_search` until now but instead left this attribute out, leaving it to default, i.e. the search starts at the safe_z_height.

## PR Content

I am fixing this issues by adapting the start position based on the length of the tip /needle that is attached to the channel - the tip's fitting_depth, visualised in this infographic:
![250109_Moschner_ztouch_probe_explainer](https://github.com/user-attachments/assets/67635d09-a80f-42b3-8120-b32e0b5abc5e)

With these fixes in place `start_pos_search` appears to work exactly as expected on our machines:

-> `start_pos_search` = the z-height at which the tip_bottom starts searching for an item below it


