### PR TITLE
Fix `teaching_tip_rack` `tip_spot` indexing

### DIFF
--- a/pylabrobot/resources/hamilton/hamilton_decks.py
+++ b/pylabrobot/resources/hamilton/hamilton_decks.py
@@ -419,13 +419,14 @@ class HamiltonSTARDeck(HamiltonDeck):
         for i in range(8)
       ]
       for i, ts in enumerate(tip_spots):
-        ts.location = Coordinate(x=0, y=9 * i, z=23.1)
+        ts.location = Coordinate(x=0, y=7 * 9 - 9 * i, z=23.1)
+
       teaching_tip_rack = TipRack(
         name="teaching_tip_rack",
         size_x=9,
         size_y=9 * 8,
         size_z=50.4,
-        ordered_items={f"{letter}1": tip_spots[idx] for idx, letter in enumerate("HGFEDCBA")},
+        ordered_items={f"{letter}1": tip_spots[idx] for idx, letter in enumerate("ABCDEFGH")},
         with_tips=True,
         model="hamilton_teaching_tip_rack",
       )


### PR DESCRIPTION
Hi everyone,

On Hamilton STAR machines: the "teaching_tip_rack" so far has inconsistent tip_spot indexing:

Currently, "A1" is the frontmost tip_spot, "B1" is the second-frontmost tip_spot, see...
<img width="676" alt="image" src="https://github.com/user-attachments/assets/26970ece-b4b1-4c66-bb07-152607d83ba9" />

This leads to problems: when pick up is called for `teaching_tip_rack["A1:H1"]` channel_0 picks up the frontmost teaching needle as a single action, _then_ channel_1 picks up the second-frontmost channel as a single action, ...

---

-> Desired behaviour: pick up from `teaching_tip_rack["A1:H1"]` should pick up all teaching needles simultaneously, with channel_0 picking up the **backmost** teaching needle.

---

**I added a small fix in the tip_spot indexing (+ corresponding `get_identifier()`) in this PR.**

Now the desired behaviour looks like this...
<img width="676" alt="image" src="https://github.com/user-attachments/assets/42fcc7d0-3023-4f8a-b13c-1d3e91079c58" />
