### PR TITLE
Add passive cooling option in TemperatureController

### DIFF
--- a/pylabrobot/temperature_controlling/temperature_controller.py
+++ b/pylabrobot/temperature_controlling/temperature_controller.py
@@ -36,13 +36,37 @@ class TemperatureController(ResourceHolder, Machine):
     self.backend: TemperatureControllerBackend = backend  # fix type
     self.target_temperature: Optional[float] = None
 
-  async def set_temperature(self, temperature: float):
+  async def set_temperature(self, temperature: float, passive: bool = False):
     """Set the temperature of the temperature controller.
 
     Args:
       temperature: Temperature in Celsius.
+      passive: If ``True`` and cooling is required, allow the device to cool
+        down naturally without calling ``set_temperature`` on the backend.
+        This can be used for backends that do not support active cooling or to
+        explicitly disable active cooling when it is available.
     """
+    current = await self.backend.get_current_temperature()
+
     self.target_temperature = temperature
+
+    if temperature < current:
+      # Cooling scenario.
+      if not self.backend.supports_active_cooling:
+        if passive:
+          # Device does not support active cooling and user opted for passive
+          # cooling. Nothing to do on the backend.
+          return
+        raise ValueError(
+          "Backend does not support active cooling. Use passive=True to allow "
+          "passive cooling or set a higher temperature."
+        )
+
+      # Backend supports active cooling.
+      if passive:
+        # Actively do nothing and let the device cool naturally.
+        return
+
     return await self.backend.set_temperature(temperature)
 
   async def get_temperature(self) -> float:

--- a/pylabrobot/temperature_controlling/temperature_controller_tests.py
+++ b/pylabrobot/temperature_controlling/temperature_controller_tests.py
@@ -5,6 +5,7 @@ from pylabrobot.temperature_controlling import (
   TemperatureController,
   TemperatureControllerChatterboxBackend,
 )
+from pylabrobot.temperature_controlling.backend import TemperatureControllerBackend
 
 
 class TemperatureControllerTests(unittest.TestCase):
@@ -21,3 +22,77 @@ class TemperatureControllerTests(unittest.TestCase):
     serialized = tc.serialize()
     deserialized = TemperatureController.deserialize(serialized)
     self.assertEqual(tc, deserialized)
+
+
+class PassiveCoolingTests(unittest.IsolatedAsyncioTestCase):
+  async def test_cannot_cool_without_support(self):
+    backend = TemperatureControllerChatterboxBackend(dummy_temperature=20.0)
+    tc = TemperatureController(
+      name="tc",
+      size_x=1,
+      size_y=1,
+      size_z=1,
+      backend=backend,
+      child_location=Coordinate.zero(),
+    )
+
+    with self.assertRaises(ValueError):
+      await tc.set_temperature(10)
+
+  async def test_passive_cooling_without_support(self):
+    backend = TemperatureControllerChatterboxBackend(dummy_temperature=20.0)
+    tc = TemperatureController(
+      name="tc",
+      size_x=1,
+      size_y=1,
+      size_z=1,
+      backend=backend,
+      child_location=Coordinate.zero(),
+    )
+
+    await tc.set_temperature(10, passive=True)
+    # Temperature should remain unchanged on the backend.
+    self.assertEqual(await backend.get_current_temperature(), 20.0)
+
+
+class _FakeBackend(TemperatureControllerBackend):
+  def __init__(self, temperature: float = 25.0):
+    super().__init__()
+    self.temperature = temperature
+    self.set_called = False
+
+  @property
+  def supports_active_cooling(self) -> bool:
+    return True
+
+  async def setup(self):
+    pass
+
+  async def stop(self):
+    pass
+
+  async def set_temperature(self, temperature: float):
+    self.set_called = True
+    self.temperature = temperature
+
+  async def get_current_temperature(self) -> float:
+    return self.temperature
+
+  async def deactivate(self):
+    pass
+
+
+class PassiveCoolingWithSupportTests(unittest.IsolatedAsyncioTestCase):
+  async def test_passive_cooling_with_support(self):
+    backend = _FakeBackend(temperature=30.0)
+    tc = TemperatureController(
+      name="tc",
+      size_x=1,
+      size_y=1,
+      size_z=1,
+      backend=backend,
+      child_location=Coordinate.zero(),
+    )
+
+    await tc.set_temperature(20, passive=True)
+    self.assertFalse(backend.set_called)


### PR DESCRIPTION
## Summary
- add `passive` parameter to `TemperatureController.set_temperature`
- update logic to allow passive cooling when backend can't actively cool or active cooling is disabled
- extend temperature controller tests to cover new behavior

## Testing
- `make lint`
- `make test`
