### PR TITLE
io.usb: send zero length packet when max packet size divides message length

### DIFF
--- a/pylabrobot/io/usb.py
+++ b/pylabrobot/io/usb.py
@@ -116,6 +116,12 @@ class USB(IOBase):
       self._executor,
       lambda: dev.write(write_endpoint, data, timeout=timeout),
     )
+    if len(data) % write_endpoint.wMaxPacketSize == 0:
+      # send a zero-length packet to indicate the end of the transfer
+      await loop.run_in_executor(
+        self._executor,
+        lambda: dev.write(write_endpoint, b"", timeout=timeout),
+      )
     logger.log(LOG_LEVEL_IO, "%s write: %s", self._unique_id, data)
     capturer.record(
       USBCommand(device_id=self._unique_id, action="write", data=data.decode("unicode_escape"))


### PR DESCRIPTION
to indicate the last message

this was giving us problems on the star when aspirating 13 or more channels, but that's just because these commands happen to be divided by 64 equally ...