### PR TITLE
fix STARBackend.pick_up_tips96 with tip tracking enabled

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -2184,12 +2184,9 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     """Pick up tips using the 96 head."""
     assert self.core96_head_installed, "96 head must be installed"
     tip_spot_a1 = pickup.resource.get_item("A1")
-    prototypical_tip = None
-    for tip_spot in pickup.resource.get_all_items():
-      if tip_spot.has_tip():
-        prototypical_tip = tip_spot.get_tip()
-        break
-    if prototypical_tip is None:
+    try:
+      prototypical_tip = next(tip for tip in pickup.tips if tip is not None)
+    except StopIteration:
       raise ValueError("No tips found in the tip rack.")
     assert isinstance(prototypical_tip, HamiltonTip), "Tip type must be HamiltonTip."
     ttti = await self.get_or_assign_tip_type_index(prototypical_tip)

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
@@ -584,6 +584,11 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
       ]
     )
 
+  async def test_tip_tracking_pick_up96(self):
+    set_tip_tracking(enabled=True)
+    await self.lh.pick_up_tips96(self.tip_rack)
+    set_tip_tracking(enabled=False)
+
   async def test_core_96_tip_drop(self):
     await self.lh.pick_up_tips96(self.tip_rack)  # pick up tips first
     self.STAR._write_and_read_command.reset_mock()

--- a/pylabrobot/liquid_handling/standard.py
+++ b/pylabrobot/liquid_handling/standard.py
@@ -40,6 +40,7 @@ class Drop:
 class PickupTipRack:
   resource: TipRack
   offset: Coordinate
+  tips: List[Optional[Tip]]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
fixing https://github.com/PyLabRobot/pylabrobot/issues/679

it was actually broken for all pick_up_tips96 with tip tracking enabled regardless of the state of the tip rack because LH removes the tips before calling the backend command