### PR TITLE
feat: add default 96-head offset

### DIFF
--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1704,7 +1704,7 @@ class LiquidHandler(Resource, Machine):
 
     try:
       await self.backend.aspirate96(aspiration=aspiration, **backend_kwargs)
-    except Exception as error:
+    except Exception:
       for channel in self.head96.values():
         channel.get_tip().tracker.rollback()
       for container in containers:
@@ -1852,7 +1852,7 @@ class LiquidHandler(Resource, Machine):
 
     try:
       await self.backend.dispense96(dispense=dispense, **backend_kwargs)
-    except Exception as error:
+    except Exception:
       for channel in self.head96.values():
         channel.get_tip().tracker.rollback()
       for container in containers:

--- a/pylabrobot/liquid_handling/liquid_handler_tests.py
+++ b/pylabrobot/liquid_handling/liquid_handler_tests.py
@@ -498,27 +498,27 @@ class TestLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     await self.lh.pick_up_tips96(self.tip_rack)
     cmd = self.get_first_command("pick_up_tips96")
     self.assertIsNotNone(cmd)
-    self.assertEqual(cmd["kwargs"]["pickup"].offset, Coordinate(1, 2, 3))
+    self.assertEqual(cmd["kwargs"]["pickup"].offset, Coordinate(1, 2, 3))  # type: ignore
     self.backend.clear()
 
     # aspirate with extra offset; effective offset should be default + provided
     await self.lh.aspirate96(self.plate, volume=10, offset=Coordinate(1, 0, 0))
     cmd = self.get_first_command("aspirate96")
     self.assertIsNotNone(cmd)
-    self.assertEqual(cmd["kwargs"]["aspiration"].offset, Coordinate(2, 2, 3))
+    self.assertEqual(cmd["kwargs"]["aspiration"].offset, Coordinate(2, 2, 3))  # type: ignore
     self.backend.clear()
 
     # dispense without providing offset uses default
     await self.lh.dispense96(self.plate, volume=10)
     cmd = self.get_first_command("dispense96")
     self.assertIsNotNone(cmd)
-    self.assertEqual(cmd["kwargs"]["dispense"].offset, Coordinate(1, 2, 3))
+    self.assertEqual(cmd["kwargs"]["dispense"].offset, Coordinate(1, 2, 3))  # type: ignore
     self.backend.clear()
 
     await self.lh.drop_tips96(self.tip_rack, offset=Coordinate(0, 1, 0))
     cmd = self.get_first_command("drop_tips96")
     self.assertIsNotNone(cmd)
-    self.assertEqual(cmd["kwargs"]["drop"].offset, Coordinate(1, 3, 3))
+    self.assertEqual(cmd["kwargs"]["drop"].offset, Coordinate(1, 3, 3))  # type: ignore
 
   async def test_default_offset_head96_initializer(self):
     backend = backends.SaverBackend(num_channels=8)


### PR DESCRIPTION
## Summary
- add `LiquidHandler.default_offset_head96` for applying a base offset to 96‑head operations
- ensure 96‑head methods add user-specified offsets to this default
- test default 96‑head offset handling
- allow configuring and serializing the default 96‑head offset

## Testing
- `pre-commit run --files pylabrobot/liquid_handling/liquid_handler.py pylabrobot/liquid_handling/liquid_handler_tests.py`
- `pytest pylabrobot/liquid_handling/liquid_handler_tests.py::TestLiquidHandlerCommands::test_default_offset_head96_initializer -q`
- `pytest pylabrobot/liquid_handling/liquid_handler_tests.py::TestLiquidHandlerCommands::test_default_offset_head96_serialization -q`
- `pytest pylabrobot/liquid_handling/liquid_handler_tests.py::TestLiquidHandlerCommands::test_default_offset_head96 -q`


------
https://chatgpt.com/codex/tasks/task_e_68adfbe15f24832b821b292dd922b3e3