### PR TITLE
Implement flow rate for Tecan EVO backend

### DIFF
--- a/pylabrobot/liquid_handling/backends/tecan/EVO_backend.py
+++ b/pylabrobot/liquid_handling/backends/tecan/EVO_backend.py
@@ -797,8 +797,9 @@ class EVOBackend(TecanLiquidHandler):
       tlc = tecan_liquid_classes[i]
       z = zadd[channel]
       assert tlc is not None and z is not None
-      sep[channel] = int(tlc.aspirate_speed * 12)  # 6?
-      ssz[channel] = round(z * tlc.aspirate_speed / ops[i].volume)
+      flow_rate = ops[i].flow_rate or tlc.aspirate_speed
+      sep[channel] = int(flow_rate * 12)  # 6?
+      ssz[channel] = round(z * flow_rate / ops[i].volume)
       volume = tlc.compute_corrected_volume(ops[i].volume)
       mtr[channel] = round(volume * 6)  # 3?
       ssz_r[channel] = int(tlc.aspirate_retract_speed * 10)
@@ -833,7 +834,8 @@ class EVOBackend(TecanLiquidHandler):
     for i, channel in enumerate(use_channels):
       tlc = tecan_liquid_classes[i]
       assert tlc is not None
-      sep[channel] = int(tlc.dispense_speed * 12)  # 6?
+      flow_rate = ops[i].flow_rate or tlc.dispense_speed
+      sep[channel] = int(flow_rate * 12)  # 6?
       spp[channel] = int(tlc.dispense_breakoff * 12)  # 6?
       stz[channel] = 0
       volume = (

--- a/pylabrobot/liquid_handling/backends/tecan/EVO_tests.py
+++ b/pylabrobot/liquid_handling/backends/tecan/EVO_tests.py
@@ -329,6 +329,47 @@ class EVOTests(unittest.IsolatedAsyncioTestCase):
       ]
     )
 
+  async def test_aspirate_custom_flow_rate(self):
+    op = SingleChannelAspiration(
+      resource=self.plate.get_item("A1"),
+      offset=Coordinate.zero(),
+      tip=self.tr.get_tip("A1"),
+      volume=100,
+      flow_rate=200,
+      liquid_height=10,
+      blow_out_air_volume=0,
+      liquids=[(None, 100)],
+    )
+    await self.evo.aspirate([op], use_channels=[0])
+    self.evo.send_command.assert_any_call(
+      module="C5",
+      command="SSZ",
+      params=[60, None, None, None, None, None, None, None],
+    )
+    self.evo.send_command.assert_any_call(
+      module="C5",
+      command="SEP",
+      params=[2400, None, None, None, None, None, None, None],
+    )
+
+  async def test_dispense_custom_flow_rate(self):
+    op = SingleChannelDispense(
+      resource=self.plate.get_item("A1"),
+      offset=Coordinate.zero(),
+      tip=self.tr.get_tip("A1"),
+      volume=100,
+      flow_rate=200,
+      liquid_height=10,
+      blow_out_air_volume=0,
+      liquids=[(None, 100)],
+    )
+    await self.evo.dispense([op], use_channels=[0])
+    self.evo.send_command.assert_any_call(
+      module="C5",
+      command="SEP",
+      params=[2400, None, None, None, None, None, None, None],
+    )
+
   async def test_move_resource(self):
     pickup = ResourcePickup(
       resource=self.plate,


### PR DESCRIPTION
## Summary
- add flow rate handling to aspirate and dispense for the Tecan EVO backend
- test custom flow rates in EVO backend tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'serial', 'responses', 'websockets', 'werkzeug', 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6840fd261fc0832b880c36b96367ad43