### PR TITLE
add init back into cytomat

### DIFF
--- a/pylabrobot/incubators/cytomat/cytomat.py
+++ b/pylabrobot/incubators/cytomat/cytomat.py
@@ -70,6 +70,7 @@ class Cytomat(IncubatorBackend):
       logger.error("Could not connect to cytomat, is it in use by a different notebook?")
       raise e
 
+    await self.initialize()
     await self.wait_for_task_completion()
 
   async def set_racks(self, racks: List[PlateCarrier]):


### PR DESCRIPTION
some cytomats are configured in the .exe service software to automatically init on startup, others are not. adding back init makes this more robust across different configs