### PR TITLE
vspin: fix bucket1 pos after spin; fix short spins

### DIFF
--- a/pylabrobot/centrifuge/centrifuge.py
+++ b/pylabrobot/centrifuge/centrifuge.py
@@ -110,7 +110,7 @@ class Centrifuge(Machine, Resource):
 
     Args:
       g: The g-force to spin at.
-      duration: The duration of the spin in seconds.
+      duration: The duration of the spin in seconds. Time at speed.
       acceleration: The acceleration as a fraction of maximum acceleration (0-1).
     """
     await self.backend.spin(


### PR DESCRIPTION
- the home position actually changes shortly after a spin, which is necessary for the bucket1 pos to be computed correctly. this issue showed up when calling `go_to_bucket1` directly after `spin` in a script but was not present during debugging/development because it's not called fast enough... in this PR, I change it to a while loop with optional retry for the "reset" part. this works very well.
- for short spins the speed is actually not always reached before we surpass the position. in that case, we stop once we reach the final position. making the spin longer is not possible unfortunately as the vspin will break automatically. kind of an edge case (only <10s spins), but still fixed because I sometimes use these short spins to test things like the issue above