### PR TITLE
Fix resource repr quoting

### DIFF
--- a/pylabrobot/resources/itemized_resource.py
+++ b/pylabrobot/resources/itemized_resource.py
@@ -366,7 +366,7 @@ class ItemizedResource(Resource, Generic[T], metaclass=ABCMeta):
 
   def __repr__(self) -> str:
     return (
-      f"{self.__class__.__name__}(name={self.name}, size_x={self._size_x}, "
+      f"{self.__class__.__name__}(name={self.name!r}, size_x={self._size_x}, "
       f"size_y={self._size_y}, size_z={self._size_z}, location={self.location})"
     )
 

--- a/pylabrobot/resources/plate.py
+++ b/pylabrobot/resources/plate.py
@@ -145,7 +145,7 @@ class Plate(ItemizedResource["Well"]):
 
   def __repr__(self) -> str:
     return (
-      f"{self.__class__.__name__}(name={self.name}, size_x={self._size_x}, "
+      f"{self.__class__.__name__}(name={self.name!r}, size_x={self._size_x}, "
       f"size_y={self._size_y}, size_z={self._size_z}, location={self.location})"
     )
 

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -133,7 +133,7 @@ class Resource:
 
   def __repr__(self) -> str:
     return (
-      f"{self.__class__.__name__}(name={self.name}, location={self.location}, "
+      f"{self.__class__.__name__}(name={self.name!r}, location={self.location}, "
       f"size_x={self._size_x}, size_y={self._size_y}, size_z={self._size_z}, "
       f"category={self.category})"
     )

--- a/pylabrobot/resources/tip_rack.py
+++ b/pylabrobot/resources/tip_rack.py
@@ -145,7 +145,7 @@ class TipRack(ItemizedResource[TipSpot], metaclass=ABCMeta):
 
   def __repr__(self) -> str:
     return (
-      f"{self.__class__.__name__}(name={self.name}, size_x={self._size_x}, "
+      f"{self.__class__.__name__}(name={self.name!r}, size_x={self._size_x}, "
       f"size_y={self._size_y}, size_z={self._size_z}, location={self.location})"
     )
 
@@ -253,7 +253,7 @@ class NestedTipRack(TipRack):
 
   def __repr__(self) -> str:
     return (
-      f"{self.__class__.__name__}(name={self.name}, size_x={self._size_x}, "
+      f"{self.__class__.__name__}(name={self.name!r}, size_x={self._size_x}, "
       f"size_y={self._size_y}, size_z={self._size_z}, "
       f"stacking_z_height={self.stacking_z_height}, location={self.location})"
     )

--- a/pylabrobot/resources/tube_rack.py
+++ b/pylabrobot/resources/tube_rack.py
@@ -49,7 +49,7 @@ class TubeRack(ItemizedResource[Tube]):
 
   def __repr__(self) -> str:
     return (
-      f"{self.__class__.__name__}(name={self.name}, size_x={self._size_x}, "
+      f"{self.__class__.__name__}(name={self.name!r}, size_x={self._size_x}, "
       f"size_y={self._size_y}, size_z={self._size_z}, location={self.location})"
     )
 


### PR DESCRIPTION
## Summary
- show resource names in quotes when printing repr

## Testing
- `make test`
- `make typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6882a8d4d3c0832bba7f65aa94f209d9