### PR TITLE
step_off_foil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - `iswap_collision_control_level: int = 0`
 - `with_trash96` on `HamiltonSTARDeck` so there is more fine grained control (https://github.com/PyLabRobot/pylabrobot/pull/347)
 - add `STAR.{get_channels_z_positions, position_channels_in_z_direction}` (https://github.com/PyLabRobot/pylabrobot/pull/356)
+- `STAR.step_off_foil` (https://github.com/PyLabRobot/pylabrobot/pull/357)
 
 ### Deprecated
 


### PR DESCRIPTION
https://youtube.com/shorts/L8cKzbF2jks

Hold down a plate by placing two channels on the edges of a plate that is sealed with foil
while moving up the channels that are still within the foil. This is useful when, for
example, aspirating from a plate that is sealed: without holding it down, the tips might get
stuck in the plate and move it up when retracting. Putting plates on the edge prevents this.

When aspirating or dispensing in the foil, be sure to set the `min_z_endpos` parameter in
`lh.aspirate` or `lh.dispense` to a value in the foil. You might want to use something like

```python
well = plate.get_well("A3")
await wc.lh.aspirate(
  [well]*4, vols=[100]*4, use_channels=[7,8,9,10],
  min_z_endpos=well.get_absolute_location(z="cavity_bottom").z,
  surface_following_distance=0,
  pull_out_distance_transport_air=[0] * 4)
await step_off_foil(lh.backend, well, front_channel=11, back_channel=6, move_inwards = 3)
```