### PR TITLE
Allow string indexing in ItemizedResource.row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `location` parameter of `assign_child_resource` is not optional (https://github.com/PyLabRobot/pylabrobot/pull/336)
 - `Resource.get_absolute_location` raises `NoLocationError` instead of `AssertionError` when absolute location is not defined (https://github.com/PyLabRobot/pylabrobot/pull/338)
 - `no_trash` and `no_teaching_rack` were renamed to `with_trash` and `with_teaching_rack` to avoid double negatives (https://github.com/PyLabRobot/pylabrobot/pull/347)
+- `ItemizedResource.row` accepts a string ("A"-"P") in addition to an integer index.
 
 ### Added
 

--- a/pylabrobot/resources/itemized_resource.py
+++ b/pylabrobot/resources/itemized_resource.py
@@ -473,6 +473,21 @@ class ItemizedResource(Resource, Generic[T], metaclass=ABCMeta):
     """Get all items in the given column."""
     return self[column * self.num_items_y : (column + 1) * self.num_items_y]
 
-  def row(self, row: int) -> List[T]:
-    """Get all items in the given row."""
+  def row(self, row: Union[int, str]) -> List[T]:
+    """Get all items in the given row.
+
+    Args:
+      row: The row index. Either an integer starting at ``0`` or a letter
+        ``"A"``-``"P"`` (case insensitive) corresponding to ``0``-``15``.
+
+    Raises:
+      ValueError: If ``row`` is a string outside ``"A"``-``"P"``.
+    """
+
+    if isinstance(row, str):
+      letter = row.upper()
+      if letter not in LETTERS[:16]:
+        raise ValueError("Row must be between 'A' and 'P'.")
+      row = LETTERS.index(letter)
+
     return self[row :: self.num_items_y]

--- a/pylabrobot/resources/itemized_resource_tests.py
+++ b/pylabrobot/resources/itemized_resource_tests.py
@@ -183,6 +183,22 @@ class TestItemizedResource(unittest.TestCase):
       ],
     )
 
+  def test_get_row_str(self):
+    self.assertEqual(
+      [w.name for w in self.plate.row("A")],
+      [w.name for w in self.plate.row(0)],
+    )
+    self.assertEqual(
+      [w.name for w in self.plate.row("d")],
+      [w.name for w in self.plate.row(3)],
+    )
+
+  def test_get_row_str_invalid(self):
+    with self.assertRaises(ValueError):
+      self.plate.row("Q")
+    with self.assertRaises(ValueError):
+      self.plate.row("AA")
+
   def test_get_column(self):
     self.assertEqual(
       [w.name for w in self.plate.column(0)],


### PR DESCRIPTION
## Summary
- extend `ItemizedResource.row` to accept row letters A-P (case-insensitive)
- test `ItemizedResource.row` with string input and invalid letters
- document new string support in changelog

## Testing
- `pytest pylabrobot/resources/itemized_resource_tests.py::TestItemizedResource -q`


------
https://chatgpt.com/codex/tasks/task_e_689a9cfee04c832b88ba94f05cecaabf