### PR TITLE
consider pickup_distance_from_top in STARBackend. move_picked_up_resource

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -2882,14 +2882,13 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     center = (
       move.location
       + move.resource.get_anchor("c", "c", "t")
-      - Coordinate(z=move.pick_up_distance_from_top)
+      - Coordinate(z=move.pickup_distance_from_top)
     )
 
     if use_arm == "iswap":
       await self.iswap_move_picked_up_resource(
         center=center,
         grip_direction=move.gripped_direction,
-        pick_up_distance_from_top=move.pickup_distance_from_top,
         minimum_traverse_height_at_beginning_of_a_command=self._iswap_traversal_height,
         collision_control_level=1,
         acceleration_index_high_acc=4,

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -2879,12 +2879,15 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
   async def move_picked_up_resource(
     self, move: ResourceMove, use_arm: Literal["iswap", "core"] = "iswap"
   ):
-    center = location + resource.get_anchor("c", "c", "t") - Coordinate(z=pick_up_distance_from_top)
+    center = (
+      move.location
+      + move.resource.get_anchor("c", "c", "t")
+      - Coordinate(z=move.pick_up_distance_from_top)
+    )
 
     if use_arm == "iswap":
       await self.iswap_move_picked_up_resource(
         center=center,
-        resource=move.resource,
         grip_direction=move.gripped_direction,
         pick_up_distance_from_top=move.pickup_distance_from_top,
         minimum_traverse_height_at_beginning_of_a_command=self._iswap_traversal_height,
@@ -2895,7 +2898,6 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     else:
       await self.core_move_picked_up_resource(
         center=center,
-        resource=move.resource,
         minimum_traverse_height_at_beginning_of_a_command=self._iswap_traversal_height,
         acceleration_index=4,
       )

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
@@ -847,8 +847,8 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
         _any_write_and_read_command_call(
           "C0PPid0001xs03479xd0yj1142yd0zj1874zd0gr1th2800te2800gw4go1308gb1245gt20ga0gc1"
         ),
-        _any_write_and_read_command_call("C0PMid0002xs03979xd0yj3062yd0zj2432zd0gr1th2800ga1xe4 1"),
-        _any_write_and_read_command_call("C0PMid0003xs02979xd0yj4022yd0zj2432zd0gr1th2800ga1xe4 1"),
+        _any_write_and_read_command_call("C0PMid0002xs03979xd0yj3062yd0zj2405zd0gr1th2800ga1xe4 1"),
+        _any_write_and_read_command_call("C0PMid0003xs02979xd0yj4022yd0zj2405zd0gr1th2800ga1xe4 1"),
         _any_write_and_read_command_call(
           "C0PRid0004xs03479xd0yj2102yd0zj1874zd0th2800te2800gr1go1308ga0gc0"
         ),

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1831,7 +1831,8 @@ class LiquidHandler(Resource, Machine):
         location=to,
         resource=self._resource_pickup.resource,
         gripped_direction=self._resource_pickup.direction,
-      )
+        pickup_distance_from_top=self._resource_pickup.pickup_distance_from_top,
+      ),
     )
 
   async def drop_resource(

--- a/pylabrobot/liquid_handling/standard.py
+++ b/pylabrobot/liquid_handling/standard.py
@@ -142,6 +142,7 @@ class ResourceMove:
   resource: Resource
   location: Coordinate
   gripped_direction: GripDirection
+  pickup_distance_from_top: float
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
this makes it easier to use lh.move_picked_up_resource with STARBackend

iswap arm takes the center location, not the lfb location

for z, we used to take the center of the resource but this is dumb

in order to get the plate lfb at the location the user requests, we need to add the plate height to requested locationg, then subtract pickup_distance_from_top

the logic is equivalent to that of drop_resource