### PR TITLE
STAR debug page

### DIFF
--- a/docs/user_guide/00_liquid-handling/hamilton-star/_hamilton-star.rst
+++ b/docs/user_guide/00_liquid-handling/hamilton-star/_hamilton-star.rst
@@ -12,3 +12,4 @@ Tools for working with Hamilton-STAR specific functions.
    z-probing
    foil
    96head
+   debug

--- a/docs/user_guide/00_liquid-handling/hamilton-star/debug.md
+++ b/docs/user_guide/00_liquid-handling/hamilton-star/debug.md
@@ -1,0 +1,15 @@
+# Debugging STAR issues
+
+This page explains how to debug issues with PLR and a Hamilton STAR(let).
+
+## Finding VENUS trace files
+
+To get the firmware instructions sent by venus when doing specific operations, locate the following file:
+
+`C:\Program Files (x86)\HAMILTON\LogFiles\HxUsbCommYYYMMDD.trc`
+
+This information will be useful to see how the firmware commands sent by VENUS differ from the ones we send in PLR.
+
+```{warning}
+This file may contain firmware output of entire protocols you are running, so be careful with sharing it. You may want to look at the timestamps and filter the file to only include the relevant parts, or share the file privately.
+```


### PR DESCRIPTION
will be helpful with instructing people how to debug certain issues with star(let)s

to start, it includes how to get firmware commands sent by VENUS

but over time we can extend it

the goal is for this to be useful for people debugging stuff on their own, as well as for providing instructions when we help people on the forum