### PR TITLE
Add block status and refine lid/block status handling

### DIFF
--- a/pylabrobot/thermocycling/backend.py
+++ b/pylabrobot/thermocycling/backend.py
@@ -57,6 +57,14 @@ class ThermocyclerBackend(MachineBackend, metaclass=ABCMeta):
     """Return ``True`` if the lid is open."""
 
   @abstractmethod
+  async def get_lid_temperature_status(self) -> str:
+    """Get the lid temperature status."""
+
+  @abstractmethod
+  async def get_block_status(self) -> str:
+    """Get the block status."""
+
+  @abstractmethod
   async def get_hold_time(self) -> float:
     """Get remaining hold time in seconds."""
 

--- a/pylabrobot/thermocycling/chatterbox.py
+++ b/pylabrobot/thermocycling/chatterbox.py
@@ -179,3 +179,13 @@ class ThermocyclerChatterboxBackend(ThermocyclerBackend):
 
   async def get_lid_open(self) -> bool:
     return self._state.lid_open
+
+  async def get_lid_temperature_status(self) -> str:
+    if self._state.lid_target is not None:
+      return "holding at target"
+    return "idle"
+
+  async def get_block_status(self) -> str:
+    if self._state.block_target is not None:
+      return "holding at target"
+    return "idle"

--- a/pylabrobot/thermocycling/opentrons_backend.py
+++ b/pylabrobot/thermocycling/opentrons_backend.py
@@ -129,21 +129,39 @@ class OpentronsThermocyclerBackend(ThermocyclerBackend):
   async def get_lid_open(self) -> bool:
     return cast(str, self._find_module()["lidStatus"]) == "open"
 
+  async def get_lid_temperature_status(self) -> str:
+    return cast(str, self._find_module()["lidTemperatureStatus"])
+
+  async def get_block_status(self) -> str:
+    return cast(str, self._find_module()["status"])
+
   async def get_hold_time(self) -> float:
     return cast(float, self._find_module().get("holdTime", 0.0))
 
   async def get_current_cycle_index(self) -> int:
     """Get the zero-based index of the current cycle from the Opentrons API."""
     # Opentrons API returns one-based, convert to zero-based
-    return cast(int, self._find_module()["currentCycleIndex"]) - 1
+    cycle_index = self._find_module().get("currentCycleIndex")
+    if cycle_index is None:
+      raise RuntimeError("Current cycle index is not available. Is a profile running?")
+    return cast(int, cycle_index) - 1
 
   async def get_total_cycle_count(self) -> int:
-    return cast(int, self._find_module()["totalCycleCount"])
+    total_cycles = self._find_module().get("totalCycleCount")
+    if total_cycles is None:
+      raise RuntimeError("Total cycle count is not available. Is a profile running?")
+    return cast(int, total_cycles)
 
   async def get_current_step_index(self) -> int:
     """Get the zero-based index of the current step from the Opentrons API."""
     # Opentrons API returns one-based, convert to zero-based
-    return cast(int, self._find_module()["currentStepIndex"]) - 1
+    step_index = self._find_module().get("currentStepIndex")
+    if step_index is None:
+      raise RuntimeError("Current step index is not available. Is a profile running?")
+    return cast(int, step_index) - 1
 
   async def get_total_step_count(self) -> int:
-    return cast(int, self._find_module()["totalStepCount"])
+    total_steps = self._find_module().get("totalStepCount")
+    if total_steps is None:
+      raise RuntimeError("Total step count is not available. Is a profile running?")
+    return cast(int, total_steps)

--- a/pylabrobot/thermocycling/opentrons_backend_tests.py
+++ b/pylabrobot/thermocycling/opentrons_backend_tests.py
@@ -88,6 +88,8 @@ class TestOpentronsThermocyclerBackend(unittest.IsolatedAsyncioTestCase):
         "lidTemperature": 37.1,
         "lidTargetTemperature": 105.0,
         "lidStatus": "open",
+        "lidTemperatureStatus": "holding at target",
+        "status": "holding at target",
         "holdTime": 12.0,
         "currentCycleIndex": 2,
         "totalCycleCount": 10,
@@ -102,6 +104,8 @@ class TestOpentronsThermocyclerBackend(unittest.IsolatedAsyncioTestCase):
     assert await self.thermocycler_backend.get_lid_current_temperature() == 37.1
     assert await self.thermocycler_backend.get_lid_target_temperature() == 105.0
     assert await self.thermocycler_backend.get_lid_open() is True
+    assert await self.thermocycler_backend.get_lid_temperature_status() == "holding at target"
+    assert await self.thermocycler_backend.get_block_status() == "holding at target"
     assert await self.thermocycler_backend.get_hold_time() == 12.0
     assert await self.thermocycler_backend.get_current_cycle_index() == 1  # 2 - 1 = 1 (zero-based)
     assert await self.thermocycler_backend.get_total_cycle_count() == 10

--- a/pylabrobot/thermocycling/thermocycler.py
+++ b/pylabrobot/thermocycling/thermocycler.py
@@ -174,6 +174,14 @@ class Thermocycler(ResourceHolder, Machine):
     """Return ``True`` if the lid is open."""
     return await self.backend.get_lid_open()
 
+  async def get_lid_temperature_status(self) -> str:
+    """Get the lid temperature status."""
+    return await self.backend.get_lid_temperature_status()
+
+  async def get_block_status(self) -> str:
+    """Get the block status."""
+    return await self.backend.get_block_status()
+
   async def get_hold_time(self) -> float:
     """Get remaining hold time (s) for the current step."""
     return await self.backend.get_hold_time()
@@ -217,7 +225,8 @@ class Thermocycler(ResourceHolder, Machine):
           return
       else:
         # If no target temperature, check status
-        if not await self.get_lid_open():
+        status = await self.get_lid_temperature_status()
+        if status in ["idle", "holding at target"]:
           return
       await asyncio.sleep(1)
     raise TimeoutError("Lid temperature timeout.")

--- a/pylabrobot/thermocycling/thermocycler.py
+++ b/pylabrobot/thermocycling/thermocycler.py
@@ -213,7 +213,7 @@ class Thermocycler(ResourceHolder, Machine):
     raise TimeoutError("Block temperature timeout.")
 
   async def wait_for_lid(self, timeout: float = 1200, tolerance: float = 0.5):
-    """Wait until the lid temperature reaches target ± ``tolerance`` or the lid closes."""
+    """Wait until the lid temperature reaches target ± ``tolerance`` or the lid temperature status is idle/holding at target."""
     try:
       target = await self.get_lid_target_temperature()
     except RuntimeError:

--- a/pylabrobot/thermocycling/thermocycler_tests.py
+++ b/pylabrobot/thermocycling/thermocycler_tests.py
@@ -28,6 +28,8 @@ def mock_backend() -> MagicMock:
   mock.get_lid_current_temperature = AsyncMock(return_value=25.0)
   mock.get_lid_target_temperature = AsyncMock(return_value=None)
   mock.get_lid_open = AsyncMock(return_value=False)
+  mock.get_lid_temperature_status = AsyncMock(return_value="idle")
+  mock.get_block_status = AsyncMock(return_value="idle")
   mock.get_hold_time = AsyncMock(return_value=0.0)
   mock.get_current_cycle_index = AsyncMock(return_value=0)
   mock.get_total_cycle_count = AsyncMock(return_value=0)


### PR DESCRIPTION
- Added `get_block_status` to ThermocyclerBackend and its implementations.                                                                                                     
- Refined `get_lid_open` and `get_lid_temperature_status` methods.                                                                                                             
- Updated Opentrons backend to handle missing cycle/step data gracefully.