### PR TITLE
Update using-the-visualizer.ipynb

### DIFF
--- a/docs/user_guide/using-the-visualizer.ipynb
+++ b/docs/user_guide/using-the-visualizer.ipynb
@@ -270,7 +270,7 @@
    "outputs": [],
    "source": [
     "tip_rack4 = lh.deck.get_resource(\"tips_04\")\n",
-    "tip_rack4.set_tip_state([[True]*6 + [False]*6]*8)"
+    "tip_rack4.set_tip_state([True]*48 + [False]*48)"
    ]
   },
   {
@@ -280,7 +280,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tip_rack3.set_tip_state([[True, False]*6]*8)"
+    "tip_rack3.set_tip_state(([True]*8 +[False]*8)*6)"
    ]
   },
   {
@@ -290,7 +290,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tip_rack2.set_tip_state([[True, True, False, False]*3]*8)"
+    "tip_rack2.set_tip_state(([True]*16 +[False]*16)*3)"
    ]
   },
   {


### PR DESCRIPTION
Fixed the set_tip_state() commands in the user guide visualizer notebook for tip rack 2, 3, and 4. The boolean values should be stored in an one dimensional list, filling the rack column by  column. This fixed the visualization problem that I was encountering.