### PR TITLE
better incubator.summary

### DIFF
--- a/pylabrobot/incubators/incubator.py
+++ b/pylabrobot/incubators/incubator.py
@@ -178,7 +178,7 @@ class Incubator(Machine, Resource):
 
     header = [f"Rack {i}" for i in range(len(self._racks))]
     sites = [
-      [site.resource.name if site.resource else "empty" for site in rack.sites.values()]
+      [site.resource.name if site.resource else "<empty>" for site in reversed(rack.sites.values())]
       for rack in self._racks
     ]
     return create_pretty_table(header, *sites)


### PR DESCRIPTION
- reverse the list, so it's accurate to physical reality (spot 0 is at the bottom)
- use `<empty>` instead of `empty` to make it more readable

```
+---------+---------+
| Rack 0  | Rack 1  |
+---------+---------+
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| <empty> | <empty> |
| plate   | <empty> |
+---------+---------+
```