### PR TITLE
fix enabling validation mode for backends with an interface

### DIFF
--- a/pylabrobot/heating_shaking/hamilton_backend.py
+++ b/pylabrobot/heating_shaking/hamilton_backend.py
@@ -69,7 +69,7 @@ class HamiltonHeaterShakerBackend(HeaterShakerBackend):
     self.index = index
 
     super().__init__()
-    self.intf = interface
+    self.interface = interface
 
   async def setup(self):
     """
@@ -116,11 +116,11 @@ class HamiltonHeaterShakerBackend(HeaterShakerBackend):
     await self._wait_for_stop()
 
   async def get_is_shaking(self) -> bool:
-    response = await self.intf.send_hhs_command(index=self.index, command="RD")
+    response = await self.interface.send_hhs_command(index=self.index, command="RD")
     return response.endswith("1")  # type: ignore[no-any-return] # what
 
   async def _move_plate_lock(self, position: PlateLockPosition):
-    return await self.intf.send_hhs_command(index=self.index, command="LP", lp=position.value)
+    return await self.interface.send_hhs_command(index=self.index, command="LP", lp=position.value)
 
   async def lock_plate(self):
     await self._move_plate_lock(PlateLockPosition.LOCKED)
@@ -130,33 +130,33 @@ class HamiltonHeaterShakerBackend(HeaterShakerBackend):
 
   async def _initialize_lock(self):
     """Firmware command initialize lock."""
-    return await self.intf.send_hhs_command(index=self.index, command="LI")
+    return await self.interface.send_hhs_command(index=self.index, command="LI")
 
   async def _start_shaking(self, direction: int, speed: int, acceleration: int):
     """Firmware command for starting shaking."""
     speed_str = str(speed).zfill(4)
     acceleration_str = str(acceleration).zfill(5)
-    return await self.intf.send_hhs_command(
+    return await self.interface.send_hhs_command(
       index=self.index, command="SB", st=direction, sv=speed_str, sr=acceleration_str
     )
 
   async def _stop_shaking(self):
     """Firmware command for stopping shaking."""
-    return await self.intf.send_hhs_command(index=self.index, command="SC")
+    return await self.interface.send_hhs_command(index=self.index, command="SC")
 
   async def _wait_for_stop(self):
     """Firmware command for waiting for shaking to stop."""
-    return await self.intf.send_hhs_command(index=self.index, command="SW")
+    return await self.interface.send_hhs_command(index=self.index, command="SW")
 
   async def set_temperature(self, temperature: float):
     """set temperature in Celsius"""
     assert 0 < temperature <= 105
     temp_str = f"{round(10*temperature):04d}"
-    return await self.intf.send_hhs_command(index=self.index, command="TA", ta=temp_str)
+    return await self.interface.send_hhs_command(index=self.index, command="TA", ta=temp_str)
 
   async def _get_current_temperature(self) -> Dict[str, float]:
     """get temperature in Celsius"""
-    response = await self.intf.send_hhs_command(index=self.index, command="RT")
+    response = await self.interface.send_hhs_command(index=self.index, command="RT")
     response = response.split("rt")[1]
     middle_temp = float(str(response).split(" ")[0].strip("+")) / 10
     edge_temp = float(str(response).split(" ")[1].strip("+")) / 10
@@ -174,4 +174,4 @@ class HamiltonHeaterShakerBackend(HeaterShakerBackend):
 
   async def deactivate(self):
     """turn off heating"""
-    return await self.intf.send_hhs_command(index=self.index, command="TO")
+    return await self.interface.send_hhs_command(index=self.index, command="TO")

--- a/pylabrobot/io/validation.py
+++ b/pylabrobot/io/validation.py
@@ -22,22 +22,29 @@ def validate(capture_file: str):
 
   global cr
   cr = CaptureReader(path=capture_file)
-  for machine_backend in MachineBackend.get_all_instances():
+
+  def _replace_io(obj):
     io2v = {
       USB: USBValidator,
       Serial: SerialValidator,
       FTDI: FTDIValidator,
       HID: HIDValidator,
     }
-
-    # replace `io` with validator variant
-    if machine_backend.io.__class__ in io2v:
-      machine_backend.io = io2v[machine_backend.io.__class__](
-        **machine_backend.io.serialize(), cr=cr
-      )
-    elif machine_backend.io.__class__ in io2v.values():
-      machine_backend.io.cr = cr
+    if not hasattr(obj, "io"):
+      return False
+    if obj.io.__class__ in io2v:
+      obj.io = io2v[obj.io.__class__](**obj.io.serialize(), cr=cr)
+    elif obj.io.__class__ in io2v.values():
+      obj.io.cr = cr
     else:
+      return False
+    return True
+
+  for machine_backend in MachineBackend.get_all_instances():
+    if not (
+      (hasattr(machine_backend, "io") and _replace_io(machine_backend))
+      or (hasattr(machine_backend, "interface") and _replace_io(machine_backend.interface))
+    ):
       raise RuntimeError(f"Backend {machine_backend} not supported for validation")
 
   cr.start()


### PR DESCRIPTION
it is kind of a hack, but it works for now

the backend for `HamiltonHeaterShakerBackend` does not have an `io` attribute anymore, because it uses an `interface` to actually communicate with the machine. this is because multiple heater shakers share one usb connection. it is also possible that they share a usb connection with a STAR. that is why i introduced this `interface` _as an exception_, it will not be the rule.

in this pr, i make the assumption that if a backend does not have `io` (for example because it shares the io with other backends), it will have an `interface` attribute and that the `interface` attribute will then have an `io` attribute. we will see in the future if this generalizes. for now it's a fix. we should revisit later when it comes up.