### PR TITLE
Add new MFX DWP module (cat.-no. 188042) with pedestal support

### DIFF
--- a/pylabrobot/resources/hamilton/mfx_modules.py
+++ b/pylabrobot/resources/hamilton/mfx_modules.py
@@ -33,12 +33,45 @@ def MFX_DWP_rackbased_module(name: str) -> PlateHolder:
     name=name,
     size_x=135.0,
     size_y=94.0,
-    size_z=178.0 - 18.195 - 100,
+    size_z=178.0 - 18.195 - 100, #59.81mm
     # probe height - carrier_height - deck_height
     child_location=Coordinate(4.0, 3.5, 178.0 - 18.195 - 100),
     model=MFX_DWP_rackbased_module.__name__,
     pedestal_size_z=0,
   )
+
+def MFX_DWP_module_188042(name: str) -> PlateHolder:
+    """Hamilton MFX DWP Module (cat.-no. 188042 / 188042-00).
+    This module contains a pedestal that elevates the plate by 6mm. The plate rests on the pedestal
+    It also contains metal clamps at the corners. 
+    https://www.hamiltoncompany.com/other-robotics/188042
+    """
+    # ── module footprint ──────────────
+    # size_x = 132.50          # mm
+    size_x = 135
+    # size_y = 92.05           # mm
+    size_y = 94 
+
+    # ── vertical geometry ──────────────────────────────
+    pedestal_size_z = 6.45   # The height of the pedestal
+    # size_z = 178.3 - 18.195 - 100   # 60.10mm is module height above MFX carrier. This height does not including pedestal
+    size_z = 184.745 - 18.195 - 100   # 60.10mm is module height above MFX carrier. This height includes pedestal.
+    # module.get_absolute_size_y() = 184.745 puts channel right on the pedestal
+
+    # ── where the plate’s lower-left corner sits ───────
+    child_x = 4.0           # mm  
+    child_y = 3.5           # mm
+    child_location = Coordinate(child_x, child_y, size_z)
+
+    return PlateHolder(
+        name=name,
+        size_x=size_x,
+        size_y=size_y,
+        size_z=size_z,
+        child_location=child_location,
+        model=MFX_DWP_module_188042.__name__,
+        pedestal_size_z=pedestal_size_z,
+    )
 
 
 def MFX_DWP_module_flat(name: str) -> PlateHolder:


### PR DESCRIPTION
This commit introduces a new function, `MFX_DWP_module_188042`, for handling the Hamilton MFX DWP Module with the catalog number 188042. This module includes a pedestal that elevates the plate by 6mm, and the function accurately reflects this by setting the `pedestal_size_z` to 6.45mm. The function also specifies the module's dimensions (size_x and size_y) and positions (child_x and child_y) to account for the metal clamps at the corners. Additionally, the `size_z` calculation is updated to include the pedestal height, ensuring the correct overall height when the module is placed on the MFX carrier. The function returns a `PlateHolder` object with all these parameters initialized appropriately.