### PR TITLE
Create `STARBackend.request_x_pos_channel_n()`

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -3982,15 +3982,16 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
 
   # -------------- 3.4.3 X-query --------------
 
-  async def request_left_x_arm_position(self):
+  async def request_left_x_arm_position(self) -> float:
     """Request left X-Arm position"""
     resp_dmm = await self.send_command(module="C0", command="RX", fmt="rx#####")
-    return resp_dmm / 10
+    return cast(float, resp_dmm["rx"]) / 10
 
-  async def request_right_x_arm_position(self):
+  async def request_right_x_arm_position(self) -> float:
     """Request right X-Arm position"""
 
-    return await self.send_command(module="C0", command="QX", fmt="rx#####")
+    resp_dmm = await self.send_command(module="C0", command="QX", fmt="rx#####")
+    return cast(float, resp_dmm["rx"]) / 10
 
   async def request_maximal_ranges_of_x_drives(self):
     """Request maximal ranges of X drives"""


### PR DESCRIPTION
Converted `STARBackend.request_left_x_arm_position()` to return in mm.

Then created a link to it called `STARBackend.request_x_pos_channel_n()` as a convenience method and stay consistent with the other request_<dimension>_pos_channel_n methods.

Actual `pipetting_channel_index` does not matter IF one assumes a single gantry system at all times.
I left it for consistency purposes and potential expansion if someone with a multi gantry system needs it in the future.

