### PR TITLE
Better string representation for Coordinate

### DIFF
--- a/pylabrobot/resources/coordinate.py
+++ b/pylabrobot/resources/coordinate.py
@@ -38,9 +38,7 @@ class Coordinate:
     )
 
   def __str__(self) -> str:
-    if self.x is not None and self.y is not None and self.z is not None:
-      return f"({self.x:07.3f}, {self.y:07.3f}, {self.z:07.3f})"
-    return "(None, None, None)"
+    return f"Coordinate({self.x:07.3f}, {self.y:07.3f}, {self.z:07.3f})"
 
   def __neg__(self) -> Coordinate:
     return Coordinate(-self.x, -self.y, -self.z)

--- a/pylabrobot/resources/coordinate_tests.py
+++ b/pylabrobot/resources/coordinate_tests.py
@@ -20,7 +20,7 @@ class TestCoordinate(unittest.TestCase):
     self.assertEqual(self.b + self.b, Coordinate(20, 20, 20))
 
   def test_to_string(self):
-    self.assertEqual(f"{self.a}", "(001.000, 002.000, 003.000)")
+    self.assertEqual(f"{self.a}", "Coordinate(001.000, 002.000, 003.000)")
 
   def test_serialization(self):
     self.assertEqual(

--- a/pylabrobot/resources/hamilton/hamilton_decks.py
+++ b/pylabrobot/resources/hamilton/hamilton_decks.py
@@ -310,7 +310,7 @@ class HamiltonDeck(Deck, metaclass=ABCMeta):
       # Print resource location
       try:
         x, y, z = resource.get_absolute_location()
-        location = f"(x: {x:7.3f}, y: {y:7.3f}, z: {z:7.3f})"
+        location = f"({x:07.3f}, {y:07.3f}, {z:07.3f})"
       except NoLocationError:
         location = "Undefined"
       r_summary += location.ljust(location_column_length)

--- a/pylabrobot/resources/hamilton/hamilton_decks.py
+++ b/pylabrobot/resources/hamilton/hamilton_decks.py
@@ -309,7 +309,8 @@ class HamiltonDeck(Deck, metaclass=ABCMeta):
 
       # Print resource location
       try:
-        location = str(resource.get_absolute_location())
+        x, y, z = resource.get_absolute_location()
+        location = f"(x: {x:7.3f}, y: {y:7.3f}, z: {z:7.3f})"
       except NoLocationError:
         location = "Undefined"
       r_summary += location.ljust(location_column_length)


### PR DESCRIPTION
```
Coordinate(x, y, z)
```

instead of

```
(x, y, z)
```