### PR TITLE
Add rtscts param to SerialValidator

### DIFF
--- a/pylabrobot/io/serial.py
+++ b/pylabrobot/io/serial.py
@@ -202,6 +202,7 @@ class SerialValidator(Serial):
     stopbits: int = 1,  # serial.STOPBITS_ONE,
     write_timeout=1,
     timeout=1,
+    rtscts: bool = False,
   ):
     super().__init__(
       port=port,
@@ -211,6 +212,7 @@ class SerialValidator(Serial):
       stopbits=stopbits,
       write_timeout=write_timeout,
       timeout=timeout,
+      rtscts=rtscts,
     )
     self.cr = cr
 


### PR DESCRIPTION
## Summary
- include rtscts in SerialValidator initialization

## Testing
- `pre-commit run --files pylabrobot/io/serial.py`
- `pytest -q` *(fails: 16 failed, 346 passed, 8 skipped, 67 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684d93999fc8832b92a0603e604a53d9