### PR TITLE
Correct CellTreat_12_troughplate_15000ul_Vb

### DIFF
--- a/pylabrobot/resources/celltreat/plates.py
+++ b/pylabrobot/resources/celltreat/plates.py
@@ -218,6 +218,7 @@ def CellTreat_12_troughplate_15000ul_Vb(name: str) -> Plate:
       dz=4.07,  # measured
       item_dx=9.0,  # standard
       item_dy=9.0,  # standard
+      cross_section_type=CrossSectionType.RECTANGLE,
       **well_kwargs,
     ),
   )


### PR DESCRIPTION
won't load otherwise since circular wells (default arg) don't accept diff x/y dim