### PR TITLE
Fix `iswap_move_picked_up_resource` to move into -x and -y dimension

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -3147,11 +3147,14 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
 
     assert self.iswap_installed, "iswap must be installed"
 
+    x_direction = 0 if center.x >= 0 else 1
+    y_direction = 0 if center.y >= 0 else 1
+
     await self.move_plate_to_position(
-      x_position=round(center.x * 10),
-      x_direction=0,
-      y_position=round(center.y * 10),
-      y_direction=0,
+      x_position=round(abs(center.x) * 10),
+      x_direction=x_direction,
+      y_position=round(abs(center.y) * 10),
+      y_direction=y_direction,
       z_position=round(center.z * 10),
       z_direction=0,
       grip_direction={


### PR DESCRIPTION
Currently only the following adjust the `x_direction` attribute to be able to go into the negative x coordinates:
- `STAR.aspirate96`
- `STAR.dispense96`
- `STAR.pick_up_tips96`
- `STAR.drop_tips96`

Importantly, `iswap_move_picked_up_resource` does not adjust to the `x_direction` nor the `y_direction`.

As a result, this command and all commands build on top of it do now allow using the iSWAP to move resources out of the main chassis.

However, the command generation chain is:

```python
move_plate_to_position (line 7828)
├── iswap_move_picked_up_resource (line 3135)
│   └── move_picked_up_resource (line 3449)
│       └── LiquidHandler.move_picked_up_resource (liquid_handler.py:2014)
│           └── LiquidHandler.move_plate (liquid_handler.py:2324)
│               [Called by user when moving plates with intermediate positions]
```

So we could move these adjustments even further up to the `STARBackend.move_plate_to_position()` method?

Please let me know what you think 🦾 