### PR TITLE
correctly roll back volume tracker on asp/disp fail

### DIFF
--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -905,7 +905,8 @@ class LiquidHandler(Resource, Machine):
       if does_volume_tracking():
         if not op.resource.tracker.is_disabled:
           (op.resource.tracker.commit if success else op.resource.tracker.rollback)()
-        (self.head[channel].get_tip().tracker.commit if success else self.head[channel].rollback)()
+        tip_volume_tracker = self.head[channel].get_tip().tracker
+        (tip_volume_tracker.commit if success else tip_volume_tracker.rollback)()
 
     # trigger callback
     self._trigger_callback(
@@ -1107,7 +1108,8 @@ class LiquidHandler(Resource, Machine):
       if does_volume_tracking():
         if not op.resource.tracker.is_disabled:
           (op.resource.tracker.commit if success else op.resource.tracker.rollback)()
-        (self.head[channel].get_tip().tracker.commit if success else self.head[channel].rollback)()
+        tip_volume_tracker = self.head[channel].get_tip().tracker
+        (tip_volume_tracker.commit if success else tip_volume_tracker.rollback)()
 
     if any(bav is not None for bav in blow_out_air_volume):
       self._blow_out_air_volume = None

--- a/pylabrobot/liquid_handling/liquid_handler_tests.py
+++ b/pylabrobot/liquid_handling/liquid_handler_tests.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Union, cast
 
 import pytest
 
+from pylabrobot.liquid_handling.errors import ChannelizedError
 from pylabrobot.liquid_handling.strictness import (
   Strictness,
   set_strictness,
@@ -1059,6 +1060,23 @@ class TestLiquidHandlerVolumeTracking(unittest.IsolatedAsyncioTestCase):
       await self.lh.pick_up_tips(self.tip_rack["A1"])
       await self.lh.aspirate([self.plate.get_item("A1")], vols=[10])
       await self.lh.dispense([self.plate.get_item("A2")], vols=[10])
+
+  async def test_dispense_fails(self):
+    well = self.plate.get_item("A1")
+    await self.lh.pick_up_tips(self.tip_rack["A1"])
+
+    async def error_func(*args, **kwargs):
+      raise ChannelizedError(errors={0: Exception("This is an error")})
+
+    self.backend.dispense = error_func
+    well.tracker.set_liquids([(None, 200)])
+
+    await self.lh.aspirate([well], vols=[200])
+    assert self.lh.head[0].get_tip().tracker.get_used_volume() == 200
+    with self.assertRaises(ChannelizedError):
+      await self.lh.dispense([well], vols=[60])
+    # test volume doens't change on failed dispense
+    assert self.lh.head[0].get_tip().tracker.get_used_volume() == 200
 
 
 class TestLiquidHandlerCrossContaminationTracking(unittest.IsolatedAsyncioTestCase):

--- a/pylabrobot/resources/volume_tracker.py
+++ b/pylabrobot/resources/volume_tracker.py
@@ -213,7 +213,7 @@ class VolumeTracker:
   def rollback(self) -> None:
     """Rollback the pending operations."""
     assert not self.is_disabled, "Volume tracker is disabled. Call `enable()`."
-    self.pending_liquids.clear()
+    self.pending_liquids = copy.deepcopy(self.liquids)
 
   def clear_cross_contamination_history(self) -> None:
     """Resets the liquid_history for cross contamination tracking. Use when there is a wash step."""


### PR DESCRIPTION
fixing https://github.com/PyLabRobot/pylabrobot/issues/427

there were two issues:
- we called rollback on the tip tracker rather than the tip's volume tracker (in both asp and disp). commit was correctly called
- rolling back volume tracker would clear the `pending_liquids` (actually current), instead of rolling back to the previously known state (called `liquids`). (these names are confusing)