### PR TITLE
easy way to make logger verbose

### DIFF
--- a/pylabrobot/__init__.py
+++ b/pylabrobot/__init__.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import sys
 from pathlib import Path
 from typing import Optional, Union
 
@@ -68,13 +69,14 @@ configure(CONFIG)
 
 def verbose(make_verbose: bool, level: int = logging.INFO) -> None:
   """Add a StreamHandler to the pylabrobot logger to make logging output visible to the console.
-  If set to False, remove the StreamHandler.
-  Careful: this will remove all existing StreamHandlers!
+  If set to False, remove the console StreamHandler. This only removes StreamHandlers that output
+  to sys.stdout or sys.stderr, and will not affect FileHandlers or other subclasses.
   """
   logger = logging.getLogger("pylabrobot")
-  for handler in logger.handlers:
-    if isinstance(handler, logging.StreamHandler):
-      logger.removeHandler(handler)
+  for handler in logger.handlers[:]:  # iterate over a copy to allow safe removal
+    if isinstance(handler, logging.StreamHandler) and not isinstance(handler, logging.FileHandler):
+      if handler.stream in (sys.stdout, sys.stderr):
+        logger.removeHandler(handler)
   if make_verbose:
     logger.setLevel(level)
     handler = logging.StreamHandler()


### PR DESCRIPTION
```
plr.verbose(True)
```

or

```
plr.verbose(True, level=logging.DEBUG)
```

(default level is info)

hacky, but useful for debugging/prototyping. not recommended for prod