### PR TITLE
prevents pips from moving in x during pierce

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -7752,9 +7752,10 @@ class STAR(HamiltonLiquidHandler):
       assert (
         len(set(w.get_absolute_location().x for w in wells)) == 1
       ), "Wells must be on the same column"
-      x = wells[0].get_absolute_location().x
-      ys = [well.get_absolute_location().y for well in wells]
-      z = wells[0].get_absolute_location(z="cavity_bottom").z
+      absolute_center = wells[0].get_absolute_location("c", "c", "cavity_bottom")
+      x = absolute_center.x
+      ys = [well.get_absolute_location(x="c", y="c").y for well in wells]
+      z = absolute_center.z
 
     await self.move_channel_x(0, x=x)
 

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR.py
@@ -7752,10 +7752,9 @@ class STAR(HamiltonLiquidHandler):
       assert (
         len(set(w.get_absolute_location().x for w in wells)) == 1
       ), "Wells must be on the same column"
-      absolute_center = wells[0].get_absolute_location("c", "c", "cavity_bottom")
-      x = absolute_center.x
-      ys = [well.get_absolute_location(x="c", y="c").y for well in wells]
-      z = absolute_center.z
+      x = wells[0].get_absolute_location().x
+      ys = [well.get_absolute_location().y for well in wells]
+      z = wells[0].get_absolute_location(z="cavity_bottom").z
 
     await self.move_channel_x(0, x=x)
 

--- a/pylabrobot/liquid_handling/utils.py
+++ b/pylabrobot/liquid_handling/utils.py
@@ -15,11 +15,7 @@ def _get_centers_with_margin(dim_size: float, n: int, margin: float, min_spacing
   if dim_size - (n - 1) * min_spacing <= min_spacing * 2:
     remaining_space = dim_size - (n - 1) * min_spacing - margin * 2
     return [margin + remaining_space / 2 + i * min_spacing for i in range(n)]
-  # return [(i + 1) * dim_size / (n + 1) for i in range(n)]
-  start = margin
-  end = dim_size - margin
-  step = (end - start) / (n - 1) if n > 1 else 0
-  return [start + i * step for i in range(n)]
+  return [(i + 1) * dim_size / (n + 1) for i in range(n)]
 
 
 def get_wide_single_resource_liquid_op_offsets(
@@ -41,7 +37,6 @@ def get_wide_single_resource_liquid_op_offsets(
   # offsets are relative to the center of the resource, but above we computed them wrt lfb
   # so we need to subtract the center of the resource
   # also, offsets are in absolute space, so we need to rotate the center
-  # return [o - resource.center().rotated(resource.get_absolute_rotation()) for o in center_offsets]
   return [
     Coordinate(
       x=0,
@@ -50,6 +45,7 @@ def get_wide_single_resource_liquid_op_offsets(
     )
     for c in centers
   ]
+
 
 def get_tight_single_resource_liquid_op_offsets(
   resource: Resource, num_channels: int
@@ -60,9 +56,7 @@ def get_tight_single_resource_liquid_op_offsets(
   if min_y < MIN_SPACING_EDGE:
     raise ValueError("Resource is too small to space channels.")
 
-  centers = [
-    min_y + i * MIN_SPACING_BETWEEN_CHANNELS for i in range(num_channels)
-  ][::-1]
+  centers = [min_y + i * MIN_SPACING_BETWEEN_CHANNELS for i in range(num_channels)][::-1]
 
   # offsets are relative to the center of the resource, but above we computed them wrt lfb
   # so we need to subtract the center of the resource


### PR DESCRIPTION
this is an older PR, finally syncing it now. this helps prevent errors related to rotations by simplifying plate-relative movements to only care about the robot's y axis