### PR TITLE
Create `STAR.probe_liquid_volumes()`

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -1707,7 +1707,6 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       NotImplementedError: If channels require different X positions.
 
     Notes:
-      - All containers must support height-volume functions
       - All specified channels must have tips attached
       - All channels must be at the same X position (single-row operation)
       - For single containers with odd channel counts, Y-offsets are applied to avoid
@@ -1882,13 +1881,11 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
 
     Raises:
       ValueError: If any container doesn't support height-to-volume conversion (raised by probe_liquid_heights).
-      AssertionError: If channels lack tips or parameter lengths mismatch.
       NotImplementedError: If channels require different X positions.
-      KeyError: If LLD fails to return heights for requested channels.
 
     Notes:
     - Delegates all motion, LLD, validation, and safety logic to probe_liquid_heights
-    - Volume calculation uses Container.compute_volume_from_height()
+    - All containers must support height-volume functions. Volume calculation uses Container.compute_volume_from_height()
     """
 
     if any(not resource.supports_compute_height_volume_functions() for resource in containers):


### PR DESCRIPTION
Hi everyone,

Our automated Protocols (aPs) keep using liquids from Containers and we _must_ know what the volume in all containers (`Well`s inside wellplates, `Tube`s, `Trough`s, ...) is.

This is crucial for "**compound management**" and **verification correct workcell/deck setups**.

Here, I am proposing a beta version of `STAR.probe_liquid_volumes()` which can measure the volume of any `Container` for which height/volume functions have been previously defined in PyLabRobot.

This first version uses the `STAR.aspirate()` function with `volume=0` to enable liquid level detection in either a...
1. capacitative- or
2. pressure- based mode.

This means that both conductive and non-conductive/clear tips can be used to probe the volume in containers.

Accuracy: cLLD/pLLD is _not_ always the most precise measurement technique and for low-volume or narrow Containers might not work at all, based on the STAR cLLD/pLLD limitations. 
You have to verify that the LLD works for your Containers and give your processes enough dead-volume if you use it at the low-volume end.

However, by enabling both LLD modes you have quite some flexibility to find a way that suits your application.

Furthermore, by default, 3 technical replicates of the probing will be executed, and this can be adjusted based on the method arguments:

```python
  async def probe_liquid_volumes(
    self,
    containers: List[Container],
    use_channels: List[int],
    resource_offsets: Optional[List[Coordinate]] = None,
    lld_mode: Optional[List[int]] = None,
    minimum_traverse_height_at_beginning_of_a_command: Optional[float] = None,
    min_z_endpos: Optional[float] = None, # defaults to self._channel_traversal_height
    techn_replicate_num: int = 3,
    return_mean: bool = True,
    traversal_height: Optional[float] = None, # defaults to self._channel_traversal_height
    move_to_z_safety_after: bool = True,
) -> Union[List[float], List[Tuple[float, ...]]]:
```

This has been tested on single Container (troughs) and different multi-wellplates on a Hamilton STAR.

Note: This is a beta method - use with caution and we will continuously iterate and improve over the coming months.
E.g.: a discussion should be had about whether to swap the `.aspirate()` implementation with `clld_probe_`/`plld_probe_` implementation.
Please report any issues you might encounter on the PyLabRobot forum.


Happy compound management 🧪  