### PR TITLE
remove resources assignment callbacks from lh

### DIFF
--- a/pylabrobot/liquid_handling/backends/backend.py
+++ b/pylabrobot/liquid_handling/backends/backend.py
@@ -19,7 +19,7 @@ from pylabrobot.liquid_handling.standard import (
   SingleChannelDispense,
 )
 from pylabrobot.machines.backend import MachineBackend
-from pylabrobot.resources import Deck, Resource, Tip
+from pylabrobot.resources import Deck, Tip
 from pylabrobot.resources.tip_tracker import TipTracker
 
 
@@ -69,24 +69,6 @@ class LiquidHandlerBackend(MachineBackend, metaclass=ABCMeta):
   async def setup(self):
     """Set up the robot. This method should be called before any other method is called."""
     assert self._deck is not None, "Deck not set"
-
-  async def assigned_resource_callback(self, resource: Resource):
-    """Called when a new resource was assigned to the robot.
-
-    This callback will also be called immediately after the setup method has been called for any
-    resources that were assigned to the robot before it was set up. The first resource will always
-    be the deck itself.
-
-    Args:
-      resource: The resource that was assigned to the robot.
-    """
-
-  async def unassigned_resource_callback(self, name: str):
-    """Called when a resource is unassigned from the robot.
-
-    Args:
-      resource: The name of the resource that was unassigned from the robot.
-    """
 
   @property
   @abstractmethod

--- a/pylabrobot/liquid_handling/backends/chatterbox.py
+++ b/pylabrobot/liquid_handling/backends/chatterbox.py
@@ -18,7 +18,7 @@ from pylabrobot.liquid_handling.standard import (
   SingleChannelAspiration,
   SingleChannelDispense,
 )
-from pylabrobot.resources import Resource, Tip
+from pylabrobot.resources import Tip
 
 
 class LiquidHandlerChatterboxBackend(LiquidHandlerBackend):
@@ -57,12 +57,6 @@ class LiquidHandlerChatterboxBackend(LiquidHandlerBackend):
   @property
   def num_channels(self) -> int:
     return self._num_channels
-
-  async def assigned_resource_callback(self, resource: Resource):
-    print(f"Resource {resource.name} was assigned to the liquid handler.")
-
-  async def unassigned_resource_callback(self, name: str):
-    print(f"Resource {name} was unassigned from the liquid handler.")
 
   async def pick_up_tips(self, ops: List[Pickup], use_channels: List[int], **backend_kwargs):
     print("Picking up tips:")

--- a/pylabrobot/liquid_handling/backends/saver_backend.py
+++ b/pylabrobot/liquid_handling/backends/saver_backend.py
@@ -31,24 +31,6 @@ class SaverBackend(LiquidHandlerBackend):
   async def send_command(self, command: str, data: Dict[str, Any]):
     self.commands_received.append({"command": command, "data": data})
 
-  async def assigned_resource_callback(self, *args, **kwargs):
-    self.commands_received.append(
-      {
-        "command": "assigned_resource_callback",
-        "args": args,
-        "kwargs": kwargs,
-      }
-    )
-
-  async def unassigned_resource_callback(self, *args, **kwargs):
-    self.commands_received.append(
-      {
-        "command": "unassigned_resource_callback",
-        "args": args,
-        "kwargs": kwargs,
-      }
-    )
-
   async def pick_up_tips(self, *args, **kwargs):
     self.commands_received.append({"command": "pick_up_tips", "args": args, "kwargs": kwargs})
 

--- a/pylabrobot/liquid_handling/backends/serializing_backend.py
+++ b/pylabrobot/liquid_handling/backends/serializing_backend.py
@@ -20,7 +20,7 @@ from pylabrobot.liquid_handling.standard import (
   SingleChannelAspiration,
   SingleChannelDispense,
 )
-from pylabrobot.resources import Resource, Tip
+from pylabrobot.resources import Tip
 from pylabrobot.serializer import serialize
 
 if sys.version_info >= (3, 8):
@@ -56,18 +56,6 @@ class SerializingBackend(LiquidHandlerBackend, metaclass=ABCMeta):
 
   def serialize(self) -> dict:
     return {**super().serialize(), "num_channels": self.num_channels}
-
-  async def assigned_resource_callback(self, resource: Resource):
-    await self.send_command(
-      command="resource_assigned",
-      data={
-        "resource": resource.serialize(),
-        "parent_name": (resource.parent.name if resource.parent else None),
-      },
-    )
-
-  async def unassigned_resource_callback(self, name: str):
-    await self.send_command(command="resource_unassigned", data={"resource_name": name})
 
   async def pick_up_tips(self, ops: List[Pickup], use_channels: List[int]):
     serialized = [

--- a/pylabrobot/liquid_handling/backends/serializing_backend_tests.py
+++ b/pylabrobot/liquid_handling/backends/serializing_backend_tests.py
@@ -221,7 +221,7 @@ class SerializingBackendTests(unittest.IsolatedAsyncioTestCase):
   async def test_move(self):
     to = Coordinate(600, 200, 200)
     await self.lh.move_plate(self.plate, to=to)
-    self.assertEqual(len(self.backend.sent_commands), 4)  # move + resource unassign + assign
+    self.assertEqual(len(self.backend.sent_commands), 2)  # pickup and drop
     self.assertEqual(
       self.backend.get_first_data_for_command("pick_up_resource"),
       {

--- a/pylabrobot/liquid_handling/backends/websocket.py
+++ b/pylabrobot/liquid_handling/backends/websocket.py
@@ -20,7 +20,6 @@ from pylabrobot.__version__ import STANDARD_FORM_JSON_VERSION
 from pylabrobot.liquid_handling.backends.serializing_backend import (
   SerializingBackend,
 )
-from pylabrobot.resources import Resource
 
 if TYPE_CHECKING:
   import websockets.legacy
@@ -171,24 +170,6 @@ class WebSocketBackend(SerializingBackend):
 
     while not self.has_connection():
       time.sleep(0.1)
-
-  async def assigned_resource_callback(self, resource: Resource):
-    # override SerializingBackend so we don't wait for a response
-    await self.send_command(
-      command="resource_assigned",
-      data={
-        "resource": resource.serialize(),
-        "parent_name": (resource.parent.name if resource.parent else None),
-      },
-      wait_for_response=False,
-    )
-
-  async def unassigned_resource_callback(self, name: str):
-    # override SerializingBackend so we don't wait for a response
-    await self.send_command(
-      command="resource_unassigned",
-      data={"resource_name": name, "wait_for_response": False},
-    )
 
   async def send_command(
     self,

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -147,9 +147,6 @@ class LiquidHandler(Resource, Machine):
     self.backend: LiquidHandlerBackend = backend  # fix type
 
     self.deck = deck
-    # register callbacks for sending resource assignment/unassignment to backend
-    self.deck.register_did_assign_resource_callback(self._send_assigned_resource_to_backend)
-    self.deck.register_did_unassign_resource_callback(self._send_unassigned_resource_to_backend)
 
     self.head: Dict[int, TipTracker] = {}
     self.head96: Dict[int, TipTracker] = {}
@@ -179,10 +176,6 @@ class LiquidHandler(Resource, Machine):
 
     self.head = {c: TipTracker(thing=f"Channel {c}") for c in range(self.backend.num_channels)}
     self.head96 = {c: TipTracker(thing=f"Channel {c}") for c in range(96)}
-
-    self._send_assigned_resource_to_backend(self.deck)
-    for resource in self.deck.children:
-      self._send_assigned_resource_to_backend(resource)
 
     self._resource_pickup = None
 
@@ -238,16 +231,6 @@ class LiquidHandler(Resource, Machine):
     t = threading.Thread(target=callback, args=args, kwargs=kwargs)
     t.start()
     t.join()
-
-  def _send_assigned_resource_to_backend(self, resource: Resource):
-    """This method is called when a resource is assigned to the deck, and passes this information
-    to the backend."""
-    self._run_async_in_thread(self.backend.assigned_resource_callback, resource)
-
-  def _send_unassigned_resource_to_backend(self, resource: Resource):
-    """This method is called when a resource is unassigned from the deck, and passes this
-    information to the backend."""
-    self._run_async_in_thread(self.backend.unassigned_resource_callback, resource.name)
 
   def summary(self):
     """Prints a string summary of the deck layout."""


### PR DESCRIPTION
lh is not special, no other machine does this

this is a relic from the old days when lh was special

OT also used to rely on this, but that was fixed in https://github.com/PyLabRobot/pylabrobot/pull/689

it's no longer needed