### PR TITLE
star: error if grip direction is not front (default) with core gripper

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -3415,6 +3415,9 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       if use_unsafe_hotel:
         raise ValueError("Cannot use iswap hotel mode with core grippers")
 
+      if pickup.direction != GripDirection.FRONT:
+        raise NotImplementedError("Core grippers only support FRONT (default)")
+
       if channel_1 is not None or channel_2 is not None:
         warnings.warn(
           "The channel_1 and channel_2 parameters are deprecated and will be removed in future versions. "
@@ -3545,7 +3548,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
           hotel_center_z_direction=0 if z >= 0 else 1,
           clearance_height=round(hotel_clearance_height * 10),
           hotel_depth=round(hotel_depth * 10),
-          grip_direction=drop.drop_direction,
+          grip_direction=drop.direction,
           open_gripper_position=round(open_gripper_position * 10),
           traverse_height_at_beginning=round(traversal_height_start * 10),
           z_position_at_end=round(z_position_at_the_command_end * 10),
@@ -3565,7 +3568,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
             GripDirection.RIGHT: 2,
             GripDirection.BACK: 3,
             GripDirection.LEFT: 4,
-          }[drop.drop_direction],
+          }[drop.direction],
           minimum_traverse_height_at_beginning_of_a_command=round(traversal_height_start * 10),
           z_position_at_the_command_end=round(z_position_at_the_command_end * 10),
           open_gripper_position=round(open_gripper_position * 10),
@@ -3575,6 +3578,9 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     elif use_arm == "core":
       if use_unsafe_hotel:
         raise ValueError("Cannot use iswap hotel mode with core grippers")
+
+      if drop.direction != GripDirection.FRONT:
+        raise NotImplementedError("Core grippers only support FRONT direction (default)")
 
       await self.core_release_picked_up_resource(
         location=Coordinate(x, y, z),

--- a/pylabrobot/liquid_handling/backends/serializing_backend.py
+++ b/pylabrobot/liquid_handling/backends/serializing_backend.py
@@ -213,7 +213,7 @@ class SerializingBackend(LiquidHandlerBackend, metaclass=ABCMeta):
         "offset": serialize(drop.offset),
         "pickup_distance_from_top": drop.pickup_distance_from_top,
         "pickup_direction": serialize(drop.pickup_direction),
-        "drop_direction": serialize(drop.drop_direction),
+        "drop_direction": serialize(drop.direction),
         "rotation": drop.rotation,
       },
       **backend_kwargs,

--- a/pylabrobot/liquid_handling/backends/tecan/EVO_tests.py
+++ b/pylabrobot/liquid_handling/backends/tecan/EVO_tests.py
@@ -387,7 +387,7 @@ class EVOTests(unittest.IsolatedAsyncioTestCase):
       offset=Coordinate.zero(),
       pickup_distance_from_top=13.2,
       pickup_direction=GripDirection.FRONT,
-      drop_direction=GripDirection.FRONT,
+      direction=GripDirection.FRONT,
       rotation=0,
     )
 

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -2221,7 +2221,7 @@ class LiquidHandler(Resource, Machine):
       offset=offset,
       pickup_distance_from_top=self._resource_pickup.pickup_distance_from_top,
       pickup_direction=self._resource_pickup.direction,
-      drop_direction=direction,
+      direction=direction,
       rotation=rotation_applied_by_move,
     )
     result = await self.backend.drop_resource(drop=drop, **backend_kwargs)

--- a/pylabrobot/liquid_handling/standard.py
+++ b/pylabrobot/liquid_handling/standard.py
@@ -169,7 +169,7 @@ class ResourceDrop:
   offset: Coordinate
   pickup_distance_from_top: float
   pickup_direction: GripDirection
-  drop_direction: GripDirection
+  direction: GripDirection
   rotation: float
 
 


### PR DESCRIPTION
the direction is meaningless so let's conventionally set it to FRONT with core grippers. direction is most important for resource rotations, which is impossible with the core grippers

however, the front end does not know that and will still apply the rotation (if directions are specified). this leads to placement errors

in this PR I fix that error case by conventionally setting core grippers as "front" pickup to avoid mistaken rotation issues (might be `None` or sth if we refactor in the future, but that's annoying with the standard API)