### PR TITLE
no longer require move_to_z_safety in request_tip_len_on_channel

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -9123,9 +9123,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     probe_position = await self.request_probe_z_position(channel_idx=channel_idx)
 
     # Request z-coordinate of channel+tip bottom
-    tip_bottom_z_coordinate = await self.request_tip_bottom_z_position(
-      pipetting_channel_index=channel_idx
-    )
+    tip_bottom_z_coordinate = await self.request_tip_bottom_z_position(channel_idx=channel_idx)
 
     total_tip_len = round(
       probe_position - (tip_bottom_z_coordinate - fitting_depth_of_all_standard_channel_tips),


### PR DESCRIPTION
instead of moving the tips to z safety in request_tip_len_on_channel to bring the probes to a known location (introduced by @BioCam in https://github.com/PyLabRobot/pylabrobot/pull/260), we can just query the location directly without having to move channels. now we can get the tip length from the machine without having to move anything. this is useful in the probing methods where we require knowing the mounted tip lengths, but don't want the user to have to specify them. loading them from the front end is kind of annoying (due to notebook autoreload issues)

in this PR I also rename `request_z_pos_channel_n` to `request_tip_bottom_z_position` to clearly differentiate it from `request_probe_z_position`.

`request_z_pos_channel_n` had the annoying behavior of returning the probe height when no tip is mounted, which is no longer allowed. tis need to be mounted to use `request_tip_bottom_z_position`, for the probe height you can use `request_probe_z_position` (return value changing based on "hidden" state is whack)