### PR TITLE
Allow partial tip racks {aspirate, dispense}96

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -2347,7 +2347,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       )
     self._check_96_position_legal(position, skip_z=True)
 
-    tip = aspiration.tips[0]
+    tip = next(tip for tip in aspiration.tips if tip is not None)
 
     liquid_height = position.z + (aspiration.liquid_height or 0)
 
@@ -2544,7 +2544,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
         + dispense.offset
       )
     self._check_96_position_legal(position, skip_z=True)
-    tip = dispense.tips[0]
+    tip = next(tip for tip in dispense.tips if tip is not None)
 
     liquid_height = position.z + (dispense.liquid_height or 0)
 

--- a/pylabrobot/liquid_handling/backends/hamilton/vantage_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/vantage_backend.py
@@ -1082,7 +1082,7 @@ class VantageBackend(HamiltonLiquidHandler):
 
     liquid_height = position.z + (aspiration.liquid_height or 0)
 
-    tip = aspiration.tips[0]
+    tip = next(tip for tip in aspiration.tips if tip is not None)
     liquid_to_be_aspirated = Liquid.WATER  # default to water
     if len(aspiration.liquids[0]) > 0 and aspiration.liquids[0][-1][0] is not None:
       # first part of tuple in last liquid of first well
@@ -1241,7 +1241,7 @@ class VantageBackend(HamiltonLiquidHandler):
 
     liquid_height = position.z + (dispense.liquid_height or 0) + 10
 
-    tip = dispense.tips[0]
+    tip = next(tip for tip in dispense.tips if tip is not None)
     liquid_to_be_dispensed = Liquid.WATER  # default to WATER
     if len(dispense.liquids[0]) > 0 and dispense.liquids[0][-1][0] is not None:
       # first part of tuple in last liquid of first well

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1724,14 +1724,16 @@ class LiquidHandler(Resource, Machine):
       await self.backend.aspirate96(aspiration=aspiration, **backend_kwargs)
     except Exception:
       for tip in tips:
-        tip.tracker.rollback()
+        if tip is not None:
+          tip.tracker.rollback()
       for container in containers:
         if does_volume_tracking() and not container.tracker.is_disabled:
           container.tracker.rollback()
       raise
     else:
       for tip in tips:
-        tip.tracker.commit()
+        if tip is not None:
+          tip.tracker.commit()
       for container in containers:
         if does_volume_tracking() and not container.tracker.is_disabled:
           container.tracker.commit()

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1630,7 +1630,7 @@ class LiquidHandler(Resource, Machine):
     for extra in extras:
       del backend_kwargs[extra]
 
-    tips = [channel.get_tip() for channel in self.head96.values()]
+    tips = [channel.get_tip() if channel.has_tip else None for channel in self.head96.values()]
     all_liquids: List[List[Tuple[Optional[Liquid], float]]] = []
     aspiration: Union[MultiHeadAspirationPlate, MultiHeadAspirationContainer]
 
@@ -1655,7 +1655,10 @@ class LiquidHandler(Resource, Machine):
       ):  # TODO: analyze as attr
         raise ValueError("Container too small to accommodate 96 head")
 
-      for channel in self.head96.values():
+      for tip in tips:
+        if tip is None:
+          continue
+
         # superfluous to have append in two places but the type checker is very angry and does not
         # understand that Optional[Liquid] (remove_liquid) is the same as None from the first case
         liquids: List[Tuple[Optional[Liquid], float]]
@@ -1667,7 +1670,7 @@ class LiquidHandler(Resource, Machine):
           all_liquids.append(liquids)
 
         for liquid, vol in reversed(liquids):
-          channel.get_tip().tracker.add_liquid(liquid=liquid, volume=vol)
+          tip.tracker.add_liquid(liquid=liquid, volume=vol)
 
       aspiration = MultiHeadAspirationContainer(
         container=container,
@@ -1689,7 +1692,10 @@ class LiquidHandler(Resource, Machine):
       if not len(containers) == 96:
         raise ValueError(f"aspirate96 expects 96 containers when a list, got {len(containers)}")
 
-      for well, channel in zip(containers, self.head96.values()):
+      for well, tip in zip(containers, tips):
+        if tip is None:
+          continue
+
         # superfluous to have append in two places but the type checker is very angry and does not
         # understand that Optional[Liquid] (remove_liquid) is the same as None from the first case
         if well.tracker.is_disabled or not does_volume_tracking():
@@ -1701,7 +1707,7 @@ class LiquidHandler(Resource, Machine):
           all_liquids.append(liquids)
 
         for liquid, vol in reversed(liquids):
-          channel.get_tip().tracker.add_liquid(liquid=liquid, volume=vol)
+          tip.tracker.add_liquid(liquid=liquid, volume=vol)
 
       aspiration = MultiHeadAspirationPlate(
         wells=cast(List[Well], containers),
@@ -1717,15 +1723,15 @@ class LiquidHandler(Resource, Machine):
     try:
       await self.backend.aspirate96(aspiration=aspiration, **backend_kwargs)
     except Exception:
-      for channel in self.head96.values():
-        channel.get_tip().tracker.rollback()
+      for tip in tips:
+        tip.tracker.rollback()
       for container in containers:
         if does_volume_tracking() and not container.tracker.is_disabled:
           container.tracker.rollback()
       raise
     else:
-      for channel in self.head96.values():
-        channel.get_tip().tracker.commit()
+      for tip in tips:
+        tip.tracker.commit()
       for container in containers:
         if does_volume_tracking() and not container.tracker.is_disabled:
           container.tracker.commit()
@@ -1786,7 +1792,7 @@ class LiquidHandler(Resource, Machine):
     for extra in extras:
       del backend_kwargs[extra]
 
-    tips = [channel.get_tip() for channel in self.head96.values()]
+    tips = [channel.get_tip() if channel.has_tip else None for channel in self.head96.values()]
     all_liquids: List[List[Tuple[Optional[Liquid], float]]] = []
     dispense: Union[MultiHeadDispensePlate, MultiHeadDispenseContainer]
 
@@ -1811,8 +1817,11 @@ class LiquidHandler(Resource, Machine):
       ):  # TODO: analyze as attr
         raise ValueError("Container too small to accommodate 96 head")
 
-      for channel in self.head96.values():
-        liquids = channel.get_tip().tracker.remove_liquid(volume=volume)
+      for tip in tips:
+        if tip is None:
+          continue
+
+        liquids = tip.tracker.remove_liquid(volume=volume)
         reversed_liquids = list(reversed(liquids))
         all_liquids.append(reversed_liquids)
 
@@ -1840,10 +1849,13 @@ class LiquidHandler(Resource, Machine):
       if not len(containers) == 96:
         raise ValueError(f"dispense96 expects 96 wells, got {len(containers)}")
 
-      for well, channel in zip(containers, self.head96.values()):
+      for well, tip in zip(containers, tips):
+        if tip is None:
+          continue
+
         # even if the volume tracker is disabled, a liquid (None, volume) is added to the list
         # during the aspiration command
-        liquids = channel.get_tip().tracker.remove_liquid(volume=volume)
+        liquids = tip.tracker.remove_liquid(volume=volume)
         reversed_liquids = list(reversed(liquids))
         all_liquids.append(reversed_liquids)
 
@@ -1865,15 +1877,17 @@ class LiquidHandler(Resource, Machine):
     try:
       await self.backend.dispense96(dispense=dispense, **backend_kwargs)
     except Exception:
-      for channel in self.head96.values():
-        channel.get_tip().tracker.rollback()
+      for tip in tips:
+        if tip is not None:
+          tip.tracker.rollback()
       for container in containers:
         if does_volume_tracking() and not container.tracker.is_disabled:
           container.tracker.rollback()
       raise
     else:
-      for channel in self.head96.values():
-        channel.get_tip().tracker.commit()
+      for tip in tips:
+        if tip is not None:
+          tip.tracker.commit()
       for container in containers:
         if does_volume_tracking() and not container.tracker.is_disabled:
           container.tracker.commit()

--- a/pylabrobot/liquid_handling/standard.py
+++ b/pylabrobot/liquid_handling/standard.py
@@ -77,7 +77,7 @@ class SingleChannelDispense:
 class MultiHeadAspirationPlate:
   wells: List[Well]
   offset: Coordinate
-  tips: List[Tip]
+  tips: List[Optional[Tip]]
   volume: float
   flow_rate: Optional[float]
   liquid_height: Optional[float]
@@ -89,7 +89,7 @@ class MultiHeadAspirationPlate:
 class MultiHeadDispensePlate:
   wells: List[Well]
   offset: Coordinate
-  tips: List[Tip]
+  tips: List[Optional[Tip]]
   volume: float
   flow_rate: Optional[float]
   liquid_height: Optional[float]
@@ -101,7 +101,7 @@ class MultiHeadDispensePlate:
 class MultiHeadAspirationContainer:
   container: Container
   offset: Coordinate
-  tips: List[Tip]
+  tips: List[Optional[Tip]]
   volume: float
   flow_rate: Optional[float]
   liquid_height: Optional[float]
@@ -113,7 +113,7 @@ class MultiHeadAspirationContainer:
 class MultiHeadDispenseContainer:
   container: Container
   offset: Coordinate
-  tips: List[Tip]
+  tips: List[Optional[Tip]]
   volume: float
   flow_rate: Optional[float]
   liquid_height: Optional[float]

--- a/pylabrobot/liquid_handling/standard.py
+++ b/pylabrobot/liquid_handling/standard.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import enum
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple, Union
 
 from pylabrobot.resources.coordinate import Coordinate
 from pylabrobot.resources.liquid import Liquid
@@ -40,7 +40,7 @@ class Drop:
 class PickupTipRack:
   resource: TipRack
   offset: Coordinate
-  tips: List[Optional[Tip]]
+  tips: Sequence[Optional[Tip]]
 
 
 @dataclass(frozen=True)
@@ -77,7 +77,7 @@ class SingleChannelDispense:
 class MultiHeadAspirationPlate:
   wells: List[Well]
   offset: Coordinate
-  tips: List[Optional[Tip]]
+  tips: Sequence[Optional[Tip]]
   volume: float
   flow_rate: Optional[float]
   liquid_height: Optional[float]
@@ -89,7 +89,7 @@ class MultiHeadAspirationPlate:
 class MultiHeadDispensePlate:
   wells: List[Well]
   offset: Coordinate
-  tips: List[Optional[Tip]]
+  tips: Sequence[Optional[Tip]]
   volume: float
   flow_rate: Optional[float]
   liquid_height: Optional[float]
@@ -101,7 +101,7 @@ class MultiHeadDispensePlate:
 class MultiHeadAspirationContainer:
   container: Container
   offset: Coordinate
-  tips: List[Optional[Tip]]
+  tips: Sequence[Optional[Tip]]
   volume: float
   flow_rate: Optional[float]
   liquid_height: Optional[float]
@@ -113,7 +113,7 @@ class MultiHeadAspirationContainer:
 class MultiHeadDispenseContainer:
   container: Container
   offset: Coordinate
-  tips: List[Optional[Tip]]
+  tips: Sequence[Optional[Tip]]
   volume: float
   flow_rate: Optional[float]
   liquid_height: Optional[float]


### PR DESCRIPTION
similar to https://github.com/PyLabRobot/pylabrobot/pull/681, but having `None` for channels without a tip instead of an indexing array. also updating the standard to have `tips: List[Optional[Tip]]` for the 96 head aspiration/dispense operations