### PR TITLE
STARBackend manual 96 head movement

### DIFF
--- a/docs/user_guide/00_liquid-handling/hamilton-star/96head.ipynb
+++ b/docs/user_guide/00_liquid-handling/hamilton-star/96head.ipynb
@@ -182,6 +182,52 @@
    "source": [
     "await lh.return_tips96()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Manually moving the 96 head around\n",
+    "\n",
+    "![star supported](https://img.shields.io/badge/STAR-supported-blue)\n",
+    "![Vantage supported](https://img.shields.io/badge/Vantage-not%20supported-red)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await wc.lh.backend.request_position_of_core_96_head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await wc.lh.backend.move_core_96_head_x(100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await wc.lh.backend.move_core_96_head_y(120)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await wc.lh.backend.move_core_96_head_z(300)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Added:
- `STARBackend.move_core_96_head_x`
- `STARBackend.move_core_96_head_y`
- `STARBackend.move_core_96_head_z`

Changed:
- `STARBackend. move_core_96_head_to_defined_position`
  - takes mm instead of 0.1mm units
  - x_direction is inferred
- `STARBackend.request_position_of_core_96_head` returns mm instead of 0.1mm units