### PR TITLE
make io methods async

### DIFF
--- a/pylabrobot/centrifuge/vspin.py
+++ b/pylabrobot/centrifuge/vspin.py
@@ -30,7 +30,7 @@ class Access2Backend(LoaderBackend):
     r = None
     start = time.time()
     while r != b"" or x == b"":
-      r = self.io.read(1)
+      r = await self.io.read(1)
       x += r
       if r == b"":
         await asyncio.sleep(0.1)
@@ -40,7 +40,7 @@ class Access2Backend(LoaderBackend):
 
   async def send_command(self, command: bytes) -> bytes:
     logger.debug("[loader] Sending %s", command.hex())
-    self.io.write(command)
+    await self.io.write(command)
     return await self._read()
 
   async def setup(self):
@@ -290,7 +290,7 @@ class VSpin(CentrifugeBackend):
     start_time = time.time()
 
     while True:
-      chunk = self.io.read(25)
+      chunk = await self.io.read(25)
       if chunk:
         data += chunk
         end_byte_found = data[-1] == 0x0D
@@ -305,7 +305,7 @@ class VSpin(CentrifugeBackend):
     return data
 
   async def send(self, cmd: Union[bytearray, bytes], read_timeout=0.2) -> bytes:
-    written = self.io.write(bytes(cmd))  # TODO: why decode? .decode("latin-1")
+    written = await self.io.write(bytes(cmd))  # TODO: why decode? .decode("latin-1")
 
     if written != len(cmd):
       raise RuntimeError("Failed to write all bytes")
@@ -332,10 +332,10 @@ class VSpin(CentrifugeBackend):
     self.io.set_baudrate(19200)
 
   async def initialize(self):
-    self.io.write(b"\x00" * 20)
+    await self.io.write(b"\x00" * 20)
     for i in range(33):
       packet = b"\xaa" + bytes([i & 0xFF, 0x0E, 0x0E + (i & 0xFF)]) + b"\x00" * 8
-      self.io.write(packet)
+      await self.io.write(packet)
     await self.send(b"\xaa\xff\x0f\x0e")
 
   # Centrifuge operations

--- a/pylabrobot/heating_shaking/hamilton.py
+++ b/pylabrobot/heating_shaking/hamilton.py
@@ -60,10 +60,12 @@ class HamiltonHeatShaker(HeaterShakerBackend):
       "shaker_index": self.shaker_index,
     }
 
-  def _send_command(self, command: str, **kwargs):
+  async def _send_command(self, command: str, **kwargs):
     assert len(command) == 2, "Command must be 2 characters long"
     args = "".join([f"{key}{value}" for key, value in kwargs.items()])
-    self.io.write(f"T{self.shaker_index}{command}id{str(self.command_id).zfill(4)}{args}".encode())
+    await self.io.write(
+      f"T{self.shaker_index}{command}id{str(self.command_id).zfill(4)}{args}".encode()
+    )
 
     self.command_id = (self.command_id + 1) % 10_000
     return self.io.read()
@@ -94,11 +96,11 @@ class HamiltonHeatShaker(HeaterShakerBackend):
     await self._wait_for_stop()
 
   async def get_is_shaking(self) -> bool:
-    response = self._send_command("RD").decode("ascii")
+    response = (await self._send_command("RD")).decode("ascii")
     return response.endswith("1")  # type: ignore[no-any-return] # what
 
   async def _move_plate_lock(self, position: PlateLockPosition):
-    return self._send_command("LP", lp=position.value)
+    return await self._send_command("LP", lp=position.value)
 
   async def lock_plate(self):
     await self._move_plate_lock(PlateLockPosition.LOCKED)
@@ -108,34 +110,34 @@ class HamiltonHeatShaker(HeaterShakerBackend):
 
   async def _initialize_lock(self):
     """Firmware command initialize lock."""
-    result = self._send_command("LI")
+    result = await self._send_command("LI")
     return result
 
   async def _start_shaking(self, direction: int, speed: int, acceleration: int):
     """Firmware command for starting shaking."""
     speed_str = str(speed).zfill(4)
     acceleration_str = str(acceleration).zfill(5)
-    return self._send_command("SB", st=direction, sv=speed_str, sr=acceleration_str)
+    return await self._send_command("SB", st=direction, sv=speed_str, sr=acceleration_str)
 
   async def _stop_shaking(self):
     """Firmware command for stopping shaking."""
-    return self._send_command("SC")
+    return await self._send_command("SC")
 
   async def _wait_for_stop(self):
     """Firmware command for waiting for shaking to stop."""
-    return self._send_command("SW")
+    return await self._send_command("SW")
 
   async def set_temperature(self, temperature: float):
     """set temperature in Celsius"""
     temp_str = f"{round(10*temperature):04d}"
-    return self._send_command("TA", ta=temp_str)
+    return await self._send_command("TA", ta=temp_str)
 
   async def get_current_temperature(self) -> float:
     """get temperature in Celsius"""
-    response = self._send_command("RT").decode("ascii")
+    response = (await self._send_command("RT")).decode("ascii")
     temp = str(response).split(" ")[1].strip("+")
     return float(temp) / 10
 
   async def deactivate(self):
     """turn off heating"""
-    return self._send_command("TO")
+    return await self._send_command("TO")

--- a/pylabrobot/heating_shaking/inheco.py
+++ b/pylabrobot/heating_shaking/inheco.py
@@ -85,12 +85,12 @@ class InhecoThermoShake(HeaterShakerBackend):
       num -= 1
     return crc
 
-  def _read_until_end(self, timeout: int) -> str:
+  async def _read_until_end(self, timeout: int) -> str:
     """Read until a packet ends with a \\x00 byte. May read multiple packets."""
     start = time.time()
     response = b""
     while time.time() - start < timeout:
-      packet = self.io.read(64, timeout=timeout)
+      packet = await self.io.read(64, timeout=timeout)
       if packet is not None and packet != b"":
         if packet.endswith(b"\x00"):
           response += packet.rstrip(b"\x00")  # strip trailing \x00's
@@ -105,7 +105,7 @@ class InhecoThermoShake(HeaterShakerBackend):
 
     return response.decode("unicode_escape")
 
-  def _read_response(self, command: str, timeout: int = 60) -> str:
+  async def _read_response(self, command: str, timeout: int = 60) -> str:
     """Read the response for a given command.
 
     "The MTC/STC replies to the first four characters of every command with a modified echo. The
@@ -116,7 +116,7 @@ class InhecoThermoShake(HeaterShakerBackend):
 
     start = time.time()
     while time.time() - start < timeout:
-      response = self._read_until_end(timeout=int(timeout - (time.time() - start)))
+      response = await self._read_until_end(timeout=int(timeout - (time.time() - start)))
 
       if response[:4] == command[:4].lower():
         return response
@@ -127,9 +127,9 @@ class InhecoThermoShake(HeaterShakerBackend):
     """Send a command to the device and return the response"""
     packets = self._generate_packets(command)
     for packet in packets:
-      self.io.write(bytes(packet))
+      await self.io.write(bytes(packet))
 
-    response = self._read_response(command, timeout=timeout)
+    response = await self._read_response(command, timeout=timeout)
 
     if response[4] != "0":
       raise RuntimeError(f"Error response from device: {response}")

--- a/pylabrobot/incubators/cytomat/cytomat.py
+++ b/pylabrobot/incubators/cytomat/cytomat.py
@@ -99,8 +99,8 @@ class Cytomat(IncubatorBackend):
   async def send_command(self, command_type: str, command: str, params: str) -> str:
     async def _send_command(command_str) -> str:
       logging.debug(command_str.encode(self.serial_message_encoding))
-      self.io.write(command_str.encode(self.serial_message_encoding))
-      resp = self.io.read(128).decode(self.serial_message_encoding)
+      await self.io.write(command_str.encode(self.serial_message_encoding))
+      resp = (await self.io.read(128)).decode(self.serial_message_encoding)
       if len(resp) == 0:
         raise RuntimeError("Cytomat did not respond to command, is it turned on?")
       key, *values = resp.split()

--- a/pylabrobot/io/hid.py
+++ b/pylabrobot/io/hid.py
@@ -48,13 +48,13 @@ class HID(IOBase):
     logger.log(LOG_LEVEL_IO, "Closing HID device %s", self._unique_id)
     capturer.record(HIDCommand(device_id=self._unique_id, action="close", data=""))
 
-  def write(self, data: bytes):
+  async def write(self, data: bytes):
     assert self.device is not None, "forgot to call setup?"
     self.device.write(data)
     logger.log(LOG_LEVEL_IO, "[%s] write %s", self._unique_id, data)
     capturer.record(HIDCommand(device_id=self._unique_id, action="write", data=data.decode()))
 
-  def read(self, size: int, timeout: int) -> bytes:
+  async def read(self, size: int, timeout: int) -> bytes:
     assert self.device is not None, "forgot to call setup?"
     r = self.device.read(size, timeout=timeout)
     logger.log(LOG_LEVEL_IO, "[%s] read %s", self._unique_id, r)
@@ -98,7 +98,7 @@ class HIDValidator(HID):
     ):
       raise ValidationError(f"Next line is {next_command}, expected HID close {self._unique_id}")
 
-  def write(self, data: bytes):
+  async def write(self, data: bytes):
     next_command = HIDCommand(**self.cr.next_command())
     if (
       not next_command.module == "hid"
@@ -110,7 +110,7 @@ class HIDValidator(HID):
       align_sequences(expected=next_command.data, actual=data.decode())
       raise ValidationError("Data mismatch: difference was written to stdout.")
 
-  def read(self, size: int, timeout: int) -> bytes:
+  async def read(self, size: int, timeout: int) -> bytes:
     next_command = HIDCommand(**self.cr.next_command())
     if (
       not next_command.module == "hid"

--- a/pylabrobot/io/io.py
+++ b/pylabrobot/io/io.py
@@ -3,11 +3,11 @@ from abc import ABC, abstractmethod
 
 class IOBase(ABC):
   @abstractmethod
-  def write(self, *args, **kwargs):
+  async def write(self, *args, **kwargs):
     pass
 
   @abstractmethod
-  def read(self, *args, **kwargs):
+  async def read(self, *args, **kwargs):
     pass
 
   def serialize(self):

--- a/pylabrobot/io/serial.py
+++ b/pylabrobot/io/serial.py
@@ -75,7 +75,7 @@ class Serial(IOBase):
     if self.ser is not None and self.ser.is_open:
       self.ser.close()
 
-  def write(self, data: bytes):
+  async def write(self, data: bytes):
     assert self.ser is not None, "forgot to call setup?"
     logger.log(LOG_LEVEL_IO, "[%s] write %s", self._port, data)
     capturer.record(
@@ -83,7 +83,7 @@ class Serial(IOBase):
     )
     self.ser.write(data)
 
-  def read(self, num_bytes: int = 1) -> bytes:
+  async def read(self, num_bytes: int = 1) -> bytes:
     assert self.ser is not None, "forgot to call setup?"
     data = self.ser.read(num_bytes)
     logger.log(LOG_LEVEL_IO, "[%s] read %s", self._port, data)
@@ -92,7 +92,7 @@ class Serial(IOBase):
     )
     return cast(bytes, data)
 
-  def readline(self) -> bytes:  # type: ignore # very dumb it's reading from pyserial
+  async def readline(self) -> bytes:  # type: ignore # very dumb it's reading from pyserial
     assert self.ser is not None, "forgot to call setup?"
     data = self.ser.readline()
     logger.log(LOG_LEVEL_IO, "[%s] readline %s", self._port, data)
@@ -151,7 +151,7 @@ class SerialValidator(Serial):
   async def setup(self):
     pass
 
-  def write(self, data: bytes):
+  async def write(self, data: bytes):
     next_command = SerialCommand(**self.cr.next_command())
     if not (
       next_command.module == "serial"
@@ -163,7 +163,7 @@ class SerialValidator(Serial):
       align_sequences(expected=next_command.data, actual=data.decode("unicode_escape"))
       raise ValidationError("Data mismatch: difference was written to stdout.")
 
-  def read(self, num_bytes: int = 1) -> bytes:
+  async def read(self, num_bytes: int = 1) -> bytes:
     next_command = SerialCommand(**self.cr.next_command())
     if not (
       next_command.module == "serial"
@@ -174,7 +174,7 @@ class SerialValidator(Serial):
       raise ValidationError(f"Next line is {next_command}, expected Serial read {num_bytes}")
     return next_command.data.encode()
 
-  def readline(self) -> bytes:  # type: ignore # very dumb it's reading from pyserial
+  async def readline(self) -> bytes:  # type: ignore # very dumb it's reading from pyserial
     next_command = SerialCommand(**self.cr.next_command())
     if not (
       next_command.module == "serial"

--- a/pylabrobot/io/usb.py
+++ b/pylabrobot/io/usb.py
@@ -87,7 +87,7 @@ class USB(IOBase):
     # unique id in the logs
     self._unique_id = f"[{hex(self._id_vendor)}:{hex(self._id_product)}][{self._serial_number or ''}][{self._device_address or ''}]"
 
-  def write(self, data: bytes, timeout: Optional[float] = None):
+  async def write(self, data: bytes, timeout: Optional[float] = None):
     """Write data to the device.
 
     Args:
@@ -131,7 +131,7 @@ class USB(IOBase):
       # No data available (yet), this will give a timeout error. Don't reraise.
       return None
 
-  def read(self, timeout: Optional[int] = None) -> bytes:
+  async def read(self, timeout: Optional[int] = None) -> bytes:
     """Read a response from the device.
 
     Args:
@@ -315,7 +315,7 @@ class USBValidator(USB):
   async def setup(self):
     pass
 
-  def write(self, data: bytes, timeout: Optional[float] = None):
+  async def write(self, data: bytes, timeout: Optional[float] = None):
     next_command = USBCommand(**self.cr.next_command())
     if not (
       next_command.module == "usb"
@@ -327,7 +327,7 @@ class USBValidator(USB):
       align_sequences(expected=next_command.data, actual=data.decode("unicode_escape"))
       raise ValidationError("Data mismatch: difference was written to stdout.")
 
-  def read(self, timeout: Optional[float] = None) -> bytes:
+  async def read(self, timeout: Optional[float] = None) -> bytes:
     next_command = USBCommand(**self.cr.next_command())
     if not (
       next_command.module == "usb"

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
@@ -145,7 +145,7 @@ class TestSTARUSBComms(unittest.IsolatedAsyncioTestCase):
   async def asyncSetUp(self):
     self.star = STAR(read_timeout=2, packet_read_timeout=1)
     self.star.set_deck(STARLetDeck())
-    self.star.io = unittest.mock.MagicMock()
+    self.star.io = unittest.mock.AsyncMock()
     await super().asyncSetUp()
 
   async def test_send_command_correct_response(self):

--- a/pylabrobot/liquid_handling/backends/tecan/EVO.py
+++ b/pylabrobot/liquid_handling/backends/tecan/EVO.py
@@ -150,11 +150,11 @@ class TecanLiquidHandler(LiquidHandlerBackend, metaclass=ABCMeta):
 
     cmd = self._assemble_command(module, command, [] if params is None else params)
 
-    self.io.write(cmd.encode(), timeout=write_timeout)
+    await self.io.write(cmd.encode(), timeout=write_timeout)
     if not wait:
       return None
 
-    resp = self.io.read(timeout=read_timeout)
+    resp = await self.io.read(timeout=read_timeout)
     return self.parse_response(resp)
 
   async def setup(self):

--- a/pylabrobot/only_fans/hamilton_hepa_fan.py
+++ b/pylabrobot/only_fans/hamilton_hepa_fan.py
@@ -146,7 +146,7 @@ class HamiltonHepaFan(FanBackend):
   async def stop(self):
     await self.io.stop()
 
-  async def send(self, command):
-    self.io.write(command)
+  async def send(self, command: bytes):
+    await self.io.write(command)
     await asyncio.sleep(0.1)
-    self.io.read(64)
+    await self.io.read(64)

--- a/pylabrobot/plate_reading/biotek_backend.py
+++ b/pylabrobot/plate_reading/biotek_backend.py
@@ -418,7 +418,7 @@ class Cytation5Backend(ImageReaderBackend):
     res = b""
     t0 = time.time()
     while x != char:
-      x = self.io.read(1)
+      x = await self.io.read(1)
       res += x
 
       if time.time() - t0 > timeout:
@@ -440,7 +440,7 @@ class Cytation5Backend(ImageReaderBackend):
   ) -> Optional[bytes]:
     await self._purge_buffers()
 
-    self.io.write(command.encode())
+    await self.io.write(command.encode())
     logger.debug("[cytation5] sent %s", command)
     response: Optional[bytes] = None
     if wait_for_response or parameter is not None:
@@ -449,7 +449,7 @@ class Cytation5Backend(ImageReaderBackend):
       )
 
     if parameter is not None:
-      self.io.write(parameter.encode())
+      await self.io.write(parameter.encode())
       logger.debug("[cytation5] sent %s", parameter)
       if wait_for_response:
         response = await self._read_until(b"\x03", timeout=timeout)

--- a/pylabrobot/plate_reading/biotek_tests.py
+++ b/pylabrobot/plate_reading/biotek_tests.py
@@ -22,6 +22,8 @@ class TestCytation5Backend(unittest.IsolatedAsyncioTestCase):
     self.backend.io = unittest.mock.MagicMock()
     self.backend.io.setup = unittest.mock.AsyncMock()
     self.backend.io.stop = unittest.mock.AsyncMock()
+    self.backend.io.read = unittest.mock.AsyncMock()
+    self.backend.io.write = unittest.mock.AsyncMock()
     self.plate = CellVis_24_wellplate_3600uL_Fb(name="plate")
 
   async def test_setup(self):

--- a/pylabrobot/plate_reading/clario_star.py
+++ b/pylabrobot/plate_reading/clario_star.py
@@ -57,7 +57,7 @@ class CLARIOStar(PlateReaderBackend):
     # we keep reading for at least one more cycle. We only check the timeout if the last read was
     # unsuccessful (i.e. keep reading if we are still getting data).
     while True:
-      last_read = self.io.read(25)  # 25 is max length observed in pcap
+      last_read = await self.io.read(25)  # 25 is max length observed in pcap
       if len(last_read) > 0:
         d += last_read
         end_byte_found = d[-1] == 0x0D
@@ -90,7 +90,7 @@ class CLARIOStar(PlateReaderBackend):
 
     logger.debug("sending %s", cmd.hex())
 
-    w = self.io.write(cmd)
+    w = await self.io.write(cmd)
 
     logger.debug("wrote %s bytes", w)
 

--- a/pylabrobot/pumps/cole_parmer/masterflex.py
+++ b/pylabrobot/pumps/cole_parmer/masterflex.py
@@ -27,8 +27,8 @@ class Masterflex(PumpBackend):
   async def setup(self):
     await self.io.setup()
 
-    self.io.write(b"\x05")  # Enquiry; ready to send.
-    self.io.write(b"\x05P02\r")
+    await self.io.write(b"\x05")  # Enquiry; ready to send.
+    await self.io.write(b"\x05P02\r")
 
   def serialize(self):
     return {**super().serialize(), "com_port": self.com_port}
@@ -36,17 +36,17 @@ class Masterflex(PumpBackend):
   async def stop(self):
     await self.io.stop()
 
-  def send_command(self, command: str):
+  async def send_command(self, command: str):
     command = "\x02P02" + command + "\x0d"
-    self.io.write(command.encode())
+    await self.io.write(command.encode())
     return self.io.read()
 
-  def run_revolutions(self, num_revolutions: float):
+  async def run_revolutions(self, num_revolutions: float):
     num_revolutions = round(num_revolutions, 2)
     cmd = f"V{num_revolutions}G"
-    self.send_command(cmd)
+    await self.send_command(cmd)
 
-  def run_continuously(self, speed: float):
+  async def run_continuously(self, speed: float):
     if speed == 0:
       self.halt()
       return
@@ -54,7 +54,7 @@ class Masterflex(PumpBackend):
     direction = "+" if speed > 0 else "-"
     speed = int(abs(speed))
     cmd = f"S{direction}{speed}G0"
-    self.send_command(cmd)
+    await self.send_command(cmd)
 
-  def halt(self):
-    self.send_command("H")
+  async def halt(self):
+    await self.send_command("H")

--- a/pylabrobot/scales/mettler_toledo.py
+++ b/pylabrobot/scales/mettler_toledo.py
@@ -180,12 +180,12 @@ class MettlerToledoWXS205SDU(ScaleBackend):
       timeout: The timeout in seconds.
     """
 
-    self.io.write(command.encode() + b"\r\n")
+    await self.io.write(command.encode() + b"\r\n")
 
     raw_response = b""
     timeout_time = time.time() + timeout
     while True:
-      raw_response = self.io.readline()
+      raw_response = await self.io.readline()
       await asyncio.sleep(0.001)
       if time.time() > timeout_time:
         raise TimeoutError("Timeout while waiting for response from scale.")

--- a/pylabrobot/tilting/hamilton_backend.py
+++ b/pylabrobot/tilting/hamilton_backend.py
@@ -54,8 +54,8 @@ class HamiltonTiltModuleBackend(TilterBackend):
     if parameter is None:
       parameter = ""
 
-    self.io.write(f"99{command}{parameter}\r\n".encode("utf-8"))
-    resp = self.io.read(128).decode("utf-8")
+    await self.io.write(f"99{command}{parameter}\r\n".encode("utf-8"))
+    resp = (await self.io.read(128)).decode("utf-8")
 
     # Check for error.
     error_matches = re.search("er[0-9]{2}", resp)


### PR DESCRIPTION
while not all of the methods here are truly async, some operations are actually fundamentally synchronous, it is possible for some operations (like in http) to be asynchronous (eg https://docs.aiohttp.org/en/stable/). PLR is fundamentally an async framework. so, it makes sense to have the io abc be async. this forces all implementations to also have async methods.

to make it easy to write async backends, i agree that implementing some async-ification directly in the io layer is very convenient (as suggested by @jrast here: https://github.com/PyLabRobot/pylabrobot/pull/471#issuecomment-2816757239). where applicable, we could run a background thread that e.g. reads until a certain condition is met (e.g. new line character is read, a certain number of bytes, etc.). all backends should be async, and this makes that easy. the alternative is like each  usb-backend async-ifies usb itself.

we already have some intelligence in the io layer. For example, `USB.read` calls the pyusb read method continuously as long as we read the max packet size (so that only one `USB.read` call is required from the PLR-backend).