### PR TITLE
Update `waste_block` Name & y-Origin Coordinate

### DIFF
--- a/pylabrobot/resources/hamilton/hamilton_decks.py
+++ b/pylabrobot/resources/hamilton/hamilton_decks.py
@@ -407,7 +407,7 @@ class HamiltonSTARDeck(HamiltonDeck):
       )
 
     if with_teaching_rack:
-      teaching_carrier = Resource(name="teaching_carrier", size_x=30, size_y=445.2, size_z=100)
+      waste_block = Resource(name="waste_block", size_x=30, size_y=445.2, size_z=100)
       tip_spots = [
         TipSpot(
           name=f"tip_spot_{i}",
@@ -419,7 +419,7 @@ class HamiltonSTARDeck(HamiltonDeck):
         for i in range(8)
       ]
       for i, ts in enumerate(tip_spots):
-        ts.location = Coordinate(x=0, y=7 * 9 - 9 * i, z=23.1)
+        ts.location = Coordinate(x=0, y=7*9 - 9*i, z=23.1) # A1 == index 0, topmost tip
 
       teaching_tip_rack = TipRack(
         name="teaching_tip_rack",
@@ -430,12 +430,12 @@ class HamiltonSTARDeck(HamiltonDeck):
         with_tips=True,
         model="hamilton_teaching_tip_rack",
       )
-      teaching_carrier.assign_child_resource(
-        teaching_tip_rack, location=Coordinate(x=5.9, y=409.3, z=0)
+      waste_block.assign_child_resource(
+        teaching_tip_rack, location=Coordinate(x=5.9, y=346.1, z=0)
       )
       self.assign_child_resource(
-        teaching_carrier,
-        location=Coordinate(x=self.rails_to_location(self.num_rails - 1).x, y=51.8, z=100),
+        waste_block,
+        location=Coordinate(x=self.rails_to_location(self.num_rails - 1).x, y=115.0, z=100),
       )
 
   def serialize(self) -> dict:


### PR DESCRIPTION
Hi everyone,

## Issues
1. the "waste block" as Hamilton names it has so far been called "teaching_carrier"
2. its y-origin coordinate has been protruding into the autoload area, i.e. was too low

## PR Content 

I updated the name.

I updated the y-origin location - while ensuring there is absolutely no change to the tip_spots inside the "teaching_tip_rack" which the "waste_block" hosts.

<img width="897" alt="image" src="https://github.com/user-attachments/assets/01edd484-fbf2-489a-958d-0ded2e509f3a" />

-> is now...

<img width="897" alt="image" src="https://github.com/user-attachments/assets/0e4fbc17-9f13-462b-99ab-8bae3729a231" />
