### PR TITLE
Fix special float deserialization

### DIFF
--- a/pylabrobot/serializer.py
+++ b/pylabrobot/serializer.py
@@ -110,7 +110,15 @@ def serialize(obj: Any) -> JSON:
 def deserialize(data: JSON, allow_marshal: bool = False) -> Any:
   """Deserialize an object."""
 
-  if isinstance(data, (int, float, str, bool, type(None))):
+  if isinstance(data, str):
+    if data == "Infinity":
+      return math.inf
+    if data == "-Infinity":
+      return -math.inf
+    if data == "nan":
+      return math.nan
+    return data
+  if isinstance(data, (int, float, bool, type(None))):
     return data
   if isinstance(data, list):
     return [deserialize(item, allow_marshal=allow_marshal) for item in data]

--- a/pylabrobot/tests/serializer_tests.py
+++ b/pylabrobot/tests/serializer_tests.py
@@ -1,3 +1,5 @@
+import math
+
 from pylabrobot.serializer import deserialize, serialize
 
 
@@ -41,3 +43,10 @@ def test_serialize_deserialize_function_with_closure():
   deserialized = deserialize(serialized, allow_marshal=True)
 
   assert func(5) == deserialized(5)
+
+
+def test_serialize_deserialize_special_floats():
+  assert deserialize(serialize(float("inf"))) == math.inf
+  assert deserialize(serialize(float("-inf"))) == -math.inf
+  result = deserialize(serialize(float("nan")))
+  assert math.isnan(result)


### PR DESCRIPTION
## Summary
- handle 'Infinity', '-Infinity' and 'nan' in deserializer
- add tests for special float handling

## Testing
- `pytest pylabrobot/tests/serializer_tests.py -q`
- `pytest -q` *(fails: ModuleNotFoundError for optional dependencies)*