### PR TITLE
Add __len__ to Carrier

### DIFF
--- a/pylabrobot/resources/carrier.py
+++ b/pylabrobot/resources/carrier.py
@@ -52,6 +52,10 @@ class Carrier(Resource, Generic[S]):
     """The number of sites on this carrier."""
     return len(self.sites)
 
+  def __len__(self) -> int:
+    """Return the number of sites on this carrier."""
+    return len(self.sites)
+
   def assign_child_resource(
     self,
     resource: Resource,

--- a/pylabrobot/resources/carrier_tests.py
+++ b/pylabrobot/resources/carrier_tests.py
@@ -160,6 +160,9 @@ class CarrierTests(unittest.TestCase):
   def test_capacity(self):
     self.assertEqual(self.tip_car.capacity, 5)
 
+  def test_len(self):
+    self.assertEqual(len(self.tip_car), 5)
+
   def test_assignment(self):
     self.tip_car[0] = self.A
     self.tip_car[1] = self.B


### PR DESCRIPTION
## Summary
- implement `__len__` in `Carrier`
- test that `len(carrier)` equals capacity

## Testing
- `pre-commit run --files pylabrobot/resources/carrier.py pylabrobot/resources/carrier_tests.py`
- `pytest pylabrobot/resources/carrier_tests.py::CarrierTests::test_len -q`

------
https://chatgpt.com/codex/tasks/task_e_68800f3e66d0832baecfe2c5d3d0b25c