### PR TITLE
Add coordinate check for STAR 96-head functions

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -3253,7 +3253,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       skip_z: If True, the z coordinate is not checked. This is useful for commands that handle
         the z coordinate separately, such as the big four.
 
-    Raises: 
+    Raises:
       ValueError: If one or more components are out of range. The error message contains all offending components.
     """
 

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -3248,16 +3248,13 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
   def _check_96_position_legal(self, c: Coordinate, skip_z=False) -> None:
     """Validate that a coordinate is within the allowed range for the 96 head.
 
-    Parameters
-    ----------
-    c:
-      The coordinate of the A1 position of the head.
+    Args:
+      c: The coordinate of the A1 position of the head.
+      skip_z: If True, the z coordinate is not checked. This is useful for commands that handle
+        the z coordinate separately, such as the big four.
 
-    Raises
-    ------
-    ValueError
-      If one or more components are out of range. The error message contains
-      all offending components.
+    Raises: 
+      ValueError: If one or more components are out of range. The error message contains all offending components.
     """
 
     errors = []


### PR DESCRIPTION
## Summary
- add `_check_96_position_legal` helper on `STARBackend`
- validate 96‑head positions for initialization, pick up/drop tips, aspirate and dispense
- call the check in `move_core_96_head_to_defined_position`

## Testing
- `pytest -q` *(fails: 22 failed, 348 passed, 18 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6883d350d99c832b967e5bce55972fa2