### PR TITLE
Updated method reference in "Dropping tips" section of basic.ipynb

### DIFF
--- a/docs/user_guide/00_liquid-handling/hamilton-star/basic.ipynb
+++ b/docs/user_guide/00_liquid-handling/hamilton-star/basic.ipynb
@@ -358,7 +358,7 @@
    "source": [
     "## Dropping tips\n",
     "\n",
-    "Finally, you can drop tips anywhere on the deck by using the {func}`~pylabrobot.liquid_handling.LiquidHandler.discard_tips` method."
+    "Finally, you can drop tips anywhere on the deck by using the {func}`~pylabrobot.liquid_handling.LiquidHandler.drop_tips` method."
    ]
   },
   {


### PR DESCRIPTION
In the "Dropping Tips" section of the "Getting started with liquid handling on a Hamilton STAR" the text refers to the method `discard_tips()` when it should be `drop_tips()` for the subsequent example.