### PR TITLE
Hamilton Mfx module 188049

### DIFF
--- a/pylabrobot/resources/hamilton/mfx_modules.py
+++ b/pylabrobot/resources/hamilton/mfx_modules.py
@@ -63,7 +63,7 @@ def MFX_DWP_module_flat(name: str) -> PlateHolder:
   )
 
 def MFX_WP_module_flat(name: str) -> PlateHolder:
-  """Hamilton cat. no.: 188041 (uncertain)
+  """Hamilton cat. no.: 188049 (uncertain)
   Module to position a Well Plate. Taller version of MFX_DWP_module_flat.
   """
   return PlateHolder(

--- a/pylabrobot/resources/hamilton/mfx_modules.py
+++ b/pylabrobot/resources/hamilton/mfx_modules.py
@@ -64,12 +64,13 @@ def MFX_DWP_module_flat(name: str) -> PlateHolder:
 
 def MFX_WP_module_flat(name: str) -> PlateHolder:
   """Hamilton cat. no.: 188041 (uncertain)
+  Module to position a Well Plate. Taller version of MFX_DWP_module_flat.
   """
   return PlateHolder(
     name=name,
     size_x=135.0,
     size_y=94.0,
-    size_z=216 - 18.195 - 100,
+    size_z=216 - 18.195 - 100, # mesured using probe
     # probe height - carrier_height - deck_height
     child_location=Coordinate(3.0, 4.0, 209.9 - 18.195 - 100),
     pedestal_size_z=0,

--- a/pylabrobot/resources/hamilton/mfx_modules.py
+++ b/pylabrobot/resources/hamilton/mfx_modules.py
@@ -61,3 +61,16 @@ def MFX_DWP_module_flat(name: str) -> PlateHolder:
     model=MFX_DWP_rackbased_module.__name__,
     pedestal_size_z=0,
   )
+
+def MFX_WP_module_flat(name: str) -> PlateHolder:
+  """Hamilton cat. no.: 188041 (uncertain)
+  """
+  return PlateHolder(
+    name=name,
+    size_x=135.0,
+    size_y=94.0,
+    size_z=216 - 18.195 - 100,
+    # probe height - carrier_height - deck_height
+    child_location=Coordinate(3.0, 4.0, 209.9 - 18.195 - 100),
+    pedestal_size_z=0,
+  )


### PR DESCRIPTION
Following the discussion about not yet implemented modules. [PLR Forum](https://discuss.pylabrobot.org/t/starlet-carrier-module-classifications/190/2).

I have attempted to create a definition for a module I have on hand.

There are no cat. no on the module. I also do not have access to the purchase history. 

From the `VENUS four Operators Manual.pdf` provided by Eric Sindelar (senior Hamilton employee) on the [labautomation.io](http://labautomation.io/) forum. There are two potential candidates.
![image](https://github.com/user-attachments/assets/f687ae04-d32a-4cbd-a30f-dff436430196)
![image](https://github.com/user-attachments/assets/f593c929-dcff-4233-ad1f-ba30ff939e65)

This [ebay listing](https://www.ebay.com/itm/235714969973) suggests it is the prior. However, this other listing for [188042](https://www.ebay.com/itm/365462833597) more aligns with the image in the manual.
![image](https://github.com/user-attachments/assets/f9bdb463-920b-423d-a445-b598ff257272)

I therefore believe that this module should be 188049.

I have tested this module on the liquid handler. There are no errors and the height is correct upon visual inspection when using plates.