### PR TITLE
remove x axis from get single resource liquid op offsets

### DIFF
--- a/pylabrobot/liquid_handling/utils.py
+++ b/pylabrobot/liquid_handling/utils.py
@@ -7,7 +7,6 @@ MIN_SPACING_BETWEEN_CHANNELS = 9
 # minimum spacing between the edge of the container and the center of channel
 MIN_SPACING_EDGE = 2
 
-
 def _get_centers_with_margin(dim_size: float, n: int, margin: float, min_spacing: float):
   """Get the centers of the channels with a minimum margin on the edges."""
   if dim_size < margin * 2 + (n - 1) * min_spacing:
@@ -15,12 +14,15 @@ def _get_centers_with_margin(dim_size: float, n: int, margin: float, min_spacing
   if dim_size - (n - 1) * min_spacing <= min_spacing * 2:
     remaining_space = dim_size - (n - 1) * min_spacing - margin * 2
     return [margin + remaining_space / 2 + i * min_spacing for i in range(n)]
-  return [(i + 1) * dim_size / (n + 1) for i in range(n)]
+  # return [(i + 1) * dim_size / (n + 1) for i in range(n)]
+  start = margin
+  end = dim_size - margin
+  step = (end - start) / (n - 1) if n > 1 else 0
+  return [start + i * step for i in range(n)]
 
 
 def get_wide_single_resource_liquid_op_offsets(
-  resource: Resource,
-  num_channels: int,
+  resource: Resource, num_channels: int,
 ) -> List[Coordinate]:
   resource_size = resource.get_absolute_size_y()
   centers = list(
@@ -34,15 +36,17 @@ def get_wide_single_resource_liquid_op_offsets(
     )
   )  # reverse because channels are from back to front
 
-  center_offsets: List[Coordinate] = []
-  x_offset = resource.get_absolute_size_x() / 2
-  center_offsets = [Coordinate(x=x_offset, y=c, z=0) for c in centers]
-
   # offsets are relative to the center of the resource, but above we computed them wrt lfb
   # so we need to subtract the center of the resource
   # also, offsets are in absolute space, so we need to rotate the center
-  return [o - resource.center().rotated(resource.get_absolute_rotation()) for o in center_offsets]
-
+  return [
+    Coordinate(
+      x=0,
+      y=c - resource.center().rotated(resource.get_absolute_rotation()).y,
+      z=0,
+    )
+    for c in centers
+  ]
 
 def get_tight_single_resource_liquid_op_offsets(
   resource: Resource, num_channels: int
@@ -53,12 +57,18 @@ def get_tight_single_resource_liquid_op_offsets(
   if min_y < MIN_SPACING_EDGE:
     raise ValueError("Resource is too small to space channels.")
 
-  x_offset = resource.get_absolute_size_x() / 2
-  offsets = [
-    Coordinate(x_offset, min_y + i * MIN_SPACING_BETWEEN_CHANNELS, 0) for i in range(num_channels)
+  centers = [
+    min_y + i * MIN_SPACING_BETWEEN_CHANNELS for i in range(num_channels)
   ][::-1]
 
   # offsets are relative to the center of the resource, but above we computed them wrt lfb
   # so we need to subtract the center of the resource
   # also, offsets are in absolute space, so we need to rotate the center
-  return [o - resource.center().rotated(resource.get_absolute_rotation()) for o in offsets]
+  return [
+    Coordinate(
+      x=0,
+      y=c - resource.center().rotated(resource.get_absolute_rotation()).y,
+      z=0,
+    )
+    for c in centers
+  ]


### PR DESCRIPTION
this fixes situations where x offset was calculated incorrectly, because we don't really need to consider x offsets when working in absolute space & positioning pipettes along just the y axis