### PR TITLE
support non-full tip racks with 96 head pickup

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -2181,9 +2181,15 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     """Pick up tips using the 96 head."""
     assert self.core96_head_installed, "96 head must be installed"
     tip_spot_a1 = pickup.resource.get_item("A1")
-    tip_a1 = tip_spot_a1.get_tip()
-    assert isinstance(tip_a1, HamiltonTip), "Tip type must be HamiltonTip."
-    ttti = await self.get_or_assign_tip_type_index(tip_a1)
+    prototypical_tip = None
+    for tip_spot in pickup.resource.get_all_items():
+      if tip_spot.has_tip:
+        prototypical_tip = tip_spot.get_tip()
+        break
+    if prototypical_tip is None:
+      raise ValueError("No tips found in the tip rack.")
+    assert isinstance(prototypical_tip, HamiltonTip), "Tip type must be HamiltonTip."
+    ttti = await self.get_or_assign_tip_type_index(prototypical_tip)
     position = tip_spot_a1.get_absolute_location() + tip_spot_a1.center() + pickup.offset
     z_deposit_position += round(pickup.offset.z * 10)
 
@@ -2213,8 +2219,8 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     """Drop tips from the 96 head."""
     assert self.core96_head_installed, "96 head must be installed"
     if isinstance(drop.resource, TipRack):
-      tip_a1 = drop.resource.get_item("A1")
-      position = tip_a1.get_absolute_location() + tip_a1.center() + drop.offset
+      prototypical_tip = drop.resource.get_item("A1")
+      position = prototypical_tip.get_absolute_location() + prototypical_tip.center() + drop.offset
     else:
       position = self._position_96_head_in_resource(drop.resource) + drop.offset
 

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -2183,7 +2183,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     tip_spot_a1 = pickup.resource.get_item("A1")
     prototypical_tip = None
     for tip_spot in pickup.resource.get_all_items():
-      if tip_spot.has_tip:
+      if tip_spot.has_tip():
         prototypical_tip = tip_spot.get_tip()
         break
     if prototypical_tip is None:

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -2219,8 +2219,8 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     """Drop tips from the 96 head."""
     assert self.core96_head_installed, "96 head must be installed"
     if isinstance(drop.resource, TipRack):
-      prototypical_tip = drop.resource.get_item("A1")
-      position = prototypical_tip.get_absolute_location() + prototypical_tip.center() + drop.offset
+      tip_spot_a1 = drop.resource.get_item("A1")
+      position = tip_spot_a1.get_absolute_location() + tip_spot_a1.center() + drop.offset
     else:
       position = self._position_96_head_in_resource(drop.resource) + drop.offset
 

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
@@ -24,6 +24,7 @@ from pylabrobot.resources import (
   Lid,
   ResourceStack,
   no_volume_tracking,
+  set_tip_tracking,
 )
 from pylabrobot.resources.hamilton import STF, STARLetDeck
 
@@ -263,6 +264,8 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     self.STAR._core_parked = True
     self.STAR._iswap_parked = True
     await self.lh.setup()
+
+    set_tip_tracking(enabled=False)
 
   async def asyncTearDown(self):
     await self.lh.stop()

--- a/pylabrobot/liquid_handling/backends/hamilton/vantage_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/vantage_backend.py
@@ -948,7 +948,7 @@ class VantageBackend(HamiltonLiquidHandler):
     tip_spot_a1 = pickup.resource.get_item("A1")
     prototypical_tip = None
     for tip_spot in pickup.resource.get_all_items():
-      if tip_spot.has_tip:
+      if tip_spot.has_tip():
         prototypical_tip = tip_spot.get_tip()
         break
     if prototypical_tip is None:

--- a/pylabrobot/liquid_handling/backends/hamilton/vantage_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/vantage_backend.py
@@ -946,9 +946,15 @@ class VantageBackend(HamiltonLiquidHandler):
   ):
     # assert self.core96_head_installed, "96 head must be installed"
     tip_spot_a1 = pickup.resource.get_item("A1")
-    tip_a1 = tip_spot_a1.get_tip()
-    assert isinstance(tip_a1, HamiltonTip), "Tip type must be HamiltonTip."
-    ttti = await self.get_or_assign_tip_type_index(tip_a1)
+    prototypical_tip = None
+    for tip_spot in pickup.resource.get_all_items():
+      if tip_spot.has_tip:
+        prototypical_tip = tip_spot.get_tip()
+        break
+    if prototypical_tip is None:
+      raise ValueError("No tips found in the tip rack.") 
+    assert isinstance(prototypical_tip, HamiltonTip), "Tip type must be HamiltonTip."
+    ttti = await self.get_or_assign_tip_type_index(prototypical_tip)
     position = tip_spot_a1.get_absolute_location() + tip_spot_a1.center() + pickup.offset
     offset_z = pickup.offset.z
 

--- a/pylabrobot/liquid_handling/backends/hamilton/vantage_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/vantage_backend.py
@@ -952,7 +952,7 @@ class VantageBackend(HamiltonLiquidHandler):
         prototypical_tip = tip_spot.get_tip()
         break
     if prototypical_tip is None:
-      raise ValueError("No tips found in the tip rack.") 
+      raise ValueError("No tips found in the tip rack.")
     assert isinstance(prototypical_tip, HamiltonTip), "Tip type must be HamiltonTip."
     ttti = await self.get_or_assign_tip_type_index(prototypical_tip)
     position = tip_spot_a1.get_absolute_location() + tip_spot_a1.center() + pickup.offset

--- a/pylabrobot/liquid_handling/backends/hamilton/vantage_tests.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/vantage_tests.py
@@ -10,6 +10,7 @@ from pylabrobot.resources import (
   TIP_CAR_480_A00,
   Coordinate,
   Cor_96_wellplate_360ul_Fb,
+  set_tip_tracking,
 )
 from pylabrobot.resources.hamilton import VantageDeck
 
@@ -258,6 +259,8 @@ class TestVantageLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     self.maxDiff = None
 
     await self.lh.setup()
+
+    set_tip_tracking(enabled=False)
 
   async def asyncTearDown(self):
     await self.lh.stop()

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1247,7 +1247,7 @@ class LiquidHandler(Resource, Machine):
       # it's possible only some tips are present in the tip rack.
       if tip_spot.has_tip():
         self.head96[i].add_tip(tip_spot.get_tip(), origin=tip_spot, commit=False)
-      if does_tip_tracking() and not tip_spot.tracker.is_disabled:
+      if does_tip_tracking() and not tip_spot.tracker.is_disabled and tip_spot.has_tip():
         tip_spot.tracker.remove_tip()
 
     pickup_operation = PickupTipRack(resource=tip_rack, offset=offset)

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1245,7 +1245,7 @@ class LiquidHandler(Resource, Machine):
         self.head96[i].remove_tip()
       # only add tips where there is one present.
       # it's possible only some tips are present in the tip rack.
-      if self.head96[i].has_tip:
+      if tip_spot.has_tip():
         self.head96[i].add_tip(tip_spot.get_tip(), origin=tip_spot, commit=False)
       if does_tip_tracking() and not tip_spot.tracker.is_disabled:
         tip_spot.tracker.remove_tip()

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1243,7 +1243,10 @@ class LiquidHandler(Resource, Machine):
     for i, tip_spot in enumerate(tip_rack.get_all_items()):
       if not does_tip_tracking() and self.head96[i].has_tip:
         self.head96[i].remove_tip()
-      self.head96[i].add_tip(tip_spot.get_tip(), origin=tip_spot, commit=False)
+      # only add tips where there is one present.
+      # it's possible only some tips are present in the tip rack.
+      if self.head96[i].has_tip:
+        self.head96[i].add_tip(tip_spot.get_tip(), origin=tip_spot, commit=False)
       if does_tip_tracking() and not tip_spot.tracker.is_disabled:
         tip_spot.tracker.remove_tip()
 
@@ -1302,6 +1305,9 @@ class LiquidHandler(Resource, Machine):
 
     # queue operation on all tip trackers
     for i in range(96):
+      # it's possible not every channel on this head has a tip.
+      if not self.head96[i].has_tip:
+        continue
       tip = self.head96[i].get_tip()
       if tip.tracker.get_used_volume() > 0 and not allow_nonzero_volume:
         error = f"Cannot drop tip with volume {tip.tracker.get_used_volume()} on channel {i}"

--- a/pylabrobot/liquid_handling/liquid_handler_tests.py
+++ b/pylabrobot/liquid_handling/liquid_handler_tests.py
@@ -1015,6 +1015,22 @@ class TestLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     reagent_reservoir = agilent_1_reservoir_290ml(name="reservoir")
     await self.lh.pick_up_tips96(self.tip_rack)
     await self.lh.aspirate96(reagent_reservoir.get_item("A1"), volume=100)
+  
+  async def test_pick_up_tips96_incomplete_rack(self):
+    set_tip_tracking(enabled=True)
+
+    # Test that picking up tips from an incomplete rack works
+    self.tip_rack.fill()
+    self.tip_rack.get_item("A1").tracker.remove_tip()
+    
+    await self.lh.pick_up_tips96(self.tip_rack)
+    
+    # Check that the tips were picked up correctly
+    self.assertFalse(self.lh.head96[0].has_tip)
+    for i in range(1, 96):
+      self.assertTrue(self.lh.head96[i].has_tip)
+
+    set_tip_tracking(enabled=False)
 
 
 class TestLiquidHandlerVolumeTracking(unittest.IsolatedAsyncioTestCase):

--- a/pylabrobot/liquid_handling/liquid_handler_tests.py
+++ b/pylabrobot/liquid_handling/liquid_handler_tests.py
@@ -1015,16 +1015,16 @@ class TestLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     reagent_reservoir = agilent_1_reservoir_290ml(name="reservoir")
     await self.lh.pick_up_tips96(self.tip_rack)
     await self.lh.aspirate96(reagent_reservoir.get_item("A1"), volume=100)
-  
+
   async def test_pick_up_tips96_incomplete_rack(self):
     set_tip_tracking(enabled=True)
 
     # Test that picking up tips from an incomplete rack works
     self.tip_rack.fill()
     self.tip_rack.get_item("A1").tracker.remove_tip()
-    
+
     await self.lh.pick_up_tips96(self.tip_rack)
-    
+
     # Check that the tips were picked up correctly
     self.assertFalse(self.lh.head96[0].has_tip)
     for i in range(1, 96):


### PR DESCRIPTION
as pointed out by @ferryistaken in https://github.com/PyLabRobot/pylabrobot/issues/547, we do not support picking up tips when the 96 head when tip tracking is enabled and the tip rack is not full.

in this PR we fix this issue

note that this is just about picking up from the entire rack, where maybe some tips are just not present. in a future PR, we will add support for "partial" pickups, i.e. shifting the head wrt the tip rack.