### PR TITLE
Enable MFX TubeHolders & TroughHolders

### DIFF
--- a/pylabrobot/resources/carrier.py
+++ b/pylabrobot/resources/carrier.py
@@ -63,7 +63,7 @@ class Carrier(Resource, Generic[S]):
     reassign: bool = True,
     spot: Optional[int] = None,
   ):
-    if not isinstance(resource, ResourceHolder):
+    if not isinstance(resource, (ResourceHolder, Carrier)):
       raise TypeError(f"Invalid resource {resource}")
 
     # see if we have an index for the resource name (eg from deserialization or user specification),


### PR DESCRIPTION
Hi everyone,

PLR is currently missing good implementations of two types of Resources/Labware commonly found in biowetlabs:

- "Racks": items that can hold mutable children in a 2D grid _but_ the item itself is movable
- "MFX Holders": items that can hold mutable children in a 2D grid _but_ the item itself is immovable, i.e. screwed onto a MFX carrier
e.g.:
<img width="133" height="438" alt="Screenshot 2025-10-12 at 23 28 21" src="https://github.com/user-attachments/assets/ad660068-0611-4828-92dc-dd9bce28c3a6" />


Functionally, both of these are completely covered by what `Carrier` can already do:
- Specify children locations in the desired order
- Modify whether the child locations vary in `x`, in `y` or both
- Enable usage of irregular children location
- Enable simple assignment based on indexing

Focusing on "MFX Holders" specifically:
As a result of this, I here propose the minimal required change to enable usage of these types of resources:
To accept Carrier as a valid type for a Carrier site.

TubeHolders & TroughHolders can then be simply modelled as Carriers.

(Note: maybe we can find a name that encapsulates the full breath of this powerful Resource after this?)