### PR TITLE
ThermoCycler support multiple zones

### DIFF
--- a/pylabrobot/thermocycling/backend.py
+++ b/pylabrobot/thermocycling/backend.py
@@ -17,12 +17,20 @@ class ThermocyclerBackend(MachineBackend, metaclass=ABCMeta):
     """Close thermocycler lid."""
 
   @abstractmethod
-  async def set_block_temperature(self, temperature: float):
-    """Set the temperature of a thermocycler block."""
+  async def set_block_temperature(self, temperature: List[float]):
+    """Set the temperature of a thermocycler block.
+
+    Args:
+      temperature: Temperature for each zone.
+    """
 
   @abstractmethod
-  async def set_lid_temperature(self, temperature: float):
-    """Set the temperature of a thermocycler lid."""
+  async def set_lid_temperature(self, temperature: List[float]):
+    """Set the temperature of a thermocycler lid.
+
+    Args:
+      temperature: Temperature for each zone.
+    """
 
   @abstractmethod
   async def deactivate_block(self):
@@ -37,20 +45,20 @@ class ThermocyclerBackend(MachineBackend, metaclass=ABCMeta):
     """Execute thermocycler profile run."""
 
   @abstractmethod
-  async def get_block_current_temperature(self) -> float:
-    """Get the current block temperature in °C."""
+  async def get_block_current_temperature(self) -> List[float]:
+    """Get the current block temperature zones in °C."""
 
   @abstractmethod
-  async def get_block_target_temperature(self) -> float:
-    """Get the block target temperature in °C. May raise RuntimeError if no target is set."""
+  async def get_block_target_temperature(self) -> List[float]:
+    """Get the block target temperature zones in °C. May raise RuntimeError if no target is set."""
 
   @abstractmethod
-  async def get_lid_current_temperature(self) -> float:
-    """Get the current lid temperature in °C."""
+  async def get_lid_current_temperature(self) -> List[float]:
+    """Get the current lid temperature zones in °C."""
 
   @abstractmethod
-  async def get_lid_target_temperature(self) -> float:
-    """Get the lid target temperature in °C. May raise RuntimeError if no target is set."""
+  async def get_lid_target_temperature(self) -> List[float]:
+    """Get the lid target temperature zones in °C. May raise RuntimeError if no target is set."""
 
   @abstractmethod
   async def get_lid_open(self) -> bool:

--- a/pylabrobot/thermocycling/chatterbox_tests.py
+++ b/pylabrobot/thermocycling/chatterbox_tests.py
@@ -22,8 +22,8 @@ class TestThermocyclerChatterbox(unittest.IsolatedAsyncioTestCase):
   async def test_chatterbox_run_profile(self):
     """Test that the chatterbox produces the correct log for a generic profile."""
     profile = [
-      Step(temperature=95.0, hold_seconds=10),
-      Step(temperature=55.0, hold_seconds=20),
+      Step(temperature=[95.0], hold_seconds=10),
+      Step(temperature=[55.0], hold_seconds=20),
     ]
 
     log_buffer = StringIO()
@@ -76,7 +76,7 @@ class TestThermocyclerChatterbox(unittest.IsolatedAsyncioTestCase):
     """Test that deactivating the block prints a cancellation message."""
     log_buffer = StringIO()
     with redirect_stdout(log_buffer):
-      await self.tc.run_profile([Step(temperature=50.0, hold_seconds=10)], 25.0)
+      await self.tc.run_profile([Step(temperature=[50.0], hold_seconds=10)], 25.0)
       await self.tc.deactivate_block()
 
     log = log_buffer.getvalue()

--- a/pylabrobot/thermocycling/chatterbox_tests.py
+++ b/pylabrobot/thermocycling/chatterbox_tests.py
@@ -56,7 +56,7 @@ class TestThermocyclerChatterbox(unittest.IsolatedAsyncioTestCase):
         extension_time=20.0,
         num_cycles=2,
         block_max_volume=25.0,
-        lid_temperature=105.0,
+        lid_temperature=[105.0],
         storage_temp=4.0,
         storage_time=1.0,
       )

--- a/pylabrobot/thermocycling/chatterbox_tests.py
+++ b/pylabrobot/thermocycling/chatterbox_tests.py
@@ -48,16 +48,16 @@ class TestThermocyclerChatterbox(unittest.IsolatedAsyncioTestCase):
     log_buffer = StringIO()
     with redirect_stdout(log_buffer):
       await self.tc.run_pcr_profile(
-        denaturation_temp=98.0,
+        denaturation_temp=[98.0],
         denaturation_time=15.0,
-        annealing_temp=60.0,
+        annealing_temp=[60.0],
         annealing_time=15.0,
-        extension_temp=72.0,
+        extension_temp=[72.0],
         extension_time=20.0,
         num_cycles=2,
         block_max_volume=25.0,
         lid_temperature=[105.0],
-        storage_temp=4.0,
+        storage_temp=[4.0],
         storage_time=1.0,
       )
       await self.tc.wait_for_profile_completion(0.01)

--- a/pylabrobot/thermocycling/opentrons_backend.py
+++ b/pylabrobot/thermocycling/opentrons_backend.py
@@ -1,7 +1,7 @@
 """Backend that drives an Opentrons Thermocycler via the HTTP API."""
 
 import sys
-from typing import cast, List
+from typing import List, cast
 
 from pylabrobot.thermocycling.backend import ThermocyclerBackend
 from pylabrobot.thermocycling.standard import BlockStatus, LidStatus, Step

--- a/pylabrobot/thermocycling/opentrons_backend.py
+++ b/pylabrobot/thermocycling/opentrons_backend.py
@@ -105,7 +105,9 @@ class OpentronsThermocyclerBackend(ThermocyclerBackend):
     ot_profile = []
     for step in profile:
       if len(set(step.temperature)) != 1:
-        raise ValueError(f"Opentrons thermocycler only supports a single unique temperature per step, got {set(step.temperature)}")
+        raise ValueError(
+          f"Opentrons thermocycler only supports a single unique temperature per step, got {set(step.temperature)}"
+        )
       celsius = step.temperature[0]
       ot_profile.append({"celsius": celsius, "holdSeconds": step.hold_seconds})
 

--- a/pylabrobot/thermocycling/opentrons_backend.py
+++ b/pylabrobot/thermocycling/opentrons_backend.py
@@ -1,7 +1,7 @@
 """Backend that drives an Opentrons Thermocycler via the HTTP API."""
 
 import sys
-from typing import cast
+from typing import cast, List
 
 from pylabrobot.thermocycling.backend import ThermocyclerBackend
 from pylabrobot.thermocycling.standard import BlockStatus, LidStatus, Step
@@ -72,13 +72,23 @@ class OpentronsThermocyclerBackend(ThermocyclerBackend):
     """Close the thermocycler lid."""
     return thermocycler_close_lid(module_id=self.opentrons_id)
 
-  async def set_block_temperature(self, temperature: float):
-    """Set block temperature in °C."""
-    return thermocycler_set_block_temperature(celsius=temperature, module_id=self.opentrons_id)
+  async def set_block_temperature(self, temperature: List[float]):
+    """Set block temperature in °C. Only single unique temperature supported."""
+    if len(set(temperature)) != 1:
+      raise ValueError(
+        f"Opentrons thermocycler only supports a single unique block temperature, got {set(temperature)}"
+      )
+    temp_value = temperature[0]
+    return thermocycler_set_block_temperature(celsius=temp_value, module_id=self.opentrons_id)
 
-  async def set_lid_temperature(self, temperature: float):
-    """Set lid temperature in °C."""
-    return thermocycler_set_lid_temperature(celsius=temperature, module_id=self.opentrons_id)
+  async def set_lid_temperature(self, temperature: List[float]):
+    """Set lid temperature in °C. Only single unique temperature supported."""
+    if len(set(temperature)) != 1:
+      raise ValueError(
+        f"Opentrons thermocycler only supports a single unique lid temperature, got {set(temperature)}"
+      )
+    temp_value = temperature[0]
+    return thermocycler_set_lid_temperature(celsius=temp_value, module_id=self.opentrons_id)
 
   async def deactivate_block(self):
     """Deactivate the block heater."""
@@ -107,24 +117,24 @@ class OpentronsThermocyclerBackend(ThermocyclerBackend):
         return cast(dict, m["data"])
     raise RuntimeError(f"Module '{self.opentrons_id}' not found")
 
-  async def get_block_current_temperature(self) -> float:
-    return cast(float, self._find_module()["currentTemperature"])
+  async def get_block_current_temperature(self) -> List[float]:
+    return [cast(float, self._find_module()["currentTemperature"])]
 
-  async def get_block_target_temperature(self) -> float:
+  async def get_block_target_temperature(self) -> List[float]:
     target_temp = self._find_module().get("targetTemperature")
     if target_temp is None:
       raise RuntimeError("Block target temperature is not set. is a cycle running?")
-    return cast(float, target_temp)
+    return [cast(float, target_temp)]
 
-  async def get_lid_current_temperature(self) -> float:
-    return cast(float, self._find_module()["lidTemperature"])
+  async def get_lid_current_temperature(self) -> List[float]:
+    return [cast(float, self._find_module()["lidTemperature"])]
 
-  async def get_lid_target_temperature(self) -> float:
+  async def get_lid_target_temperature(self) -> List[float]:
     """Get the lid target temperature in °C. Raises RuntimeError if no target is active."""
     target_temp = self._find_module().get("lidTargetTemperature")
     if target_temp is None:
       raise RuntimeError("Lid target temperature is not set. is a cycle running?")
-    return cast(float, target_temp)
+    return [cast(float, target_temp)]
 
   async def get_lid_open(self) -> bool:
     return cast(str, self._find_module()["lidStatus"]) == "open"

--- a/pylabrobot/thermocycling/opentrons_backend_tests.py
+++ b/pylabrobot/thermocycling/opentrons_backend_tests.py
@@ -51,13 +51,13 @@ class TestOpentronsThermocyclerBackend(unittest.IsolatedAsyncioTestCase):
 
   @patch("pylabrobot.thermocycling.opentrons_backend.thermocycler_set_block_temperature")
   async def test_set_block_temperature(self, mock_set_block_temp):
-    await self.thermocycler_backend.set_block_temperature(95.0)
-    mock_set_block_temp.assert_called_once_with(celsius=95.0, module_id="test_id")
+    await self.thermocycler_backend.set_block_temperature([95.0])
+    mock_set_block_temp.assert_called_once_with(celsius=[95.0], module_id="test_id")
 
   @patch("pylabrobot.thermocycling.opentrons_backend.thermocycler_set_lid_temperature")
   async def test_set_lid_temperature(self, mock_set_lid_temp):
-    await self.thermocycler_backend.set_lid_temperature(105.0)
-    mock_set_lid_temp.assert_called_once_with(celsius=105.0, module_id="test_id")
+    await self.thermocycler_backend.set_lid_temperature([105.0])
+    mock_set_lid_temp.assert_called_once_with(celsius=[105.0], module_id="test_id")
 
   @patch("pylabrobot.thermocycling.opentrons_backend.thermocycler_deactivate_block")
   async def test_deactivate_block(self, mock_deactivate_block):

--- a/pylabrobot/thermocycling/opentrons_backend_tests.py
+++ b/pylabrobot/thermocycling/opentrons_backend_tests.py
@@ -52,12 +52,12 @@ class TestOpentronsThermocyclerBackend(unittest.IsolatedAsyncioTestCase):
   @patch("pylabrobot.thermocycling.opentrons_backend.thermocycler_set_block_temperature")
   async def test_set_block_temperature(self, mock_set_block_temp):
     await self.thermocycler_backend.set_block_temperature([95.0])
-    mock_set_block_temp.assert_called_once_with(celsius=[95.0], module_id="test_id")
+    mock_set_block_temp.assert_called_once_with(celsius=95.0, module_id="test_id")
 
   @patch("pylabrobot.thermocycling.opentrons_backend.thermocycler_set_lid_temperature")
   async def test_set_lid_temperature(self, mock_set_lid_temp):
     await self.thermocycler_backend.set_lid_temperature([105.0])
-    mock_set_lid_temp.assert_called_once_with(celsius=[105.0], module_id="test_id")
+    mock_set_lid_temp.assert_called_once_with(celsius=105.0, module_id="test_id")
 
   @patch("pylabrobot.thermocycling.opentrons_backend.thermocycler_deactivate_block")
   async def test_deactivate_block(self, mock_deactivate_block):
@@ -99,10 +99,10 @@ class TestOpentronsThermocyclerBackend(unittest.IsolatedAsyncioTestCase):
     }
     mock_list_connected_modules.return_value = [mock_data]
 
-    assert await self.thermocycler_backend.get_block_current_temperature() == 25.5
-    assert await self.thermocycler_backend.get_block_target_temperature() == 95.0
-    assert await self.thermocycler_backend.get_lid_current_temperature() == 37.1
-    assert await self.thermocycler_backend.get_lid_target_temperature() == 105.0
+    assert await self.thermocycler_backend.get_block_current_temperature() == [25.5]
+    assert await self.thermocycler_backend.get_block_target_temperature() == [95.0]
+    assert await self.thermocycler_backend.get_lid_current_temperature() == [37.1]
+    assert await self.thermocycler_backend.get_lid_target_temperature() == [105.0]
     assert await self.thermocycler_backend.get_lid_open() is True
     assert await self.thermocycler_backend.get_lid_status() == LidStatus.HOLDING_AT_TARGET
     assert await self.thermocycler_backend.get_block_status() == BlockStatus.HOLDING_AT_TARGET

--- a/pylabrobot/thermocycling/opentrons_backend_tests.py
+++ b/pylabrobot/thermocycling/opentrons_backend_tests.py
@@ -71,7 +71,7 @@ class TestOpentronsThermocyclerBackend(unittest.IsolatedAsyncioTestCase):
 
   @patch("pylabrobot.thermocycling.opentrons_backend.thermocycler_run_profile_no_wait")
   async def test_run_profile(self, mock_run_profile):
-    profile = [Step(temperature=95, hold_seconds=10)]
+    profile = [Step(temperature=[95], hold_seconds=10)]
     await self.thermocycler_backend.run_profile(profile, 50.0)
     # print all calls
     mock_run_profile.assert_called_once_with(

--- a/pylabrobot/thermocycling/standard.py
+++ b/pylabrobot/thermocycling/standard.py
@@ -1,12 +1,13 @@
 import enum
 from dataclasses import dataclass
+from typing import List
 
 
 @dataclass
 class Step:
   """Represents a single step in a thermocycler profile."""
 
-  temperature: float
+  temperature: List[float]
   hold_seconds: float
 
 

--- a/pylabrobot/thermocycling/thermocycler.py
+++ b/pylabrobot/thermocycling/thermocycler.py
@@ -86,44 +86,54 @@ class Thermocycler(ResourceHolder, Machine):
       profile: List of {"temperature": float, "holdSeconds": float} steps.
       block_max_volume: Maximum block volume (µL) for safety.
     """
+
+    # Ensure all steps have the same number of temperatures
+    num_zones = len(profile[0].temperature)
+    for i, step in enumerate(profile):
+      if len(step.temperature) != num_zones:
+        raise ValueError(
+          f"All steps must have the same number of temperatures. "
+          f"Expected {num_zones}, got {len(step.temperature)} in step {i}."
+        )
+
     return await self.backend.run_profile(profile, block_max_volume, **backend_kwargs)
 
   async def run_pcr_profile(
     self,
-    denaturation_temp: float,
+    denaturation_temp: List[float],
     denaturation_time: float,
-    annealing_temp: float,
+    annealing_temp: List[float],
     annealing_time: float,
-    extension_temp: float,
+    extension_temp: List[float],
     extension_time: float,
     num_cycles: int,
     block_max_volume: float,
     lid_temperature: List[float],
-    pre_denaturation_temp: Optional[float] = None,
+    pre_denaturation_temp: Optional[List[float]] = None,
     pre_denaturation_time: Optional[float] = None,
-    final_extension_temp: Optional[float] = None,
+    final_extension_temp: Optional[List[float]] = None,
     final_extension_time: Optional[float] = None,
-    storage_temp: Optional[float] = None,
+    storage_temp: Optional[List[float]] = None,
     storage_time: Optional[float] = None,
     **backend_kwargs,
   ):
     """Run a PCR profile with specified parameters.
 
     Args:
-      denaturation_temp: Denaturation temperature in °C.
+      denaturation_temp: List of denaturation temperatures in °C.
       denaturation_time: Denaturation time in seconds.
-      annealing_temp: Annealing temperature in °C.
+      annealing_temp: List of annealing temperatures in °C.
       annealing_time: Annealing time in seconds.
-      extension_temp: Extension temperature in °C.
+      extension_temp: List of extension temperatures in °C.
       extension_time: Extension time in seconds.
       num_cycles: Number of PCR cycles.
       block_max_volume: Maximum block volume (µL) for safety.
       lid_temperature: List of lid temperatures to set during the profile.
-      pre_denaturation_temp: Optional pre-denaturation temperature in °C.
+      pre_denaturation_temp: Optional list of pre-denaturation temperatures in °C.
       pre_denaturation_time: Optional pre-denaturation time in seconds.
-      final_extension_temp: Optional final extension temperature in °C.
+      final_extension_temp: Optional list of final extension temperatures in °C.
       final_extension_time: Optional final extension time in seconds.
-      storage_temp: Optional storage temperature in °C.
+      storage_temp: Optional list of storage temperatures in °C.
       storage_time: Optional storage time in seconds.
     """
 

--- a/pylabrobot/thermocycling/thermocycler_tests.py
+++ b/pylabrobot/thermocycling/thermocycler_tests.py
@@ -74,7 +74,7 @@ class ThermocyclerTests(unittest.IsolatedAsyncioTestCase):
       extension_time=60.0,
       num_cycles=2,
       block_max_volume=25.0,
-      lid_temperature=105.0,
+      lid_temperature=[105.0],
       pre_denaturation_temp=95.0,
       pre_denaturation_time=180.0,
       final_extension_temp=72.0,
@@ -83,7 +83,7 @@ class ThermocyclerTests(unittest.IsolatedAsyncioTestCase):
       storage_time=600.0,
     )
 
-    self.tc.backend.set_lid_temperature.assert_called_once_with(105.0)  # type: ignore
+    self.tc.backend.set_lid_temperature.assert_called_once_with([105.0])  # type: ignore
 
     expected_profile = [
       Step(temperature=95.0, hold_seconds=180.0),

--- a/pylabrobot/thermocycling/thermocycler_tests.py
+++ b/pylabrobot/thermocycling/thermocycler_tests.py
@@ -23,9 +23,9 @@ def mock_backend() -> MagicMock:
   mock.deactivate_block = AsyncMock()
   mock.deactivate_lid = AsyncMock()
   mock.run_profile = AsyncMock()
-  mock.get_block_current_temperature = AsyncMock(return_value=25.0)
+  mock.get_block_current_temperature = AsyncMock(return_value=[25.0])
   mock.get_block_target_temperature = AsyncMock(return_value=None)
-  mock.get_lid_current_temperature = AsyncMock(return_value=25.0)
+  mock.get_lid_current_temperature = AsyncMock(return_value=[25.0])
   mock.get_lid_target_temperature = AsyncMock(return_value=None)
   mock.get_lid_open = AsyncMock(return_value=False)
   mock.get_lid_temperature_status = AsyncMock(return_value="idle")
@@ -66,20 +66,20 @@ class ThermocyclerTests(unittest.IsolatedAsyncioTestCase):
     self.tc.wait_for_lid = mock_wait_for_lid  # type: ignore
 
     await self.tc.run_pcr_profile(
-      denaturation_temp=98.0,
+      denaturation_temp=[98.0],
       denaturation_time=10.0,
-      annealing_temp=55.0,
+      annealing_temp=[55.0],
       annealing_time=30.0,
-      extension_temp=72.0,
+      extension_temp=[72.0],
       extension_time=60.0,
       num_cycles=2,
       block_max_volume=25.0,
       lid_temperature=[105.0],
-      pre_denaturation_temp=95.0,
+      pre_denaturation_temp=[95.0],
       pre_denaturation_time=180.0,
-      final_extension_temp=72.0,
+      final_extension_temp=[72.0],
       final_extension_time=300.0,
-      storage_temp=4.0,
+      storage_temp=[4.0],
       storage_time=600.0,
     )
 

--- a/pylabrobot/thermocycling/thermocycler_tests.py
+++ b/pylabrobot/thermocycling/thermocycler_tests.py
@@ -86,15 +86,15 @@ class ThermocyclerTests(unittest.IsolatedAsyncioTestCase):
     self.tc.backend.set_lid_temperature.assert_called_once_with([105.0])  # type: ignore
 
     expected_profile = [
-      Step(temperature=95.0, hold_seconds=180.0),
-      Step(temperature=98.0, hold_seconds=10.0),
-      Step(temperature=55.0, hold_seconds=30.0),
-      Step(temperature=72.0, hold_seconds=60.0),
-      Step(temperature=98.0, hold_seconds=10.0),
-      Step(temperature=55.0, hold_seconds=30.0),
-      Step(temperature=72.0, hold_seconds=60.0),
-      Step(temperature=72.0, hold_seconds=300.0),
-      Step(temperature=4.0, hold_seconds=600.0),
+      Step(temperature=[95.0], hold_seconds=180.0),
+      Step(temperature=[98.0], hold_seconds=10.0),
+      Step(temperature=[55.0], hold_seconds=30.0),
+      Step(temperature=[72.0], hold_seconds=60.0),
+      Step(temperature=[98.0], hold_seconds=10.0),
+      Step(temperature=[55.0], hold_seconds=30.0),
+      Step(temperature=[72.0], hold_seconds=60.0),
+      Step(temperature=[72.0], hold_seconds=300.0),
+      Step(temperature=[4.0], hold_seconds=600.0),
     ]
 
     self.tc.backend.run_profile.assert_called_once_with(expected_profile, 25.0)  # type: ignore


### PR DESCRIPTION
use a list to support multiple zones, which most thermocyclers do

for OT, raise an error if more than one unique value is given (for max interoperability between protocols). return the queried values in a list