### PR TITLE
Fix abstract class detection

### DIFF
--- a/pylabrobot/machines/backend.py
+++ b/pylabrobot/machines/backend.py
@@ -1,6 +1,6 @@
-import weakref
-import inspect
 from abc import ABC, abstractmethod
+import inspect
+import weakref
 
 from pylabrobot.utils.object_parsing import find_subclass
 

--- a/pylabrobot/machines/backend.py
+++ b/pylabrobot/machines/backend.py
@@ -1,5 +1,6 @@
 import weakref
-from abc import ABC, ABCMeta, abstractmethod
+import inspect
+from abc import ABC, abstractmethod
 
 from pylabrobot.utils.object_parsing import find_subclass
 
@@ -29,7 +30,7 @@ class MachineBackend(ABC):
     subclass = find_subclass(class_name, cls=cls)
     if subclass is None:
       raise ValueError(f'Could not find subclass with name "{data["type"]}"')
-    if issubclass(subclass, ABCMeta):
+    if inspect.isabstract(subclass):
       raise ValueError(f'Subclass with name "{data["type"]}" is abstract')
     assert issubclass(subclass, cls)
     return subclass(**data)

--- a/pylabrobot/machines/backend.py
+++ b/pylabrobot/machines/backend.py
@@ -1,6 +1,6 @@
-from abc import ABC, abstractmethod
 import inspect
 import weakref
+from abc import ABC, abstractmethod
 
 from pylabrobot.utils.object_parsing import find_subclass
 


### PR DESCRIPTION
## Summary
- fix abstract class detection when deserializing machine backends

## Testing
- `pytest -q`
- `ruff .`
- `mypy pylabrobot`

------
https://chatgpt.com/codex/tasks/task_e_6876c8888068832b8e622d1118f91342