### PR TITLE
Remove deprecated resource definitions

### DIFF
--- a/pylabrobot/resources/azenta/plates.py
+++ b/pylabrobot/resources/azenta/plates.py
@@ -80,21 +80,3 @@ def Azenta4titudeFrameStar_96_wellplate_200ul_Vb(name: str, with_lid: bool = Fal
       cross_section_type=CrossSectionType.CIRCLE,
     ),
   )
-
-
-#: Azenta4titudeFrameStar_96_wellplate_Vb_L
-def Azenta4titudeFrameStar_96_wellplate_200ul_Vb_L(name: str, with_lid: bool = False) -> Plate:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use "
-    "Azenta4titudeFrameStar_96_wellplate_200ul_Vb instead."
-  )
-
-
-#: Azenta4titudeFrameStar_96_wellplate_Vb_P
-def Azenta4titudeFrameStar_96_wellplate_200ul_Vb_P(name: str, with_lid: bool = False) -> Plate:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. For portrait, use "
-    "Azenta4titudeFrameStar_96_wellplate_200ul_Vb().rotated(z=90) instead."
-  )

--- a/pylabrobot/resources/eppendorf/plates.py
+++ b/pylabrobot/resources/eppendorf/plates.py
@@ -98,18 +98,3 @@ def Eppendorf_96_wellplate_250ul_Vb(name: str, with_lid: bool = False) -> Plate:
       compute_height_from_volume=(_compute_height_from_volume_Eppendorf_96_wellplate_250ul_Vb),
     ),
   )
-
-
-def Eppendorf_96_wellplate_250ul_Vb_L(name: str, with_lid: bool = False) -> Plate:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use " "Eppendorf_96_wellplate_250ul_Vb instead."
-  )
-
-
-def Eppendorf_96_wellplate_250ul_Vb_P(name: str, with_lid: bool = False) -> Plate:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use "
-    "Eppendorf_96_wellplate_250ul_Vb.rotated(90) instead."
-  )

--- a/pylabrobot/resources/hamilton/tip_racks.py
+++ b/pylabrobot/resources/hamilton/tip_racks.py
@@ -253,7 +253,7 @@ def STF_Slim(name: str, with_tips: bool = True) -> TipRack:
     size_x=122.4,
     size_y=82.6,
     size_z=20.0,
-    model=STF_Slim_L.__name__,
+    model=STF_Slim.__name__,
     ordered_items=create_ordered_items_2d(
       TipSpot,
       num_items_x=12,

--- a/pylabrobot/resources/hamilton/tip_racks.py
+++ b/pylabrobot/resources/hamilton/tip_racks.py
@@ -146,6 +146,7 @@ def HTF_ULTRAWIDE(name: str, with_tips: bool = True) -> TipRack:
     with_tips=with_tips,
   )
 
+
 def HT(name: str, with_tips: bool = True) -> TipRack:
   """Tip Rack with 96 1000ul High Volume Tip"""
   return TipRack(

--- a/pylabrobot/resources/hamilton/tip_racks.py
+++ b/pylabrobot/resources/hamilton/tip_racks.py
@@ -146,6 +146,8 @@ def HTF_ULTRAWIDE(name: str, with_tips: bool = True) -> TipRack:
     with_tips=with_tips,
   )
 
+def HT(name: str, with_tips: bool = True) -> TipRack:
+  """Tip Rack with 96 1000ul High Volume Tip"""
   return TipRack(
     name=name,
     size_x=122.4,

--- a/pylabrobot/resources/hamilton/tip_racks.py
+++ b/pylabrobot/resources/hamilton/tip_racks.py
@@ -47,18 +47,6 @@ def FourmlTF(name: str, with_tips: bool = True) -> TipRack:
   )
 
 
-def FourmlTF_L(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError("_L and _P definitions are deprecated. Use " "FourmlTF instead.")
-
-
-def FourmlTF_P(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use " "FourmlTF().rotated(z=90) instead."
-  )
-
-
 def FivemlT(name: str, with_tips: bool = True) -> TipRack:
   """Tip Rack 24x 5ml Tip landscape oriented"""
   return TipRack(
@@ -81,18 +69,6 @@ def FivemlT(name: str, with_tips: bool = True) -> TipRack:
       make_tip=five_ml_tip,
     ),
     with_tips=with_tips,
-  )
-
-
-def FivemlT_L(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError("_L and _P definitions are deprecated. Use " "FivemlT instead.")
-
-
-def FivemlT_P(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use " "FivemlT().rotated(z=90) instead."
   )
 
 
@@ -121,18 +97,6 @@ def HTF(name: str, with_tips: bool = True) -> TipRack:
   )
 
 
-def HTF_L(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError("_L and _P definitions are deprecated. Use " "HTF instead.")
-
-
-def HTF_P(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use " "HTF().rotated(z=90) instead."
-  )
-
-
 def HTF_WIDE(name: str, with_tips: bool = True) -> TipRack:
   """Tip Rack with 96 1000ul High Volume Tip with filter"""
   return TipRack(
@@ -156,10 +120,6 @@ def HTF_WIDE(name: str, with_tips: bool = True) -> TipRack:
     ),
     with_tips=with_tips,
   )
-
-
-def HTF_L_WIDE(name: str, with_tips: bool = True) -> TipRack:
-  raise NotImplementedError("_L and _P definitions are deprecated. Use " "HTF_WIDE instead.")
 
 
 def HTF_ULTRAWIDE(name: str, with_tips: bool = True) -> TipRack:
@@ -186,13 +146,6 @@ def HTF_ULTRAWIDE(name: str, with_tips: bool = True) -> TipRack:
     with_tips=with_tips,
   )
 
-
-def HTF_L_ULTRAWIDE(name: str, with_tips: bool = True) -> TipRack:
-  raise NotImplementedError("_L and _P definitions are deprecated. Use " "HTF_ULTRAWIDE instead.")
-
-
-def HT(name: str, with_tips: bool = True) -> TipRack:
-  """Tip Rack with 96 1000ul High Volume Tip"""
   return TipRack(
     name=name,
     size_x=122.4,
@@ -213,18 +166,6 @@ def HT(name: str, with_tips: bool = True) -> TipRack:
       make_tip=high_volume_tip_no_filter,
     ),
     with_tips=with_tips,
-  )
-
-
-def HT_L(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError("_L and _P definitions are deprecated. Use " "HT instead.")
-
-
-def HT_P(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use " "HT().rotated(z=90) instead."
   )
 
 
@@ -253,18 +194,6 @@ def LTF(name: str, with_tips: bool = True) -> TipRack:
   )
 
 
-def LTF_L(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError("_L and _P definitions are deprecated. Use " "LTF instead.")
-
-
-def LTF_P(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use " "LTF().rotated(z=90) instead."
-  )
-
-
 def LT(name: str, with_tips: bool = True) -> TipRack:
   """Tip Rack with 96 10ul Low Volume Tip"""
   return TipRack(
@@ -287,18 +216,6 @@ def LT(name: str, with_tips: bool = True) -> TipRack:
       make_tip=low_volume_tip_no_filter,
     ),
     with_tips=with_tips,
-  )
-
-
-def LT_L(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError("_L and _P definitions are deprecated. Use " "LT instead.")
-
-
-def LT_P(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use " "LT().rotated(z=90) instead."
   )
 
 
@@ -327,18 +244,6 @@ def STF(name: str, with_tips: bool = True) -> TipRack:
   )
 
 
-def STF_L(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError("_L and _P definitions are deprecated. Use " "STF instead.")
-
-
-def STF_P(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use " "STF().rotated(z=90) instead."
-  )
-
-
 def STF_Slim(name: str, with_tips: bool = True) -> TipRack:
   """Tip Rack with 96 300ul Slim Standard Volume Tip with filter"""
   return TipRack(
@@ -361,18 +266,6 @@ def STF_Slim(name: str, with_tips: bool = True) -> TipRack:
       make_tip=slim_standard_volume_tip_with_filter,
     ),
     with_tips=with_tips,
-  )
-
-
-def STF_Slim_L(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError("_L and _P definitions are deprecated. Use " "STF_Slim instead.")
-
-
-def STF_Slim_P(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use " "STF_Slim().rotated(z=90) instead."
   )
 
 
@@ -401,18 +294,6 @@ def ST(name: str, with_tips: bool = True) -> TipRack:
   )
 
 
-def ST_L(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError("_L and _P definitions are deprecated. Use " "ST instead.")
-
-
-def ST_P(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use " "ST().rotated(z=90) instead."
-  )
-
-
 def TIP_50ul_w_filter(name: str, with_tips: bool = True) -> TipRack:
   """Tip Rack with 96 50ul Tip with filter"""
   return TipRack(
@@ -435,20 +316,6 @@ def TIP_50ul_w_filter(name: str, with_tips: bool = True) -> TipRack:
       make_tip=fifty_ul_tip_with_filter,
     ),
     with_tips=with_tips,
-  )
-
-
-def TIP_50ul_w_filter_L(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use " "TIP_50ul_w_filter instead."
-  )
-
-
-def TIP_50ul_w_filter_P(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use " "TIP_50ul_w_filter().rotated(z=90) instead."
   )
 
 
@@ -477,18 +344,6 @@ def TIP_50ul(name: str, with_tips: bool = True) -> TipRack:
   )
 
 
-def TIP_50ul_L(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError("_L and _P definitions are deprecated. Use " "TIP_50ul instead.")
-
-
-def TIP_50ul_P(name: str, with_tips: bool = True) -> TipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use " "TIP_50ul().rotated(z=90) instead."
-  )
-
-
 def Hamilton_96_tiprack_50ul_NTR(name: str, with_tips: bool = True) -> NestedTipRack:
   """Nested Tip Rack with 96 50ul Tip"""
   return NestedTipRack(
@@ -513,19 +368,4 @@ def Hamilton_96_tiprack_50ul_NTR(name: str, with_tips: bool = True) -> NestedTip
       make_tip=fifty_ul_tip_no_filter,
     ),
     with_tips=with_tips,
-  )
-
-
-def Hamilton_96_tiprack_50ul_NTR_L(name: str, with_tips: bool = True) -> NestedTipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use " "Hamilton_96_tiprack_50ul_NTR instead."
-  )
-
-
-def Hamilton_96_tiprack_50ul_NTR_P(name: str, with_tips: bool = True) -> NestedTipRack:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use "
-    "Hamilton_96_tiprack_50ul_NTR().rotated(z=90) instead."
   )

--- a/pylabrobot/resources/porvair/plates.py
+++ b/pylabrobot/resources/porvair/plates.py
@@ -94,22 +94,6 @@ def Porvair_6_reservoir_47ml_Vb(name: str, with_lid: bool = False) -> Plate:
   )
 
 
-#: Porvair_6_reservoir_47ml_Vb_L
-def Porvair_6_reservoir_47ml_Vb_L(name: str, with_lid: bool = False) -> Plate:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use " "Porvair_6_reservoir_47ml_Vb instead."
-  )
-
-
-#: Porvair_6_reservoir_47ml_Vb_P
-def Porvair_6_reservoir_47ml_Vb_P(name: str, with_lid: bool = False) -> Plate:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use " "Porvair_6_reservoir_47ml_Vb.rotated(90) instead."
-  )
-
-
 def Porvair_24_wellplate_Vb(name: str, lid: Optional[Lid] = None) -> Plate:
   """
   Porvair cat. no.: 390108

--- a/pylabrobot/resources/thermo_fisher/plates.py
+++ b/pylabrobot/resources/thermo_fisher/plates.py
@@ -118,21 +118,6 @@ def Thermo_TS_96_wellplate_1200ul_Rb(name: str, with_lid: bool = False) -> Plate
   )
 
 
-def Thermo_TS_96_wellplate_1200ul_Rb_L(name: str, with_lid: bool = False) -> Plate:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use Thermo_TS_96_wellplate_1200ul_Rb instead."
-  )
-
-
-def Thermo_TS_96_wellplate_1200ul_Rb_P(name: str, with_lid: bool = False) -> Plate:
-  # https://github.com/PyLabRobot/pylabrobot/issues/252
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use "
-    "Thermo_TS_96_wellplate_1200ul_Rb().rotated(z=90) instead."
-  )
-
-
 # # # # # # # # # # Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate # # # # # # # # # #
 
 
@@ -170,79 +155,6 @@ def _compute_height_from_volume_Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate(
 #     "Predicted Height (mm)": [0, 0.338, 0.839, 2.230, 6.526, 9.195, 11.152, 13.141, 15.145],
 #     "Relative Deviation (%)": [0, 99.07, 9.01, -1.76, -0.66, 0.27, -0.16, -0.22, -0.17]
 # }
-
-
-def Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate_Lid(name: str) -> Lid:
-  raise NotImplementedError("This lid is not currently defined.")
-  # See https://github.com/PyLabRobot/pylabrobot/pull/161.
-  # return Lid(
-  #   name=name,
-  #   size_x=127.76,
-  #   size_y=85.48,
-  #   size_z=5,
-  #   nesting_z_height=None, # measure overlap between lid and plate
-  #   model="Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate_Lid",
-  # )
-
-
-def Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate(name: str, with_lid: bool = False) -> Plate:
-  """Thermo Fisher Scientific/Fisher Scientific cat. no.: 4483354/15273005 (= with barcode)
-  - Part no.: 16698853 (FS) (= **without** barcode).
-  - See `./engineering_diagrams/` directory for more part numbers (different colours).
-  - Material: Polycarbonate, Polypropylene.
-  - Sterilization compatibility: ?
-  - Chemical resistance: ?
-  - Thermal resistance: ?
-  - Cleanliness: 'Certified DNA-, RNAse-, and PCR inhibitor-free with in-process sampling tests'.
-  - ANSI/SLAS-format for compatibility with automated systems.
-  - optimal pickup_distance_from_top=4 mm.
-  - total_volume = 300 ul.
-  - working_volume = 200 ul (recommended by manufacturer).
-  """
-  return Plate(
-    name=name,
-    size_x=127.76,
-    size_y=85.48,
-    size_z=20.1 + 1.6 - 0.5,  # cavity_depth + material_z_thickness - well_extruding_over_plate
-    lid=Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate_Lid(name + "_lid") if with_lid else None,
-    model="Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate",
-    plate_type="semi-skirted",
-    ordered_items=create_ordered_items_2d(
-      Well,
-      num_items_x=12,
-      num_items_y=8,
-      dx=11.63,
-      dy=9.95,
-      dz=0.0,  # check that plate is semi-skirted
-      item_dx=9,
-      item_dy=9,
-      size_x=5.49,
-      size_y=5.49,
-      size_z=20.1,
-      bottom_type=WellBottomType.V,
-      material_z_thickness=1.6,
-      cross_section_type=CrossSectionType.CIRCLE,
-      compute_volume_from_height=(
-        _compute_volume_from_height_Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate
-      ),
-      compute_height_from_volume=(
-        _compute_height_from_volume_Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate
-      ),
-    ),
-  )
-
-
-def Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate_L(name: str, with_lid: bool = False) -> Plate:
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate instead."
-  )
-
-
-def Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate_P(name: str, with_lid: bool = False) -> Plate:
-  raise NotImplementedError(
-    "_L and _P definitions are deprecated. Use "
-    "Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate.rotated(90) instead."
-  )
 
 
 def Thermo_Nunc_96_well_plate_1300uL_Rb(name: str) -> Plate:

--- a/pylabrobot/resources/thermo_fisher/plates.py
+++ b/pylabrobot/resources/thermo_fisher/plates.py
@@ -156,6 +156,7 @@ def _compute_height_from_volume_Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate(
 #     "Relative Deviation (%)": [0, 99.07, 9.01, -1.76, -0.66, 0.27, -0.16, -0.22, -0.17]
 # }
 
+
 def Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate_Lid(name: str) -> Lid:
   raise NotImplementedError("This lid is not currently defined.")
   # See https://github.com/PyLabRobot/pylabrobot/pull/161.

--- a/pylabrobot/resources/thermo_fisher/plates.py
+++ b/pylabrobot/resources/thermo_fisher/plates.py
@@ -156,6 +156,65 @@ def _compute_height_from_volume_Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate(
 #     "Relative Deviation (%)": [0, 99.07, 9.01, -1.76, -0.66, 0.27, -0.16, -0.22, -0.17]
 # }
 
+def Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate_Lid(name: str) -> Lid:
+  raise NotImplementedError("This lid is not currently defined.")
+  # See https://github.com/PyLabRobot/pylabrobot/pull/161.
+  # return Lid(
+  #   name=name,
+  #   size_x=127.76,
+  #   size_y=85.48,
+  #   size_z=5,
+  #   nesting_z_height=None, # measure overlap between lid and plate
+  #   model="Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate_Lid",
+  # )
+
+
+def Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate(name: str, with_lid: bool = False) -> Plate:
+  """Thermo Fisher Scientific/Fisher Scientific cat. no.: 4483354/15273005 (= with barcode)
+  - Part no.: 16698853 (FS) (= **without** barcode).
+  - See `./engineering_diagrams/` directory for more part numbers (different colours).
+  - Material: Polycarbonate, Polypropylene.
+  - Sterilization compatibility: ?
+  - Chemical resistance: ?
+  - Thermal resistance: ?
+  - Cleanliness: 'Certified DNA-, RNAse-, and PCR inhibitor-free with in-process sampling tests'.
+  - ANSI/SLAS-format for compatibility with automated systems.
+  - optimal pickup_distance_from_top=4 mm.
+  - total_volume = 300 ul.
+  - working_volume = 200 ul (recommended by manufacturer).
+  """
+  return Plate(
+    name=name,
+    size_x=127.76,
+    size_y=85.48,
+    size_z=20.1 + 1.6 - 0.5,  # cavity_depth + material_z_thickness - well_extruding_over_plate
+    lid=Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate_Lid(name + "_lid") if with_lid else None,
+    model="Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate",
+    plate_type="semi-skirted",
+    ordered_items=create_ordered_items_2d(
+      Well,
+      num_items_x=12,
+      num_items_y=8,
+      dx=11.63,
+      dy=9.95,
+      dz=0.0,  # check that plate is semi-skirted
+      item_dx=9,
+      item_dy=9,
+      size_x=5.49,
+      size_y=5.49,
+      size_z=20.1,
+      bottom_type=WellBottomType.V,
+      material_z_thickness=1.6,
+      cross_section_type=CrossSectionType.CIRCLE,
+      compute_volume_from_height=(
+        _compute_volume_from_height_Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate
+      ),
+      compute_height_from_volume=(
+        _compute_height_from_volume_Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate
+      ),
+    ),
+  )
+
 
 def Thermo_Nunc_96_well_plate_1300uL_Rb(name: str) -> Plate:
   """


### PR DESCRIPTION
## Summary
- clean up _L and _P resource functions that only raised deprecation errors
- restore `Thermo_Nunc_96_well_plate_1300uL_Rb` after removing old helpers

## Testing
- `python -m py_compile pylabrobot/resources/azenta/plates.py pylabrobot/resources/eppendorf/plates.py pylabrobot/resources/hamilton/tip_racks.py pylabrobot/resources/porvair/plates.py pylabrobot/resources/thermo_fisher/plates.py`
- `make format`

------
https://chatgpt.com/codex/tasks/task_e_6840fe5c44c4832b85e3298ac77fef28