### PR TITLE
Fix ItemizedResource item ordering

### DIFF
--- a/pylabrobot/resources/itemized_resource.py
+++ b/pylabrobot/resources/itemized_resource.py
@@ -1,6 +1,6 @@
-from collections import OrderedDict
 import sys
 from abc import ABCMeta
+from collections import OrderedDict
 from string import ascii_uppercase as LETTERS
 from typing import (
   Dict,
@@ -96,7 +96,9 @@ class ItemizedResource(Resource, Generic[T], metaclass=ABCMeta):
           raise ValueError("Item location must be specified if supplied at initialization.")
         item.name = f"{self.name}_{item.name}"  # prefix item name with resource name
         self.assign_child_resource(item, location=item.location)
-      self._ordering = OrderedDict((identifier, item.name) for identifier, item in ordered_items.items())
+      self._ordering = OrderedDict(
+        (identifier, item.name) for identifier, item in ordered_items.items()
+      )
     else:
       if ordering is None:
         raise ValueError("Must specify either `ordered_items` or `ordering`.")

--- a/pylabrobot/resources/itemized_resource.py
+++ b/pylabrobot/resources/itemized_resource.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import sys
 from abc import ABCMeta
 from string import ascii_uppercase as LETTERS
@@ -47,7 +48,7 @@ class ItemizedResource(Resource, Generic[T], metaclass=ABCMeta):
     size_y: float,
     size_z: float,
     ordered_items: Optional[Dict[str, T]] = None,
-    ordering: Optional[List[str]] = None,
+    ordering: Optional[OrderedDict[str, str]] = None,
     category: Optional[str] = None,
     model: Optional[str] = None,
   ):
@@ -62,8 +63,8 @@ class ItemizedResource(Resource, Generic[T], metaclass=ABCMeta):
         :func:`pylabrobot.resources.create_ordered_items_2d`. If this is specified, `ordering` must
         be `None`. Keys must be in transposed MS Excel style notation, e.g. "A1" for the first item,
         "B1" for the item below that, "A2" for the item to the right, etc.
-      ordering: The order of the items on the resource. This is a list of identifiers. If this is
-        specified, `ordered_items` must be `None`. See `ordered_items` for the format of the
+      ordering: The order of the items on the resource. This is a dict of item identifier <> item name.
+        If this is specified, `ordered_items` must be `None`. See `ordered_items` for the format of the
         identifiers.
       category: The category of the resource.
 
@@ -95,7 +96,7 @@ class ItemizedResource(Resource, Generic[T], metaclass=ABCMeta):
           raise ValueError("Item location must be specified if supplied at initialization.")
         item.name = f"{self.name}_{item.name}"  # prefix item name with resource name
         self.assign_child_resource(item, location=item.location)
-      self._ordering = list(ordered_items.keys())
+      self._ordering = OrderedDict((identifier, item.name) for identifier, item in ordered_items.items())
     else:
       if ordering is None:
         raise ValueError("Must specify either `ordered_items` or `ordering`.")
@@ -155,11 +156,11 @@ class ItemizedResource(Resource, Generic[T], metaclass=ABCMeta):
     if isinstance(identifier, (slice, range)):
       start, stop = identifier.start, identifier.stop
       if isinstance(identifier.start, str):
-        start = self._ordering.index(identifier.start)
+        start = list(self._ordering.keys()).index(identifier.start)
       elif identifier.start is None:
         start = 0
       if isinstance(identifier.stop, str):
-        stop = self._ordering.index(identifier.stop)
+        stop = list(self._ordering.keys()).index(identifier.stop)
       elif identifier.stop is None:
         stop = self.num_items
       identifier = list(range(start, stop, identifier.step or 1))
@@ -188,7 +189,7 @@ class ItemizedResource(Resource, Generic[T], metaclass=ABCMeta):
       identifier = LETTERS[row] + str(column + 1)  # standard transposed-Excel style notation
     if isinstance(identifier, str):
       try:
-        identifier = self._ordering.index(identifier)
+        identifier = list(self._ordering.keys()).index(identifier)
       except ValueError as e:
         raise IndexError(
           f"Item with identifier '{identifier}' does not exist on " f"resource '{self.name}'."
@@ -413,17 +414,17 @@ class ItemizedResource(Resource, Generic[T], metaclass=ABCMeta):
 
   def index_of_item(self, item: T) -> Optional[int]:
     """Return the index of the given item in the resource, or `None` if not found."""
-    for i, i_item in enumerate(self.children):
-      if i_item == item:
+    for i, i_item_name in enumerate(self._ordering.values()):
+      if i_item_name == item.name:
         return i
     return None
 
   def get_child_identifier(self, item: T) -> str:
     """Get the identifier of the item."""
-    index = self.index_of_item(item)
-    if index is None:
-      raise ValueError(f"Item {item} not found in resource.")
-    return self._ordering[index]
+    for identifier, i_item_name in self._ordering.items():
+      if i_item_name == item.name:
+        return identifier
+    raise ValueError(f"Item {item} not found in resource.")
 
   def get_all_items(self) -> List[T]:
     """Get all items in the resource. Items are in a 1D list, starting from the top left and going

--- a/pylabrobot/resources/plate.py
+++ b/pylabrobot/resources/plate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import OrderedDict
 from typing import (
   TYPE_CHECKING,
   Dict,
@@ -73,7 +74,7 @@ class Plate(ItemizedResource["Well"]):
     size_y: float,
     size_z: float,
     ordered_items: Optional[Dict[str, "Well"]] = None,
-    ordering: Optional[List[str]] = None,
+    ordering: Optional[OrderedDict[str, str]] = None,
     category: str = "plate",
     lid: Optional[Lid] = None,
     model: Optional[str] = None,

--- a/pylabrobot/resources/tip_rack.py
+++ b/pylabrobot/resources/tip_rack.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABCMeta
+from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Sequence, Union, cast
 
 from pylabrobot.resources.coordinate import Coordinate
@@ -120,7 +121,7 @@ class TipRack(ItemizedResource[TipSpot], metaclass=ABCMeta):
     size_y: float,
     size_z: float,
     ordered_items: Optional[Dict[str, TipSpot]] = None,
-    ordering: Optional[List[str]] = None,
+    ordering: Optional[OrderedDict[str, str]] = None,
     category: str = "tip_rack",
     model: Optional[str] = None,
     with_tips: bool = True,
@@ -230,7 +231,7 @@ class NestedTipRack(TipRack):
     size_z: float,
     stacking_z_height: float,
     ordered_items: Optional[Dict[str, TipSpot]] = None,
-    ordering: Optional[List[str]] = None,
+    ordering: Optional[OrderedDict[str, str]] = None,
     category: str = "tip_rack",
     model: Optional[str] = None,
     with_tips: bool = True,


### PR DESCRIPTION
This PR refactors the ItemizedResource class (and its subclasses like Plate and TipRack) to store item ordering as an OrderedDict[str, str] mapping from identifier (e.g. “A1”) to child name (e.g. “plate_A1”) instead of a List[str]. This enables unambiguous conversion between indices and identifiers, resolving issues where get_item() and other methods could retrieve the wrong child due to reordered and/or extra children. The example that inspired this is a Lid as a child of Plate in front of Wells, messing up the well indexing. See https://github.com/PyLabRobot/pylabrobot/pull/565.

Key Changes:

- ItemizedResource._ordering is now an OrderedDict[str, str] mapping identifier to item name.
- All usages of self._ordering that previously relied on list indexing have been updated to use the mapping correctly.
- index_of_item() and get_child_identifier() have been updated to work with item names via _ordering.values(). No API change.
- Constructors for Plate, TipRack, and NestedTipRack now accept an OrderedDict for ordering.

Why:

Previously, child retrieval methods relied on a flat list of identifiers without a stable mapping to actual child names. This was fragile in cases where there are other children (such as a Lid on a Plate). By tracking the mapping explicitly, we can safely reference children by both identifier and name without relying on implicit positional assumptions.
