### PR TITLE
STARBackend can_reach_position and ensure_can_reach_position

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -1485,7 +1485,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     return True
 
   def ensure_can_reach_position(
-    self, use_channels: List[int], ops: List[PipettingOp], op_name: str
+    self, use_channels: List[int], ops: Sequence[PipettingOp], op_name: str
   ):
     locs = [(op.resource.get_location_wrt(self.deck, y="c") + op.offset) for op in ops]
     cant_reach = [


### PR DESCRIPTION
- `can_reach_position`: check if a certain channel can reach a position
- `ensure_can_reach_position` ensures all channels can reach their positions, or raises an error. added to all four operations (pick up tips, drop tips, aspirate, dispense) before sending a firmware command. this has a clearer error message than the firmware, and also prevents an error-causing firmware command from being sent
  - also helps "simulation" in STARChatterboxBackend