### PR TITLE
Add is_in_subtree_of helper

### DIFF
--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -375,6 +375,16 @@ class Resource:
       return self
     return self.parent.get_root()
 
+  def is_in_subtree_of(self, other: Resource) -> bool:
+    """Return ``True`` if ``self`` is in the subtree rooted at ``other``."""
+
+    current: Optional[Resource] = self
+    while current is not None:
+      if current is other:
+        return True
+      current = current.parent
+    return False
+
   def _check_naming_conflicts(self, resource: Resource):
     """Recursively check for naming conflicts in the resource tree."""
     if resource.name == self.name:


### PR DESCRIPTION
## Summary
- provide `Resource.is_in_subtree_of` to check containment in a tree

## Testing
- `make format`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6882b789e32c832bb861b42aa9d487de