### PR TITLE
Hamilton deck indicate carriers when loading deck

### DIFF
--- a/pylabrobot/resources/hamilton/hamilton_decks.py
+++ b/pylabrobot/resources/hamilton/hamilton_decks.py
@@ -219,12 +219,12 @@ class HamiltonDeck(Deck, metaclass=ABCMeta):
       occupied_rails = []
       for og_resource in self.children:
         occupied_rails.append(_rails_for_x_coordinate(og_resource.location.x))
-      led_bits = [0]*54
+      led_bits = [0] * 54
       for rail in range(54):
-        if rail+1 in occupied_rails:
+        if rail + 1 in occupied_rails:
           led_bits[rail] = 1
       # invert order of bits and send command
-      asyncio.create_task(root.backend.set_loading_indicators(led_bits[::-1], [0]*54))
+      asyncio.create_task(root.backend.set_loading_indicators(led_bits[::-1], [0] * 54))
 
     return super().assign_child_resource(resource, location=resource_location, reassign=reassign)
 


### PR DESCRIPTION
I would like to take advantage of the LED on the deck to indicate where a carrier should be loaded. This would be helpful for users who are running a program to know where carriers should be loaded. I wrote a script that would find all the rails where resources are loaded and turn on those LEDs when a carrier is "loaded" onto the pylabrobot deck. Not actually sensing a physical carrier, just when the user assigns it to the deck in pylabrobot.