### PR TITLE
Fix `STARBackend.pick_up_tips96()`

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -2201,43 +2201,76 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     return ret
 
   async def pick_up_tips96(
-    self,
-    pickup: PickupTipRack,
-    tip_pickup_method: int = 0,
-    z_deposit_position: float = 216.4,
-    minimum_height_command_end: Optional[float] = None,
-    minimum_traverse_height_at_beginning_of_a_command: Optional[float] = None,
+      self,
+      pickup: PickupTipRack,
+      tip_pickup_method: int = 0,
+      minimum_height_command_end: Optional[float] = None,
+      minimum_traverse_height_at_beginning_of_a_command: Optional[float] = None,
   ):
     """Pick up tips using the 96 head."""
-    assert self.core96_head_installed, "96 head must be installed"
-    tip_spot_a1 = pickup.resource.get_item("A1")
-    tip_spot_top = pickup.resource.get_absolute_location(z="top").z - 8 - 2 # fitting_depth, tip_collar
-    try:
-      prototypical_tip = next(tip for tip in pickup.tips if tip is not None)
-    except StopIteration:
-      raise ValueError("No tips found in the tip rack.")
-    assert isinstance(prototypical_tip, HamiltonTip), "Tip type must be HamiltonTip."
-    ttti = await self.get_or_assign_tip_type_index(prototypical_tip)
-    position = tip_spot_a1.get_location_wrt(self.deck) + tip_spot_a1.center() + pickup.offset
-    position.z = tip_spot_top + pickup.offset.z
-    self._check_96_position_legal(position, skip_z=True)
-    z_deposit_position += pickup.offset.z
 
-    x_direction = 0 if position.x >= 0 else 1
-    return await self.pick_up_tips_core96(
-      x_position=abs(round(position.x * 10)),
-      x_direction=x_direction,
-      y_position=round(position.y * 10),
-      tip_type_idx=ttti,
-      tip_pickup_method=tip_pickup_method,
-      z_deposit_position=round(z_deposit_position * 10),
-      minimum_traverse_height_at_beginning_of_a_command=round(
-        (minimum_traverse_height_at_beginning_of_a_command or self._channel_traversal_height) * 10
-      ),
-      minimum_height_command_end=round(
-        (minimum_height_command_end or self._channel_traversal_height) * 10
-      ),
+    assert self.core96_head_installed, "96 head must be installed"
+
+    tip_spot_a1 = pickup.resource.get_item("A1")
+
+    prototypical_tip = next((tip for tip in pickup.tips if tip is not None), None)
+    if prototypical_tip is None:
+        raise ValueError("No tips found in the tip rack.")
+    if not isinstance(prototypical_tip, HamiltonTip):
+        raise TypeError("Tip type must be HamiltonTip.")
+
+    ttti = await self.get_or_assign_tip_type_index(prototypical_tip)
+
+    tip_length = prototypical_tip.total_tip_length
+    fitting_depth = prototypical_tip.fitting_depth
+    tip_engage_height_from_tipspot = tip_length - fitting_depth
+
+    # Tip size–based z-adjustment
+    h_tip = self._get_hamilton_tip([tip_spot_a1])
+    if h_tip.tip_size == TipSize.LOW_VOLUME:
+        tip_engage_height_from_tipspot += 2
+    elif h_tip.tip_size != TipSize.STANDARD_VOLUME:
+        tip_engage_height_from_tipspot -= 2
+
+    # Compute pickup Z
+    tip_spot_z = tip_spot_a1.get_location_wrt(self.deck).z + pickup.offset.z
+    z_pickup_position = tip_spot_z + tip_engage_height_from_tipspot
+
+    # Compute full position (used for x/y)
+    pickup_position = (
+        tip_spot_a1.get_location_wrt(self.deck) +
+        tip_spot_a1.center() +
+        pickup.offset
     )
+    pickup_position.z = round(z_pickup_position, 2)
+
+    self._check_96_position_legal(pickup_position, skip_z=True)
+
+    x_direction = 0 if pickup_position.x >= 0 else 1
+
+    # Fallback to default heights
+    traverse_height = round(
+        (minimum_traverse_height_at_beginning_of_a_command or self._channel_traversal_height) * 10
+    )
+    end_cmd_height = round(
+        (minimum_height_command_end or self._channel_traversal_height) * 10
+    )
+
+    try:
+        return await self.pick_up_tips_core96(
+            x_position=abs(round(pickup_position.x * 10)),
+            x_direction=x_direction,
+            y_position=round(pickup_position.y * 10),
+            tip_type_idx=ttti,
+            tip_pickup_method=tip_pickup_method,
+            z_deposit_position=round(pickup_position.z * 10),
+            minimum_traverse_height_at_beginning_of_a_command=traverse_height,
+            minimum_height_command_end=end_cmd_height,
+        )
+    except STARFirmwareError as e:
+        if plr_e := convert_star_firmware_error_to_plr_error(e):
+            raise plr_e from e
+        raise e
 
   async def drop_tips96(
     self,

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -2211,6 +2211,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     """Pick up tips using the 96 head."""
     assert self.core96_head_installed, "96 head must be installed"
     tip_spot_a1 = pickup.resource.get_item("A1")
+    tip_spot_top = pickup.resource.get_absolute_location(z="top").z - 8 - 2 # fitting_depth, tip_collar
     try:
       prototypical_tip = next(tip for tip in pickup.tips if tip is not None)
     except StopIteration:
@@ -2218,8 +2219,9 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     assert isinstance(prototypical_tip, HamiltonTip), "Tip type must be HamiltonTip."
     ttti = await self.get_or_assign_tip_type_index(prototypical_tip)
     position = tip_spot_a1.get_location_wrt(self.deck) + tip_spot_a1.center() + pickup.offset
+    position.z = tip_spot_top + pickup.offset.z
     self._check_96_position_legal(position, skip_z=True)
-    z_deposit_position += round(pickup.offset.z * 10)
+    z_deposit_position += pickup.offset.z
 
     x_direction = 0 if position.x >= 0 else 1
     return await self.pick_up_tips_core96(


### PR DESCRIPTION
Hi everyone,

## Problem Statement

`STARBackend.pick_up_tips96()` is broken on multiple levels:

**1. The z-coordinate at which tip_pickup has so far been taking place was hardcoded to z=216.5 mm - this is (a) for some tips slightly incorrect, and (b) eliminates the usage of "non-standard" tip_racks such as Hamilton's nested tip racks (NTRs).**
<img width="928" height="217" alt="old_way_mistake_no1" src="https://github.com/user-attachments/assets/2011df4e-60cb-4175-b072-190027255d1e" />


**2. The conversion from mm to dmm has so far been applied twice to the tip_pickup z-coordinate offset:**
<img width="940" height="783" alt="old_way_mistake_no2" src="https://github.com/user-attachments/assets/3a1dfcf0-b23d-44b3-9367-a64924cfb666" />

**3. The check for whether the 96-head can go to the tiprack has been applied based on the *bottom* of tip_spot "A1", which doesn't make sense because the 96-head never needs to go to that z-coordinate which is *inside* the tiprack or the tipcarrier.
This leads to incorrect triggering of not being able to go to tip_racks below a the standard tip_carrier height, e.g. NTRs.**

<img width="884" height="502" alt="old_way_mistake_no3" src="https://github.com/user-attachments/assets/06d797b2-44b5-46ae-a508-fce3ce16e14c" />


## PR Content

1. I made `STARBackend.pick_up_tips96()` compute the location to which the 96-head actually has to go dynamically based on the tips it is picking up + the (potentially variable) location of the tiprack.
2. removed double dmm conversion.
3. Gave the 96-head check the actual z-coordinate used for pickup derived from fix no.1 above.

## Testing

This is a change to an atomic command, i.e. not something we should take lightly - and therefore should perform extensive testing before merging into main.

I tested tip pickup with everything I have:
Standard tip_carrier tiprack pickup of tips...
- 10 ul
- 50 ul
- 300 ul
- 1000 ul

NTR tiprack pickup of tips...
- 50 ul
- 300 ul

<img width="1235" height="399" alt="Screenshot 2025-10-07 at 18 44 22" src="https://github.com/user-attachments/assets/dd3f687c-1c06-448f-8cf0-b9b8f93ad4bc" />


Can I please ask others to also test this new `STARBackend.pick_up_tips96()` method for inter-lab cross-validation?

