### PR TITLE
Centrifuge loader decode error due to single \

### DIFF
--- a/pylabrobot/io/ftdi.py
+++ b/pylabrobot/io/ftdi.py
@@ -117,7 +117,7 @@ class FTDI(IOBase):
       FTDICommand(
         device_id=self._device_id,
         action="read",
-        data=data if isinstance(data, str) else data.decode("unicode_escape"),
+        data=data if isinstance(data, str) else data.decode("unicode_escape", errors="ignore"),
       )
     )
     return cast(bytes, data)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/47c1833d-7ae8-4745-9ac0-985e2db714a6)
Error when trying to decode communication with the centrifuge loader. There are \ in the response causing the decoding to fail.

I set the errors to be ignored. Resulting in the setup process being able to be completed.