### PR TITLE
move to rotated resource

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -2902,7 +2902,7 @@ class STAR(HamiltonLiquidHandler):
       # The computation of the center has to be rotated so that the offset is in absolute space.
       center_in_absolute_space = Coordinate(
         *matrix_vector_multiply_3x3(
-          drop.resource.rotated(z=drop.rotation).get_absolute_rotation().get_rotation_matrix(),
+          drop.resource.rotated(z=drop.rotation + drop.destination_absolute_rotation.z).get_absolute_rotation().get_rotation_matrix(),
           drop.resource.center().vector(),
         )
       )

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -2892,9 +2892,13 @@ class STAR(HamiltonLiquidHandler):
       # original grip direction. Hack.
       # the resource still has its original orientation.
       if drop.direction in (GripDirection.FRONT, GripDirection.BACK):
-        plate_width = drop.resource.rotated(z=drop.rotation + drop.destination_absolute_rotation.z).get_absolute_size_x()
+        plate_width = drop.resource.rotated(
+          z=drop.rotation + drop.destination_absolute_rotation.z
+        ).get_absolute_size_x()
       elif drop.direction in (GripDirection.RIGHT, GripDirection.LEFT):
-        plate_width = drop.resource.rotated(z=drop.rotation + drop.destination_absolute_rotation.z).get_absolute_size_y()
+        plate_width = drop.resource.rotated(
+          z=drop.rotation + drop.destination_absolute_rotation.z
+        ).get_absolute_size_y()
       else:
         raise ValueError("Invalid grip direction")
 

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -2902,7 +2902,9 @@ class STAR(HamiltonLiquidHandler):
       # The computation of the center has to be rotated so that the offset is in absolute space.
       center_in_absolute_space = Coordinate(
         *matrix_vector_multiply_3x3(
-          drop.resource.rotated(z=drop.rotation + drop.destination_absolute_rotation.z).get_absolute_rotation().get_rotation_matrix(),
+          drop.resource.rotated(z=drop.rotation + drop.destination_absolute_rotation.z)
+          .get_absolute_rotation()
+          .get_rotation_matrix(),
           drop.resource.center().vector(),
         )
       )

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -2892,9 +2892,9 @@ class STAR(HamiltonLiquidHandler):
       # original grip direction. Hack.
       # the resource still has its original orientation.
       if drop.direction in (GripDirection.FRONT, GripDirection.BACK):
-        plate_width = drop.resource.rotated(z=drop.rotation).get_absolute_size_x()
+        plate_width = drop.resource.rotated(z=drop.rotation + drop.destination_absolute_rotation.z).get_absolute_size_x()
       elif drop.direction in (GripDirection.RIGHT, GripDirection.LEFT):
-        plate_width = drop.resource.rotated(z=drop.rotation).get_absolute_size_y()
+        plate_width = drop.resource.rotated(z=drop.rotation + drop.destination_absolute_rotation.z).get_absolute_size_y()
       else:
         raise ValueError("Invalid grip direction")
 

--- a/pylabrobot/liquid_handling/backends/tecan/EVO_tests.py
+++ b/pylabrobot/liquid_handling/backends/tecan/EVO_tests.py
@@ -16,6 +16,7 @@ from pylabrobot.liquid_handling.standard import (
   ResourceDrop,
   ResourcePickup,
 )
+from pylabrobot.resources.rotation import Rotation
 from pylabrobot.resources import (
   Coordinate,
   DeepWell_96_Well,
@@ -340,6 +341,7 @@ class EVOTests(unittest.IsolatedAsyncioTestCase):
     drop = ResourceDrop(
       resource=self.plate,
       destination=self.plate_carrier[0].get_absolute_location(),
+      destination_absolute_rotation=Rotation(0, 0, 0),
       offset=Coordinate.zero(),
       pickup_distance_from_top=13.2,
       direction=GripDirection.FRONT,

--- a/pylabrobot/liquid_handling/backends/tecan/EVO_tests.py
+++ b/pylabrobot/liquid_handling/backends/tecan/EVO_tests.py
@@ -16,7 +16,6 @@ from pylabrobot.liquid_handling.standard import (
   ResourceDrop,
   ResourcePickup,
 )
-from pylabrobot.resources.rotation import Rotation
 from pylabrobot.resources import (
   Coordinate,
   DeepWell_96_Well,
@@ -25,6 +24,7 @@ from pylabrobot.resources import (
   EVO150Deck,
   MP_3Pos_PCR,
 )
+from pylabrobot.resources.rotation import Rotation
 
 
 class EVOTests(unittest.IsolatedAsyncioTestCase):

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1878,6 +1878,7 @@ class LiquidHandler(Resource, Machine):
     drop = ResourceDrop(
       resource=self._resource_pickup.resource,
       destination=to_location,
+      destination_absolute_rotation=destination.get_absolute_rotation(),
       offset=offset,
       pickup_distance_from_top=self._resource_pickup.pickup_distance_from_top,
       direction=direction,

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -30,7 +30,6 @@ from pylabrobot.liquid_handling.strictness import (
 )
 from pylabrobot.machines.machine import Machine, need_setup_finished
 from pylabrobot.plate_reading import PlateReader
-from pylabrobot.resources.rotation import Rotation
 from pylabrobot.resources import (
   Container,
   Coordinate,
@@ -55,6 +54,7 @@ from pylabrobot.resources import (
 )
 from pylabrobot.resources.errors import CrossContaminationError, HasTipError
 from pylabrobot.resources.liquid import Liquid
+from pylabrobot.resources.rotation import Rotation
 from pylabrobot.tilting.tilter import Tilter
 
 from .backends import LiquidHandlerBackend
@@ -1922,7 +1922,9 @@ class LiquidHandler(Resource, Machine):
     drop = ResourceDrop(
       resource=self._resource_pickup.resource,
       destination=to_location,
-      destination_absolute_rotation=destination.get_absolute_rotation() if isinstance(destination, Resource) else Rotation(0, 0, 0),
+      destination_absolute_rotation=destination.get_absolute_rotation()
+      if isinstance(destination, Resource)
+      else Rotation(0, 0, 0),
       offset=offset,
       pickup_distance_from_top=self._resource_pickup.pickup_distance_from_top,
       direction=direction,

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -30,6 +30,7 @@ from pylabrobot.liquid_handling.strictness import (
 )
 from pylabrobot.machines.machine import Machine, need_setup_finished
 from pylabrobot.plate_reading import PlateReader
+from pylabrobot.resources.rotation import Rotation
 from pylabrobot.resources import (
   Container,
   Coordinate,
@@ -1921,7 +1922,7 @@ class LiquidHandler(Resource, Machine):
     drop = ResourceDrop(
       resource=self._resource_pickup.resource,
       destination=to_location,
-      destination_absolute_rotation=destination.get_absolute_rotation(),
+      destination_absolute_rotation=destination.get_absolute_rotation() if isinstance(destination, Resource) else Rotation(0, 0, 0),
       offset=offset,
       pickup_distance_from_top=self._resource_pickup.pickup_distance_from_top,
       direction=direction,

--- a/pylabrobot/liquid_handling/standard.py
+++ b/pylabrobot/liquid_handling/standard.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 from pylabrobot.resources.coordinate import Coordinate
 from pylabrobot.resources.liquid import Liquid
+from pylabrobot.resources.rotation import Rotation
 
 if TYPE_CHECKING:
   from pylabrobot.resources import (
@@ -147,6 +148,7 @@ class ResourceMove:
 class ResourceDrop:
   resource: Resource
   destination: Coordinate
+  destination_absolute_rotation: Rotation
   offset: Coordinate
   pickup_distance_from_top: float
   direction: GripDirection


### PR DESCRIPTION
Before this, dropping a rotated lid was not applying the rotation of the destination properly.