### PR TITLE
Fix atc available blocks detection

### DIFF
--- a/pylabrobot/io/socket.py
+++ b/pylabrobot/io/socket.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import ssl
 from dataclasses import dataclass
-from ssl import SSLContext
 from typing import TYPE_CHECKING, Optional
 
 from pylabrobot.io.capture import Command, capturer, get_capture_or_validation_active

--- a/pylabrobot/thermocycling/thermo_fisher/thermo_fisher_thermocycler.py
+++ b/pylabrobot/thermocycling/thermo_fisher/thermo_fisher_thermocycler.py
@@ -890,7 +890,7 @@ class ThermoFisherThermocyclerBackend(ThermocyclerBackend, metaclass=ABCMeta):
     await self._load_num_blocks_and_type()
     if blocks_to_setup is None:
       await self._load_available_blocks()
-      if not self.available_blocks:
+      if len(self.available_blocks) == 0:
         raise ValueError("No available blocks. Set blocks_to_setup to force setup")
     else:
       self.available_blocks = blocks_to_setup


### PR DESCRIPTION
Fixed logic for detecting available blocks on thermofisher thermocyclers. Add error for attempting to setup without available blocks