### PR TITLE
Safety Feature: Protect Channels during y-Movement

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -2998,7 +2998,7 @@ class STAR(HamiltonLiquidHandler):
     else:
       channel_idx_plus_one_y_pos = 6
       # Insight: STAR machines appear to lose connection to a channel
-      # if y < 6 mm OR y > 635 mm 
+      # if y < 6 mm OR y > 635 mm
 
     max_safe_upper_y_pos = channel_idx_minus_one_y_pos - 9
     max_safe_lower_y_pos = channel_idx_plus_one_y_pos + 9 if channel_idx_plus_one_y_pos != 0 else 6

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -3005,10 +3005,10 @@ class STAR(HamiltonLiquidHandler):
 
     assert current_y_pos != y, f"Channel {channel} already at y-position = {y}"
     assert max_safe_lower_y_pos <= y <= max_safe_upper_y_pos, (
-      f"Channel {channel} y-target must be >= {max_safe_lower_y_pos} and"
+      f"channel_{channel} y-target must be >= {max_safe_lower_y_pos} and"
       + f" <= {max_safe_upper_y_pos}, is {round(y,2)} mm,\n"
       + f"  current y-position = {current_y_pos} mm,\n"
-      + f"  Can you move the neighboring channels to create space for channel {channel}?"
+      + f"  Can you move the neighboring channels to create space for channel_{channel}?"
     )
 
     await self.position_single_pipetting_channel_in_y_direction(


### PR DESCRIPTION
Hi everyone,

This is an anti-crash PLR Safety Feature for channel movements in the y-dimension.

## Problem Statement

Currently `STAR.move_channel_y(channel: int, y: float)` simply requests the machine to move a channel with a specified index to a `y` position, regardless of whether another channel might be in the way.

PLR users are forced to humanly memorise where each channel is in the y-position if they wanted to avoid crashes.

As a result, crashes of one channel into another are very likely to occur.

## PR Content

I have added a couple of lines of code to `STAR.move_channel_y(channel: int, y: float)` which calculate the neighbouring channels' y-positions and the safe y-space (i.e. 6 - 635 mm in y-dimension) and raises an error if the target y-value does not fall into the safe y-range.

**Example 0**: channel_2 is surrounded by channels (i.e. there is a 9mm distance to them) -> triggers...
```python
await lh.backend.move_channel_y(
    y= 496.0,
    channel=2
)

AssertionError: channel_2 y-target must be >= 50.9 and <= 50.9, is 496.0 mm,
  current y-position = 50.9 mm,
  Can you move the neighboring channels to create space for channel_2?
```

**Example 1**: channel_0 is tasked to move outside the safe y-range -> triggers...
```python
await lh.backend.move_channel_y(
    y= 640,
    channel=0
)

AssertionError: channel_0 y-target must be >= 68.9 and <= 635, is 640 mm,
  current y-position = 528.6 mm,
  Can you move the neighboring channels to create space for channel_0?
```

**Example 2**: channel_0 is tasked to move "through" other channels -> triggers...
```python
await lh.backend.move_channel_y(
    y= 60,
    channel=0
)

AssertionError: channel_0 y-target must be >= 68.9 and <= 635, is 60 mm,
  current y-position = 528.6 mm,
  Can you move the neighboring channels to create space for channel_0?
```

## Next steps
I have added an assertion error if the channel is asked to move to the y-position that it already is in... I am not sure whether this is needed (I'm leaning towards removing it) but wanted to ask you for your opinion on this?

