### PR TITLE
add retries to cytomat query overview register

### DIFF
--- a/pylabrobot/incubators/cytomat/cytomat.py
+++ b/pylabrobot/incubators/cytomat/cytomat.py
@@ -70,6 +70,7 @@ class Cytomat(IncubatorBackend):
       logger.error("Could not connect to cytomat, is it in use by a different notebook?")
       raise e
 
+    await self.initialize()
     await self.wait_for_task_completion()
 
   async def set_racks(self, racks: List[PlateCarrier]):


### PR DESCRIPTION
once every 5 or 6 tries, our cytomat 6000 & cytomat 2C will report it is "busy" for longer than an await function takes to complete. this change intends to fix this issue