### PR TITLE
Add warning to hamilton troughs

### DIFF
--- a/pylabrobot/resources/hamilton/troughs.py
+++ b/pylabrobot/resources/hamilton/troughs.py
@@ -75,6 +75,11 @@ def hamilton_1_trough_60ml_Vb(name: str) -> Trough:
   True maximal volume capacity ~80 mL.
   Compatible with Trough_CAR_?? (194057 <- not yet integrated into PLR!).
   """
+  warnings.warn(
+    "hamilton_1_trough_60ml_Vb has a center support that can interfere with pipetting.\
+     If using an odd number of channels, use spread='custom' and define offsets for each channel to avoid collision."
+  )
+
   return Trough(
     name=name,
     size_x=19.0,


### PR DESCRIPTION
The hamilton trough has a center support that will collide with pipette tips if using 1 or odd number of channels. I added a warning and a solution.

Address this conversation:
https://discuss.pylabrobot.org/t/hamilton-trough-center-support-interference/399/2