### PR TITLE
Modify tip presence probe return type

### DIFF
--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -2337,7 +2337,7 @@ class LiquidHandler(Resource, Machine):
 
   async def probe_tip_presence_via_pickup(
     self, tip_spots: List[TipSpot], use_channels: Optional[List[int]] = None
-  ) -> List[bool]:
+  ) -> Dict[str, bool]:
     """Probe tip presence by attempting pickup on each TipSpot.
 
     Args:
@@ -2345,7 +2345,7 @@ class LiquidHandler(Resource, Machine):
       use_channels: Channels to use (must match tip_spots length).
 
     Returns:
-      List[bool]: True if tip is present, False otherwise.
+      Dict[str, bool]: Mapping of tip spot names to presence flags.
     """
 
     if use_channels is None:
@@ -2410,4 +2410,4 @@ class LiquidHandler(Resource, Machine):
           assert cluster[0][0].location is not None, "TipSpot location must be at a location"
           print(f"Warning: drop_tips failed for cluster at x={cluster[0][0].location.x}: {e}")
 
-    return presence_flags
+    return {ts.name: flag for ts, flag in zip(tip_spots, presence_flags)}


### PR DESCRIPTION
## Summary
- adjust `probe_tip_presence_via_pickup` to return a dictionary mapping tip spot names to presence flags instead of a list

## Testing
- `make format`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68487e6903a8832ba01cb526fcfd8b8a