### PR TITLE
Improve ImportError handling

### DIFF
--- a/pylabrobot/audio/audio.py
+++ b/pylabrobot/audio/audio.py
@@ -9,15 +9,18 @@ try:
   from IPython.display import Audio, display
 
   USE_AUDIO = True
-except ImportError:
+except ImportError as e:
   USE_AUDIO = False
+  _AUDIO_IMPORT_ERROR = e
 
 
 def _audio_check(func):
   @functools.wraps(func)
   def wrapper(*args, **kwargs):
     if not USE_AUDIO:
-      return
+      raise RuntimeError(
+        f"Audio functionality requires IPython.display. Import error: {_AUDIO_IMPORT_ERROR}"
+      )
     return func(*args, **kwargs)
 
   return wrapper

--- a/pylabrobot/io/ftdi.py
+++ b/pylabrobot/io/ftdi.py
@@ -9,8 +9,9 @@ try:
   from pylibftdi import Device
 
   HAS_PYLIBFTDI = True
-except ImportError:
+except ImportError as e:
   HAS_PYLIBFTDI = False
+  _FTDI_IMPORT_ERROR = e
 
 from pylabrobot.io.capture import CaptureReader, Command, capturer, get_capture_or_validation_active
 from pylabrobot.io.errors import ValidationError
@@ -38,7 +39,7 @@ class FTDI(IOBase):
 
   async def setup(self):
     if not HAS_PYLIBFTDI:
-      raise RuntimeError("pylibftdi not installed.")
+      raise RuntimeError(f"pylibftdi not installed. Import error: {_FTDI_IMPORT_ERROR}")
     self._dev.open()
     self._executor = ThreadPoolExecutor(max_workers=1)
 

--- a/pylabrobot/io/hid.py
+++ b/pylabrobot/io/hid.py
@@ -12,8 +12,9 @@ try:
   import hid  # type: ignore
 
   USE_HID = True
-except ImportError:
+except ImportError as e:
   USE_HID = False
+  _HID_IMPORT_ERROR = e
 
 
 logger = logging.getLogger(__name__)
@@ -40,7 +41,9 @@ class HID(IOBase):
 
   async def setup(self):
     if not USE_HID:
-      raise RuntimeError("This backend requires the `hid` package to be installed")
+      raise RuntimeError(
+        f"This backend requires the `hid` package to be installed. Import error: {_HID_IMPORT_ERROR}"
+      )
     self.device = hid.Device(vid=self.vid, pid=self.pid, serial=self.serial_number)
     self._executor = ThreadPoolExecutor(max_workers=1)
     logger.log(LOG_LEVEL_IO, "Opened HID device %s", self._unique_id)

--- a/pylabrobot/io/serial.py
+++ b/pylabrobot/io/serial.py
@@ -11,8 +11,9 @@ try:
   import serial
 
   HAS_SERIAL = True
-except ImportError:
+except ImportError as e:
   HAS_SERIAL = False
+  _SERIAL_IMPORT_ERROR = e
 
 from pylabrobot.io.capture import CaptureReader, Command, capturer, get_capture_or_validation_active
 from pylabrobot.io.validation_utils import LOG_LEVEL_IO, align_sequences
@@ -63,7 +64,7 @@ class Serial(IOBase):
 
   async def setup(self):
     if not HAS_SERIAL:
-      raise RuntimeError("pyserial not installed.")
+      raise RuntimeError(f"pyserial not installed. Import error: {_SERIAL_IMPORT_ERROR}")
     loop = asyncio.get_running_loop()
     self._executor = ThreadPoolExecutor(max_workers=1)
 

--- a/pylabrobot/liquid_handling/backends/http.py
+++ b/pylabrobot/liquid_handling/backends/http.py
@@ -10,8 +10,9 @@ try:
   import requests
 
   HAS_REQUESTS = True
-except ImportError:
+except ImportError as e:
   HAS_REQUESTS = False
+  _REQUESTS_IMPORT_ERROR = e
 
 
 class HTTPBackend(SerializingBackend):
@@ -44,7 +45,9 @@ class HTTPBackend(SerializingBackend):
     """
 
     if not HAS_REQUESTS:
-      raise RuntimeError("The http backend requires the requests module.")
+      raise RuntimeError(
+        f"The http backend requires the requests module. Import error: {_REQUESTS_IMPORT_ERROR}"
+      )
 
     super().__init__(num_channels=num_channels)
     self.session: Optional[requests.Session] = None

--- a/pylabrobot/liquid_handling/backends/opentrons_backend.py
+++ b/pylabrobot/liquid_handling/backends/opentrons_backend.py
@@ -43,8 +43,9 @@ if PYTHON_VERSION == (3, 10):
     from requests import HTTPError
 
     USE_OT = True
-  except ImportError:
+  except ImportError as e:
     USE_OT = False
+    _OT_IMPORT_ERROR = e
 else:
   USE_OT = False
 
@@ -79,6 +80,7 @@ class OpentronsBackend(LiquidHandlerBackend):
     if not USE_OT:
       raise RuntimeError(
         "Opentrons is not installed. Please run pip install pylabrobot[opentrons]."
+        f" Import error: {_OT_IMPORT_ERROR}."
         " Only supported on Python 3.10 and below."
       )
 

--- a/pylabrobot/liquid_handling/backends/websocket.py
+++ b/pylabrobot/liquid_handling/backends/websocket.py
@@ -12,8 +12,9 @@ try:
   import websockets.legacy.server
 
   HAS_WEBSOCKETS = True
-except ImportError:
+except ImportError as e:
   HAS_WEBSOCKETS = False
+  _WEBSOCKETS_IMPORT_ERROR = e
 
 from pylabrobot.__version__ import STANDARD_FORM_JSON_VERSION
 from pylabrobot.liquid_handling.backends.serializing_backend import (
@@ -46,7 +47,9 @@ class WebSocketBackend(SerializingBackend):
     """
 
     if not HAS_WEBSOCKETS:
-      raise RuntimeError("The WebSocketBackend requires websockets to be installed.")
+      raise RuntimeError(
+        f"The WebSocketBackend requires websockets to be installed. Import error: {_WEBSOCKETS_IMPORT_ERROR}"
+      )
 
     super().__init__(num_channels=num_channels)
     self._websocket: Optional["websockets.legacy.server.WebSocketServerProtocol"] = None
@@ -252,7 +255,9 @@ class WebSocketBackend(SerializingBackend):
     """Start the websocket server. This will run in a separate thread."""
 
     if not HAS_WEBSOCKETS:
-      raise RuntimeError("The WebSocketBackend requires websockets to be installed.")
+      raise RuntimeError(
+        f"The WebSocketBackend requires websockets to be installed. Import error: {_WEBSOCKETS_IMPORT_ERROR}"
+      )
 
     async def run_server():
       self._stop_ = self.loop.create_future()

--- a/pylabrobot/pumps/agrowpumps/agrowdosepump_backend.py
+++ b/pylabrobot/pumps/agrowpumps/agrowdosepump_backend.py
@@ -6,8 +6,11 @@ from typing import Dict, List, Optional, Union
 
 try:
   from pymodbus.client import AsyncModbusSerialClient  # type: ignore
-except ImportError:
+
+  _MODBUS_IMPORT_ERROR = None
+except ImportError as e:
   AsyncModbusSerialClient = None  # type: ignore
+  _MODBUS_IMPORT_ERROR = e
 
 from pylabrobot.pumps.backend import PumpArrayBackend
 
@@ -117,7 +120,10 @@ class AgrowPumpArrayBackend(PumpArrayBackend):
 
   async def _setup_modbus(self):
     if AsyncModbusSerialClient is None:
-      raise RuntimeError("pymodbus is not installed. Please install it with 'pip install pymodbus'")
+      raise RuntimeError(
+        "pymodbus is not installed. Please install it with 'pip install pymodbus'."
+        f" Import error: {_MODBUS_IMPORT_ERROR}"
+      )
     self._modbus = AsyncModbusSerialClient(
       port=self.port,
       baudrate=115200,

--- a/pylabrobot/resources/opentrons/load.py
+++ b/pylabrobot/resources/opentrons/load.py
@@ -6,8 +6,9 @@ try:
   import opentrons_shared_data.labware
 
   USE_OT = True
-except ImportError:
+except ImportError as e:
   USE_OT = False
+  _OT_IMPORT_ERROR = e
 
 from pylabrobot.resources.coordinate import Coordinate
 from pylabrobot.resources.plate import Plate
@@ -35,7 +36,9 @@ def ot_definition_to_resource(
 
   if not USE_OT:
     raise ImportError(
-      "opentrons_shared_data is not installed. " "run `pip install opentrons_shared_data`"
+      "opentrons_shared_data is not installed. "
+      f"Import error: {_OT_IMPORT_ERROR}. "
+      "run `pip install opentrons_shared_data`"
     )
 
   display_category = data["metadata"]["displayCategory"]

--- a/pylabrobot/temperature_controlling/opentrons_backend.py
+++ b/pylabrobot/temperature_controlling/opentrons_backend.py
@@ -12,8 +12,9 @@ if PYTHON_VERSION == (3, 10):
     import ot_api
 
     USE_OT = True
-  except ImportError:
+  except ImportError as e:
     USE_OT = False
+    _OT_IMPORT_ERROR = e
 else:
   USE_OT = False
 
@@ -37,6 +38,7 @@ class OpentronsTemperatureModuleBackend(TemperatureControllerBackend):
     if not USE_OT:
       raise RuntimeError(
         "Opentrons is not installed. Please run pip install pylabrobot[opentrons]."
+        f" Import error: {_OT_IMPORT_ERROR}."
         " Only supported on Python 3.10."
       )
 

--- a/pylabrobot/tilting/hamilton_backend.py
+++ b/pylabrobot/tilting/hamilton_backend.py
@@ -5,8 +5,9 @@ try:
   import serial
 
   HAS_SERIAL = True
-except ImportError:
+except ImportError as e:
   HAS_SERIAL = False
+  _SERIAL_IMPORT_ERROR = e
 
 from pylabrobot.io.serial import Serial
 from pylabrobot.tilting.tilter_backend import (
@@ -24,6 +25,11 @@ class HamiltonTiltModuleBackend(TilterBackend):
     write_timeout: float = 10,
     timeout: float = 10,
   ):
+    if not HAS_SERIAL:
+      raise RuntimeError(
+        f"pyserial is required for the Hamilton tilt module backend. Import error: {_SERIAL_IMPORT_ERROR}"
+      )
+
     self.setup_finished = False
     self.com_port = com_port
     self.timeout = timeout

--- a/pylabrobot/visualizer/visualizer.py
+++ b/pylabrobot/visualizer/visualizer.py
@@ -15,8 +15,9 @@ try:
   import websockets.legacy.server
 
   HAS_WEBSOCKETS = True
-except ImportError:
+except ImportError as e:
   HAS_WEBSOCKETS = False
+  _WEBSOCKETS_IMPORT_ERROR = e
 
 from pylabrobot.__version__ import STANDARD_FORM_JSON_VERSION
 from pylabrobot.resources import Resource
@@ -277,7 +278,9 @@ class Visualizer:
     """
 
     if not HAS_WEBSOCKETS:
-      raise RuntimeError("The visualizer requires websockets to be installed.")
+      raise RuntimeError(
+        f"The visualizer requires websockets to be installed. Import error: {_WEBSOCKETS_IMPORT_ERROR}"
+      )
 
     async def run_server():
       self._stop_ = self.loop.create_future()


### PR DESCRIPTION
## Summary
- surface import failures when optional dependencies are missing
- report the import exception at runtime in several modules
- keep `make format` happy

## Testing
- `make format-check`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687adf9b1cc0832b8ba43ac3e94c80ab