### PR TITLE
ztouch probing uses request_tip_len_on_channel again

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -7419,7 +7419,10 @@ class STAR(HamiltonLiquidHandler):
         )
 
     if tip_len is None:
-      tip_len = self.head[channel_idx].get_tip().total_tip_length
+      # currently a bug, will be fixed in the future
+      # reverted to previous implementation
+      # tip_len = self.head[channel_idx].get_tip().total_tip_length
+      tip_len = await self.request_tip_len_on_channel(channel_idx)
 
     # fitting_depth = 8 mm for 10, 50, 300, 1000 ul Hamilton tips
     fitting_depth = self.head[channel_idx].get_tip().fitting_depth

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -7425,7 +7425,8 @@ class STAR(HamiltonLiquidHandler):
       tip_len = await self.request_tip_len_on_channel(channel_idx)
 
     # fitting_depth = 8 mm for 10, 50, 300, 1000 ul Hamilton tips
-    fitting_depth = self.head[channel_idx].get_tip().fitting_depth
+    # fitting_depth = self.head[channel_idx].get_tip().fitting_depth
+    fitting_depth = 8  # mm, for 10, 50, 300, 1000 ul Hamilton tips
 
     if start_pos_search is None:
       start_pos_search = 334.7 - tip_len + fitting_depth


### PR DESCRIPTION
lh.backend.head sometimes is incorrect. Presumably because autoreload breaks the reference of lh.backend.head to the dictionary pointed to by lh (the value is copied and they point to different dictionaries after autoreload). We don't know for sure. Will be fixed in the future. For now, revert to the previous implementation that works.
