### PR TITLE
Automate CLARIOstar & Hamilton HEPA fan VID:PID Search at Runtime

### DIFF
--- a/pylabrobot/only_fans/hamilton_hepa_fan_backend.py
+++ b/pylabrobot/only_fans/hamilton_hepa_fan_backend.py
@@ -1,14 +1,16 @@
 import asyncio
 
+# Make pylibftdi scan the Hamilton HEPA Fan VID:PID
+# appears as ID 0856:ac11 B&B Electronics Model USOPTL4
+from pylibftdi import driver
+
 from pylabrobot.io.ftdi import FTDI
 
 from .backend import FanBackend
 
-# Make pylibftdi scan the Hamilton HEPA Fan VID:PID
-# appears as ID 0856:ac11 B&B Electronics Model USOPTL4
-from pylibftdi import driver
-driver.USB_VID_LIST.append(0x0856) # i.e. 2134
-driver.USB_PID_LIST.append(0xac11) # i.e. 44049
+driver.USB_VID_LIST.append(0x0856)  # i.e. 2134
+driver.USB_PID_LIST.append(0xAC11)  # i.e. 44049
+
 
 class HamiltonHepaFanBackend(FanBackend):
   """Backend for Hepa fan attachment on Hamilton Liquid Handler"""

--- a/pylabrobot/only_fans/hamilton_hepa_fan_backend.py
+++ b/pylabrobot/only_fans/hamilton_hepa_fan_backend.py
@@ -4,6 +4,11 @@ from pylabrobot.io.ftdi import FTDI
 
 from .backend import FanBackend
 
+# Make pylibftdi scan the Hamilton HEPA Fan VID:PID
+# appears as ID 0856:ac11 B&B Electronics Model USOPTL4
+from pylibftdi import driver
+driver.USB_VID_LIST.append(0x0856) # i.e. 2134
+driver.USB_PID_LIST.append(0xac11) # i.e. 44049
 
 class HamiltonHepaFanBackend(FanBackend):
   """Backend for Hepa fan attachment on Hamilton Liquid Handler"""

--- a/pylabrobot/plate_reading/clario_star_backend.py
+++ b/pylabrobot/plate_reading/clario_star_backend.py
@@ -22,8 +22,10 @@ logger = logging.getLogger("pylabrobot")
 # Make pylibftdi scan the CLARIOstar VID:PID
 # appears as ID 0403:bb68 Future Technology Devices International Limited CLARIOstar
 from pylibftdi import driver
-driver.USB_VID_LIST.append(0x0403) # i.e. 1027
-driver.USB_PID_LIST.append(0xbb68) # i.e. 47976
+
+driver.USB_VID_LIST.append(0x0403)  # i.e. 1027
+driver.USB_PID_LIST.append(0xBB68)  # i.e. 47976
+
 
 class CLARIOStarBackend(PlateReaderBackend):
   """A plate reader backend for the Clario star. Note that this is not a complete implementation

--- a/pylabrobot/plate_reading/clario_star_backend.py
+++ b/pylabrobot/plate_reading/clario_star_backend.py
@@ -19,6 +19,11 @@ else:
 
 logger = logging.getLogger("pylabrobot")
 
+# Make pylibftdi scan the CLARIOstar VID:PID
+# appears as ID 0403:bb68 Future Technology Devices International Limited CLARIOstar
+from pylibftdi import driver
+driver.USB_VID_LIST.append(0x0403) # i.e. 1027
+driver.USB_PID_LIST.append(0xbb68) # i.e. 47976
 
 class CLARIOStarBackend(PlateReaderBackend):
   """A plate reader backend for the Clario star. Note that this is not a complete implementation

--- a/pylabrobot/plate_reading/clario_star_backend.py
+++ b/pylabrobot/plate_reading/clario_star_backend.py
@@ -6,6 +6,8 @@ import sys
 import time
 from typing import List, Optional, Union
 
+from pylibftdi import driver
+
 from pylabrobot import utils
 from pylabrobot.io.ftdi import FTDI
 from pylabrobot.resources.plate import Plate
@@ -21,7 +23,6 @@ logger = logging.getLogger("pylabrobot")
 
 # Make pylibftdi scan the CLARIOstar VID:PID
 # appears as ID 0403:bb68 Future Technology Devices International Limited CLARIOstar
-from pylibftdi import driver
 
 driver.USB_VID_LIST.append(0x0403)  # i.e. 1027
 driver.USB_PID_LIST.append(0xBB68)  # i.e. 47976


### PR DESCRIPTION
Hi everyone,

tiny PR to avoid head scratching about why PLR does not connect to machines:

Many machines' Vendor ID:Product ID (VID:PID) combos ([Understanding VID and PID in USB Devices](https://blog.stackademic.com/understanding-vid-and-pid-in-usb-devices-a183c6ec0d25)) are **not** automatically searched for by `pylibftdi`.

As a result, we have to manually tell Python to search for them.
PLR users might not be familiar with this requirement and might then incorrectly attribute failure to connect to their machines as a "bug of PyLabRobot" - we must fix that misconception before it arises.

In this PR, we propose adding the required information into the runtime's `USB_VID_LIST` and `USB_PID_LIST` in the specific backend's .py file.
This means the required information is only imported when needed and when needed import is automated without the user having to identify the IDs every time.
