### PR TITLE
Add liquid_height parameter to aspirate96 and dispense96

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -2239,7 +2239,6 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     jet: bool = False,
     blow_out: bool = False,
     use_lld: bool = False,
-    liquid_height: float = 0,
     air_transport_retract_dist: float = 10,
     hlc: Optional[HamiltonLiquidClass] = None,
     aspiration_type: int = 0,
@@ -2277,7 +2276,6 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
         automatically.
 
       use_lld: If True, use gamma liquid level detection. If False, use liquid height.
-      liquid_height: The height of the liquid above the bottom of the well, in millimeters.
       air_transport_retract_dist: The distance to retract after aspirating, in millimeters.
 
       aspiration_type: The type of aspiration to perform. (0 = simple; 1 = sequence; 2 = cup emptied
@@ -2332,7 +2330,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
 
     tip = aspiration.tips[0]
 
-    liquid_height = position.z + liquid_height
+    liquid_height = position.z + (aspiration.liquid_height or 0)
 
     liquid_to_be_aspirated = Liquid.WATER
     if len(aspiration.liquids[0]) > 0 and aspiration.liquids[0][0][0] is not None:
@@ -2430,7 +2428,6 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     empty: bool = False,
     blow_out: bool = False,
     hlc: Optional[HamiltonLiquidClass] = None,
-    liquid_height: float = 0,
     dispense_mode: Optional[int] = None,
     air_transport_retract_dist=10,
     use_lld: bool = False,
@@ -2462,7 +2459,6 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       dispense: The Dispense command to execute.
       jet: Whether to use jet dispense mode.
       blow_out: Whether to blow out after dispensing.
-      liquid_height: The height of the liquid in the well, in mm. Used if LLD is not used.
       dispense_mode: The dispense mode to use. 0 = Partial volume in jet mode 1 = Blow out in jet
         mode 2 = Partial volume at surface 3 = Blow out at surface 4 = Empty tip at fix position.
         If `None`, the mode will be determined based on the `jet`, `empty`, and `blow_out`
@@ -2518,7 +2514,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       )
     tip = dispense.tips[0]
 
-    liquid_height = position.z + liquid_height
+    liquid_height = position.z + (dispense.liquid_height or 0)
 
     dispense_mode = _dispensing_mode_for_op(empty=empty, jet=jet, blow_out=blow_out)
 

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1517,6 +1517,7 @@ class LiquidHandler(Resource, Machine):
     volume: float,
     offset: Coordinate = Coordinate.zero(),
     flow_rate: Optional[float] = None,
+    liquid_height: Optional[float] = None,
     blow_out_air_volume: Optional[float] = None,
     **backend_kwargs,
   ):
@@ -1535,6 +1536,8 @@ class LiquidHandler(Resource, Machine):
         the plate or container is defined to be. Defaults to Coordinate.zero().
       flow_rate ([Optional[float]]): The flow rate to use when aspirating, in ul/s. If `None`, the
         backend default will be used.
+      liquid_height ([Optional[float]]): The height of the liquid in the well wrt the bottom, in
+        mm. If `None`, the backend default will be used.
       blow_out_air_volume ([Optional[float]]): The volume of air to aspirate after the liquid, in
         ul. If `None`, the backend default will be used.
       backend_kwargs: Additional keyword arguments for the backend, optional.
@@ -1546,6 +1549,7 @@ class LiquidHandler(Resource, Machine):
       volume=volume,
       offset=offset,
       flow_rate=flow_rate,
+      liquid_height=liquid_height,
       blow_out_air_volume=blow_out_air_volume,
     )
 
@@ -1597,7 +1601,7 @@ class LiquidHandler(Resource, Machine):
         offset=offset,
         flow_rate=flow_rate,
         tips=tips,
-        liquid_height=None,
+        liquid_height=liquid_height,
         blow_out_air_volume=blow_out_air_volume,
         liquids=cast(List[List[Tuple[Optional[Liquid], float]]], all_liquids),  # stupid
       )
@@ -1640,7 +1644,7 @@ class LiquidHandler(Resource, Machine):
         offset=offset,
         flow_rate=flow_rate,
         tips=tips,
-        liquid_height=None,
+        liquid_height=liquid_height,
         blow_out_air_volume=blow_out_air_volume,
         liquids=cast(List[List[Tuple[Optional[Liquid], float]]], all_liquids),  # stupid
       )
@@ -1665,6 +1669,7 @@ class LiquidHandler(Resource, Machine):
     volume: float,
     offset: Coordinate = Coordinate.zero(),
     flow_rate: Optional[float] = None,
+    liquid_height: Optional[float] = None,
     blow_out_air_volume: Optional[float] = None,
     **backend_kwargs,
   ):
@@ -1682,6 +1687,8 @@ class LiquidHandler(Resource, Machine):
         the plate or container is defined to be. Defaults to Coordinate.zero().
       flow_rate ([Optional[float]]): The flow rate to use when dispensing, in ul/s. If `None`, the
         backend default will be used.
+      liquid_height ([Optional[float]]): The height of the liquid in the well wrt the bottom, in
+        mm. If `None`, the backend default will be used.
       blow_out_air_volume ([Optional[float]]): The volume of air to dispense after the liquid, in
         ul. If `None`, the backend default will be used.
       backend_kwargs: Additional keyword arguments for the backend, optional.
@@ -1693,6 +1700,7 @@ class LiquidHandler(Resource, Machine):
       volume=volume,
       offset=offset,
       flow_rate=flow_rate,
+      liquid_height=liquid_height,
       blow_out_air_volume=blow_out_air_volume,
     )
 
@@ -1744,7 +1752,7 @@ class LiquidHandler(Resource, Machine):
         offset=offset,
         flow_rate=flow_rate,
         tips=tips,
-        liquid_height=None,
+        liquid_height=liquid_height,
         blow_out_air_volume=blow_out_air_volume,
         liquids=cast(List[List[Tuple[Optional[Liquid], float]]], all_liquids),  # stupid
       )
@@ -1784,7 +1792,7 @@ class LiquidHandler(Resource, Machine):
         offset=offset,
         flow_rate=flow_rate,
         tips=tips,
-        liquid_height=None,
+        liquid_height=liquid_height,
         blow_out_air_volume=blow_out_air_volume,
         liquids=all_liquids,
       )


### PR DESCRIPTION
## Summary
- allow specifying `liquid_height` in the LiquidHandler `aspirate96` and `dispense96` APIs
- forward the parameter to backend operations and remove backend specific argument

## Testing
- `make format`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68802234b690832b807da597d3dcc087