### PR TITLE
add STAR.pierce_foil

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -26,10 +26,6 @@ from pylabrobot.liquid_handling.liquid_classes.hamilton import (
   HamiltonLiquidClass,
   get_star_liquid_class,
 )
-from pylabrobot.liquid_handling.liquid_handler import (
-  _get_tight_single_resource_liquid_op_offsets,
-  _get_wide_single_resource_liquid_op_offsets,
-)
 from pylabrobot.liquid_handling.standard import (
   Drop,
   DropTipRack,
@@ -46,6 +42,10 @@ from pylabrobot.liquid_handling.standard import (
   ResourcePickup,
   SingleChannelAspiration,
   SingleChannelDispense,
+)
+from pylabrobot.liquid_handling.utils import (
+  get_tight_single_resource_liquid_op_offsets,
+  get_wide_single_resource_liquid_op_offsets,
 )
 from pylabrobot.resources import (
   Carrier,
@@ -7671,30 +7671,30 @@ class STAR(HamiltonLiquidHandler):
     """
 
     x, y, z = well.get_absolute_location("c", "c", "cavity_bottom")
-    await self.lh.move_channel_x(0, x=x)
+    await self.move_channel_x(0, x=x)
 
     if spread == "wide":
-      offsets = _get_wide_single_resource_liquid_op_offsets(
+      offsets = get_wide_single_resource_liquid_op_offsets(
         well, num_channels=len(piercing_channels)
       )
     else:
-      offsets = _get_tight_single_resource_liquid_op_offsets(
+      offsets = get_tight_single_resource_liquid_op_offsets(
         well, num_channels=len(piercing_channels)
       )
     ys = [y + offset.y for offset in offsets]
 
     await self.position_channels_in_y_direction(
-      {channel: y for channel, y in zip(self.config.use_channels, ys)}
+      {channel: y for channel, y in zip(piercing_channels, ys)}
     )
 
     distance_from_bottom = 20
-    zs = [z + distance_from_bottom for _ in range(len(self.config.use_channels))]
+    zs = [z + distance_from_bottom for _ in range(len(piercing_channels))]
     if one_by_one:
       for channel in piercing_channels:
         await self.move_channel_z(channel, z)
     else:
       await self.position_channels_in_z_direction(
-        {channel: z for channel, z in zip(self.config.use_channels, zs)}
+        {channel: z for channel, z in zip(piercing_channels, zs)}
       )
 
     await self.step_off_foil(

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -7689,9 +7689,13 @@ class STAR(HamiltonLiquidHandler):
 
     distance_from_bottom = 20
     zs = [z + distance_from_bottom for _ in range(len(self.config.use_channels))]
-    await self.position_channels_in_z_direction(
-      {channel: z for channel, z in zip(self.config.use_channels, zs)}
-    )
+    if one_by_one:
+      for channel in piercing_channels:
+        await self.move_channel_z(channel, z)
+    else:
+      await self.position_channels_in_z_direction(
+        {channel: z for channel, z in zip(self.config.use_channels, zs)}
+      )
 
     await self.step_off_foil(
       well, back_channel=hold_down_channels[0], front_channel=hold_down_channels[1], move_inwards=3

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -7596,6 +7596,47 @@ class STAR(HamiltonLiquidHandler):
       module="C0", command="JZ", zp=[f"{round(z*10):04}" for z in channel_locations.values()]
     )
 
+  async def pierce_foil(self, media_column: int):
+    """Pierce the foil of the media source plate at the specified column. Throw away the tips
+    after piercing because there will be a bit of foil stuck to the tips. Use this method
+    before aspirating from a foil-sealed plate to make sure the tips are clean and the
+    aspirations are accurate.
+    """
+
+    foil_channels = [self.config.use_channels[0] - 1, self.config.use_channels[-1] + 1]
+    if foil_channels[0] < 0 or foil_channels[1] >= self.lh.backend.num_channels:
+      raise ValueError(
+        "Foil channels are out of range. One channel to the back and one channel to the front of use_channels must be available"
+      )
+
+    well = self.media_source_plate.get_well(media_column - 1)
+
+    await self.pick_up_tips(4)
+    await self.lh.pick_up_tips(self.foil_tips, use_channels=foil_channels)
+    x, y, z = well.get_absolute_location("c", "c", "cavity_bottom")
+    await self.lh.move_channel_x(0, x=x)
+
+    offsets = self.lh._get_single_resource_liquid_op_offsets(well, num_channels=4)
+    ys = [y + offset.y for offset in offsets]
+
+    await self.lh.backend.position_channels_in_y_direction(
+      {channel: y for channel, y in zip(self.config.use_channels, ys)}
+    )
+
+    distance_from_bottom = 20
+    zs = [z + distance_from_bottom for _ in range(len(self.config.use_channels))]
+    await self.lh.backend.position_channels_in_z_direction(
+      {channel: z for channel, z in zip(self.config.use_channels, zs)}
+    )
+
+    await self.lh.backend.step_off_foil(
+      well, back_channel=foil_channels[0], front_channel=foil_channels[1], move_inwards=3
+    )
+
+    # return foil tips, discard piercing tips
+    await self.lh.return_tips(use_channels=foil_channels)
+    await self.lh.discard_tips()
+
   async def step_off_foil(
     self, well: Well, front_channel: int, back_channel: int, move_inwards: float = 2
   ):

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -7714,7 +7714,10 @@ class STAR(HamiltonLiquidHandler):
       )
 
     await self.step_off_foil(
-      well, back_channel=hold_down_channels[0], front_channel=hold_down_channels[1], move_inwards=move_inwards
+      well,
+      back_channel=hold_down_channels[0],
+      front_channel=hold_down_channels[1],
+      move_inwards=move_inwards,
     )
 
   async def step_off_foil(

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -7653,6 +7653,7 @@ class STAR(HamiltonLiquidHandler):
     wells: Union[Well, List[Well]],
     piercing_channels: List[int],
     hold_down_channels: List[int],
+    move_inwards: float,
     spread: Literal["wide", "tight"] = "wide",
     one_by_one: bool = False,
   ):
@@ -7713,7 +7714,7 @@ class STAR(HamiltonLiquidHandler):
       )
 
     await self.step_off_foil(
-      well, back_channel=hold_down_channels[0], front_channel=hold_down_channels[1], move_inwards=3
+      well, back_channel=hold_down_channels[0], front_channel=hold_down_channels[1], move_inwards=move_inwards
     )
 
   async def step_off_foil(

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -29,6 +29,10 @@ from pylabrobot.liquid_handling.strictness import (
   Strictness,
   get_strictness,
 )
+from pylabrobot.liquid_handling.utils import (
+  get_tight_single_resource_liquid_op_offsets,
+  get_wide_single_resource_liquid_op_offsets,
+)
 from pylabrobot.machines.machine import Machine, need_setup_finished
 from pylabrobot.plate_reading import PlateReader
 from pylabrobot.resources import (
@@ -92,16 +96,6 @@ def check_updatable(src_tracker: VolumeTracker, dest_tracker: VolumeTracker):
     not src_tracker.is_cross_contamination_tracking_disabled
     and not dest_tracker.is_cross_contamination_tracking_disabled
   )
-
-
-def _get_centers_with_margin(dim_size: float, n: int, margin: float, min_spacing: float):
-  """Get the centers of the channels with a minimum margin on the edges."""
-  if dim_size < margin * 2 + (n - 1) * min_spacing:
-    raise ValueError("Resource is too small to space channels.")
-  if dim_size - (n - 1) * min_spacing <= min_spacing * 2:
-    remaining_space = dim_size - (n - 1) * min_spacing - margin * 2
-    return [margin + remaining_space / 2 + i * min_spacing for i in range(n)]
-  return [(i + 1) * dim_size / (n + 1) for i in range(n)]
 
 
 class BlowOutVolumeError(Exception):
@@ -721,72 +715,6 @@ class LiquidHandler(Resource, Machine):
     if len(not_containers) > 0:
       raise TypeError(f"Resources must be `Container`s, got {not_containers}")
 
-  def _get_wide_single_resource_liquid_op_offsets(
-    self, resource: Resource, num_channels: int
-  ) -> List[Coordinate]:
-    min_spacing_edge = (
-      2  # minimum spacing between the edge of the container and the center of channel
-    )
-    min_spacing_between_channels = 9
-
-    resource_size: float
-    if resource.get_absolute_rotation().z % 180 == 0:
-      resource_size = resource.get_size_y()
-    elif resource.get_absolute_rotation().z % 90 == 0:
-      resource_size = resource.get_size_x()
-    else:
-      raise ValueError("Only 90 and 180 degree rotations are supported for now.")
-
-    centers = list(
-      reversed(
-        _get_centers_with_margin(
-          dim_size=resource_size,
-          n=num_channels,
-          margin=min_spacing_edge,
-          min_spacing=min_spacing_between_channels,
-        )
-      )
-    )  # reverse because channels are from back to front
-
-    center_offsets: List[Coordinate] = []
-    if resource.get_absolute_rotation().z % 180 == 0:
-      x_offset = resource.get_size_x() / 2
-      center_offsets = [Coordinate(x=x_offset, y=c, z=0) for c in centers]
-    elif resource.get_absolute_rotation().z % 90 == 0:
-      y_offset = resource.get_size_y() / 2
-      center_offsets = [Coordinate(x=c, y=y_offset, z=0) for c in centers]
-
-    # offsets are relative to the center of the resource, but above we computed them wrt lfb
-    # so we need to subtract the center of the resource
-    return [c - resource.center() for c in center_offsets]
-
-  def _get_tight_single_resource_liquid_op_offsets(
-    self, resource: Resource, num_channels: int
-  ) -> List[Coordinate]:
-    min_spacing_between_channels = 9
-    min_spacing_edge = (
-      2  # minimum spacing between the edge of the container and the center of channel
-    )
-
-    channel_space = min_spacing_edge * 2 + (num_channels - 1) * min_spacing_between_channels
-
-    if resource.get_absolute_rotation().z % 180 == 0:
-      min_y = (resource.get_size_y() - channel_space) / 2
-      offsets = [
-        Coordinate(0, min_y + i * min_spacing_between_channels, 0) for i in range(num_channels)
-      ]
-    elif resource.get_absolute_rotation().z % 90 == 0:
-      min_x = (resource.get_size_x() - channel_space) / 2
-      offsets = [
-        Coordinate(min_x + i * min_spacing_between_channels, 0, 0) for i in range(num_channels)
-      ]
-    else:
-      raise ValueError("Only 90 and 180 degree rotations are supported for now.")
-
-    # offsets are relative to the center of the resource, but above we computed them wrt lfb
-    # so we need to subtract the center of the resource
-    return [o - resource.center() for o in offsets]
-
   @need_setup_finished
   async def aspirate(
     self,
@@ -887,11 +815,11 @@ class LiquidHandler(Resource, Machine):
       resource = resources[0]
       resources = [resource] * len(use_channels)
       if spread == "tight":
-        center_offsets = self._get_tight_single_resource_liquid_op_offsets(
+        center_offsets = get_tight_single_resource_liquid_op_offsets(
           resource=resource, num_channels=len(use_channels)
         )
       else:  # wide
-        center_offsets = self._get_wide_single_resource_liquid_op_offsets(
+        center_offsets = get_wide_single_resource_liquid_op_offsets(
           resource=resource, num_channels=len(use_channels)
         )
 
@@ -1080,11 +1008,11 @@ class LiquidHandler(Resource, Machine):
       resource = resources[0]
       resources = [resource] * len(use_channels)
       if spread == "tight":
-        center_offsets = self._get_tight_single_resource_liquid_op_offsets(
+        center_offsets = get_tight_single_resource_liquid_op_offsets(
           resource=resource, num_channels=len(use_channels)
         )
       else:
-        center_offsets = self._get_wide_single_resource_liquid_op_offsets(
+        center_offsets = get_wide_single_resource_liquid_op_offsets(
           resource=resource, num_channels=len(use_channels)
         )
 

--- a/pylabrobot/liquid_handling/utils.py
+++ b/pylabrobot/liquid_handling/utils.py
@@ -1,0 +1,82 @@
+from typing import List
+
+from pylabrobot.resources.coordinate import Coordinate
+from pylabrobot.resources.resource import Resource
+
+
+def _get_centers_with_margin(dim_size: float, n: int, margin: float, min_spacing: float):
+  """Get the centers of the channels with a minimum margin on the edges."""
+  if dim_size < margin * 2 + (n - 1) * min_spacing:
+    raise ValueError("Resource is too small to space channels.")
+  if dim_size - (n - 1) * min_spacing <= min_spacing * 2:
+    remaining_space = dim_size - (n - 1) * min_spacing - margin * 2
+    return [margin + remaining_space / 2 + i * min_spacing for i in range(n)]
+  return [(i + 1) * dim_size / (n + 1) for i in range(n)]
+
+
+def get_wide_single_resource_liquid_op_offsets(
+  resource: Resource, num_channels: int
+) -> List[Coordinate]:
+  min_spacing_edge = (
+    2  # minimum spacing between the edge of the container and the center of channel
+  )
+  min_spacing_between_channels = 9
+
+  resource_size: float
+  if resource.get_absolute_rotation().z % 180 == 0:
+    resource_size = resource.get_size_y()
+  elif resource.get_absolute_rotation().z % 90 == 0:
+    resource_size = resource.get_size_x()
+  else:
+    raise ValueError("Only 90 and 180 degree rotations are supported for now.")
+
+  centers = list(
+    reversed(
+      _get_centers_with_margin(
+        dim_size=resource_size,
+        n=num_channels,
+        margin=min_spacing_edge,
+        min_spacing=min_spacing_between_channels,
+      )
+    )
+  )  # reverse because channels are from back to front
+
+  center_offsets: List[Coordinate] = []
+  if resource.get_absolute_rotation().z % 180 == 0:
+    x_offset = resource.get_size_x() / 2
+    center_offsets = [Coordinate(x=x_offset, y=c, z=0) for c in centers]
+  elif resource.get_absolute_rotation().z % 90 == 0:
+    y_offset = resource.get_size_y() / 2
+    center_offsets = [Coordinate(x=c, y=y_offset, z=0) for c in centers]
+
+  # offsets are relative to the center of the resource, but above we computed them wrt lfb
+  # so we need to subtract the center of the resource
+  return [c - resource.center() for c in center_offsets]
+
+
+def get_tight_single_resource_liquid_op_offsets(
+  resource: Resource, num_channels: int
+) -> List[Coordinate]:
+  min_spacing_between_channels = 9
+  min_spacing_edge = (
+    2  # minimum spacing between the edge of the container and the center of channel
+  )
+
+  channel_space = min_spacing_edge * 2 + (num_channels - 1) * min_spacing_between_channels
+
+  if resource.get_absolute_rotation().z % 180 == 0:
+    min_y = (resource.get_size_y() - channel_space) / 2
+    offsets = [
+      Coordinate(0, min_y + i * min_spacing_between_channels, 0) for i in range(num_channels)
+    ]
+  elif resource.get_absolute_rotation().z % 90 == 0:
+    min_x = (resource.get_size_x() - channel_space) / 2
+    offsets = [
+      Coordinate(min_x + i * min_spacing_between_channels, 0, 0) for i in range(num_channels)
+    ]
+  else:
+    raise ValueError("Only 90 and 180 degree rotations are supported for now.")
+
+  # offsets are relative to the center of the resource, but above we computed them wrt lfb
+  # so we need to subtract the center of the resource
+  return [o - resource.center() for o in offsets]

--- a/pylabrobot/liquid_handling/utils.py
+++ b/pylabrobot/liquid_handling/utils.py
@@ -62,18 +62,20 @@ def get_tight_single_resource_liquid_op_offsets(
     2  # minimum spacing between the edge of the container and the center of channel
   )
 
-  channel_space = min_spacing_edge * 2 + (num_channels - 1) * min_spacing_between_channels
+  channel_space = (num_channels - 1) * min_spacing_between_channels
 
   if resource.get_absolute_rotation().z % 180 == 0:
     min_y = (resource.get_size_y() - channel_space) / 2
+    if min_y < min_spacing_edge:
+      raise ValueError("Resource is too small to space channels.")
     offsets = [
       Coordinate(0, min_y + i * min_spacing_between_channels, 0) for i in range(num_channels)
-    ]
+    ][::-1]
   elif resource.get_absolute_rotation().z % 90 == 0:
     min_x = (resource.get_size_x() - channel_space) / 2
     offsets = [
       Coordinate(min_x + i * min_spacing_between_channels, 0, 0) for i in range(num_channels)
-    ]
+    ][::-1]
   else:
     raise ValueError("Only 90 and 180 degree rotations are supported for now.")
 


### PR DESCRIPTION
Pierce the foil of the media source plate at the specified column. Throw away the tips
after piercing because there will be a bit of foil stuck to the tips. Use this method
before aspirating from a foil-sealed plate to make sure the tips are clean and the
aspirations are accurate.