### PR TITLE
Enable STAR 96head partial tiprack pickup/drop + Fix requirement for A1 to have a tip

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -2491,10 +2491,8 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       tip_pickup_method: The method to use for picking up tips. One of "from_rack", "from_waste", "full_blowout".
       minimum_height_command_end: The minimum height to move to at the end of the command.
       minimum_traverse_height_at_beginning_of_a_command: The minimum height to move to at the beginning of the command.
-      alignment_tipspot: The tipspot to use for alignment with head's A1 channel. Defaults to "tipspot A1".
-        allowed range is ZA-11 to H12 (negative numbers indicate 'head offset to the left'), see PLR's head documentation for details.
+      experimental_alignment_tipspot_identifier: The tipspot to use for alignment with head's A1 channel. Defaults to "tipspot A1".  allowed range is A1 to H12.
     """
-    # TODO: add link to documentation
 
     if isinstance(tip_pickup_method, int):
       warnings.warn(


### PR DESCRIPTION
Hi everyone,

## The Problems

1. PLR on a STAR currently ALWAYS requires tiprack position A1 to have a tip (so it can retrieve that tip's information to calculate the correct z-coordinate for pickup)

2. We can only pick up full tipracks with the 96head, i.e. picking up partial tipracks (e.g. only the last 6 columns) is currently not possible with PLR.

## PR Content

1. Instead of retrieving tip information from the tiprack based on hardcoded position "A1", PLR is already performing a check that there _are_ tips in the tiprack and stores the tip instance handles in a list. I replaced the hardcoded "A1" dependency with the first element of the tip instance handle list.

2. The STAR uses the x_center-y_center position of its _96head **"A1"** probe_ (the part that houses the metal bearing, and picks up a tip) and is sent to any **alignment_tipspot** - so far this tipspot has been hardcoded to "A1" of the tiprack it picks up from.
Here I am introducing the new `STAR. pick_up_tips96()` attribute `alignment_tipspot: str = "A1"`.
It's default is set to `"A1"`, ensuring no change in existing behaviour and keeping the expected default behaviour (i.e. "full tiprack pickup").
Setting it to a different `Well` identifier, e.g. "C3", would move the 96head to align its probe_A1 wit tipspot_C3, leading to a **partial tiprack pickup**.
 
## TODOs
- this solution _only accepts valid_ `Well` `identifiers! -> as a result the 96head can _only_ offset to the right and to the bottom relative to the tiprack itself.
i.e. offsetting to the top or left is currently not possible! (I am working on a separate solution to this and have left an Easter egg in the docstring to it, but it is a self-contained PR and needs a lot more testing)
- to ensure people don't accidentally use this new feature on a "framed/fenced" tiprack - which would result in a crash of the 96head probes into the tiprack - we will need to update the tipracks to include information about whether they are "framed/fenced" and raise an error if this is the case AND `alignment_tipspot != "A1"`.