### PR TITLE
Add assign_child_by_anchor method for anchor-based resource assignment

### DIFF
--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -4,7 +4,7 @@ import itertools
 import json
 import logging
 import sys
-from typing import Any, Callable, Dict, List, Optional, cast
+from typing import Any, Callable, Dict, List, Optional, Union, cast
 
 from pylabrobot.serializer import deserialize, serialize
 from pylabrobot.utils.linalg import matrix_vector_multiply_3x3
@@ -21,6 +21,39 @@ else:
   from typing_extensions import Self
 
 logger = logging.getLogger("pylabrobot")
+
+
+def _compute_location_from_anchors(
+  parent: "Resource",
+  child: "Resource",
+  parent_anchor: Union[tuple[str, str, str], str],
+  child_anchor: Union[tuple[str, str, str], str],
+) -> Coordinate:
+  """Compute the location for a child resource to align anchor points.
+
+  Args:
+    parent: The parent resource.
+    child: The child resource to be assigned.
+    parent_anchor: Tuple of (x, y, z) anchor specifiers or a 3-character string for the parent.
+    child_anchor: Tuple of (x, y, z) anchor specifiers or a 3-character string for the child.
+
+  Returns:
+    The location to pass to assign_child_resource to align the anchors.
+  """
+  # Convert string anchors to tuples
+  if isinstance(parent_anchor, str):
+    if len(parent_anchor) != 3:
+      raise ValueError(f"Anchor string must be exactly 3 characters, got: {parent_anchor}")
+    parent_anchor = (parent_anchor[0], parent_anchor[1], parent_anchor[2])
+
+  if isinstance(child_anchor, str):
+    if len(child_anchor) != 3:
+      raise ValueError(f"Anchor string must be exactly 3 characters, got: {child_anchor}")
+    child_anchor = (child_anchor[0], child_anchor[1], child_anchor[2])
+
+  parent_anchor_pos = parent.get_anchor(x=parent_anchor[0], y=parent_anchor[1], z=parent_anchor[2])
+  child_anchor_pos = child.get_anchor(x=child_anchor[0], y=child_anchor[1], z=child_anchor[2])
+  return parent_anchor_pos - child_anchor_pos
 
 
 WillAssignResourceCallback = Callable[["Resource"], None]
@@ -341,6 +374,59 @@ class Resource:
     # Call "did assign" callbacks
     for callback in self._did_assign_resource_callbacks:
       callback(resource)
+
+  def assign_child_by_anchor(
+    self,
+    resource: Resource,
+    parent_anchor: Union[tuple[str, str, str], str] = ("l", "f", "b"),
+    child_anchor: Union[tuple[str, str, str], str] = ("l", "f", "b"),
+    reassign: bool = True,
+  ):
+    """Assign a child resource by aligning anchor points.
+
+    This method computes the location needed to align the specified anchor points of the parent
+    and child resources, then calls :meth:`assign_child_resource` with the computed location.
+
+    Args:
+      resource: The resource to assign.
+      parent_anchor: Anchor specifiers for the parent. Can be either:
+        - A tuple of (x, y, z) strings, or
+        - A 3-character string (e.g., "lfb" for left-front-bottom)
+        Each element can be:
+        x: `"l"`/`"left"`, `"c"`/`"center"`, or `"r"`/`"right"`
+        y: `"b"`/`"back"`, `"c"`/`"center"`, or `"f"`/`"front"`
+        z: `"t"`/`"top"`, `"c"`/`"center"`, or `"b"`/`"bottom"`
+        Defaults to left-front-bottom.
+      child_anchor: Anchor specifiers for the child (same format as parent_anchor).
+        Defaults to left-front-bottom.
+      reassign: If `False`, an error will be raised if the resource to be assigned is already
+        assigned to this resource. Defaults to `True`.
+
+    Examples:
+      Align left-front-bottom (default behavior):
+
+      >>> parent = Resource("parent", size_x=100, size_y=100, size_z=10)
+      >>> child = Resource("child", size_x=80, size_y=80, size_z=5)
+      >>> parent.assign_child_by_anchor(child)  # Both default to LFB
+
+      Align the center-center-bottom using tuple syntax:
+
+      >>> parent.assign_child_by_anchor(child, parent_anchor=("c", "c", "b"),
+      ...                               child_anchor=("c", "c", "b"))
+
+      Align the center-center-bottom using string syntax:
+
+      >>> parent.assign_child_by_anchor(child, parent_anchor="ccb", child_anchor="ccb")
+
+      Stack on top by aligning parent's top with child's bottom:
+
+      >>> parent.assign_child_by_anchor(child, parent_anchor="lft", child_anchor="lfb")
+    """
+
+    location = _compute_location_from_anchors(
+      parent=self, child=resource, parent_anchor=parent_anchor, child_anchor=child_anchor
+    )
+    self.assign_child_resource(resource=resource, location=location, reassign=reassign)
 
   # Helper methods to call all callbacks. These are used to propagate callbacks up the tree.
   def _call_will_assign_resource_callbacks(self, resource: Resource):

--- a/pylabrobot/resources/resource_tests.py
+++ b/pylabrobot/resources/resource_tests.py
@@ -454,3 +454,285 @@ class TestResourceCallback(unittest.TestCase):
     new_child = Resource("new_child", size_x=5, size_y=5, size_z=5)
     self.child.assign_child_resource(new_child, location=Coordinate.zero())
     mock_function.assert_called_once_with(new_child)
+
+
+class TestAssignChildByAnchor(unittest.TestCase):
+  def setUp(self) -> None:
+    super().setUp()
+    self.parent = Resource("parent", size_x=100, size_y=100, size_z=10)
+    self.parent.location = Coordinate.zero()  # Set location for absolute position tests
+
+  def test_center_center_bottom_alignment(self):
+    """Test aligning center-center-bottom of both parent and child."""
+    child = Resource("child", size_x=80, size_y=60, size_z=5)
+    self.parent.assign_child_by_anchor(
+      child,
+      parent_anchor=("c", "c", "b"),
+      child_anchor=("c", "c", "b"),
+    )
+    # Parent CCB is at (50, 50, 0) relative to parent LFB
+    # Child CCB should be at (40, 30, 0) relative to child LFB
+    # So child LFB should be at (50-40, 50-30, 0-0) = (10, 20, 0)
+    self.assertEqual(child.location, Coordinate(10, 20, 0))
+    # Check absolute positions match
+    parent_ccb = self.parent.get_absolute_location(x="c", y="c", z="b")
+    child_ccb = child.get_absolute_location(x="c", y="c", z="b")
+    self.assertEqual(parent_ccb, child_ccb)
+
+  def test_left_front_bottom_alignment(self):
+    """Test aligning left-front-bottom of both (should be at origin)."""
+    child = Resource("child", size_x=50, size_y=50, size_z=5)
+    self.parent.assign_child_by_anchor(
+      child,
+      parent_anchor=("l", "f", "b"),
+      child_anchor=("l", "f", "b"),
+    )
+    # Both LFB anchors are at (0, 0, 0) relative to their own LFB
+    self.assertEqual(child.location, Coordinate(0, 0, 0))
+
+  def test_default_anchor_is_lfb(self):
+    """Test that the default anchor is left-front-bottom."""
+    child = Resource("child", size_x=50, size_y=50, size_z=5)
+    self.parent.assign_child_by_anchor(child)
+    # Default should be LFB for both, so child should be at origin
+    self.assertEqual(child.location, Coordinate(0, 0, 0))
+
+  def test_right_back_top_alignment(self):
+    """Test aligning right-back-top of both."""
+    child = Resource("child", size_x=60, size_y=40, size_z=8)
+    self.parent.assign_child_by_anchor(
+      child,
+      parent_anchor=("r", "b", "t"),
+      child_anchor=("r", "b", "t"),
+    )
+    # Parent RBT is at (100, 100, 10)
+    # Child RBT is at (60, 40, 8)
+    # Child LFB should be at (100-60, 100-40, 10-8) = (40, 60, 2)
+    self.assertEqual(child.location, Coordinate(40, 60, 2))
+    parent_rbt = self.parent.get_absolute_location(x="r", y="b", z="t")
+    child_rbt = child.get_absolute_location(x="r", y="b", z="t")
+    self.assertEqual(parent_rbt, child_rbt)
+
+  def test_stacking_on_top(self):
+    """Test stacking child on top of parent by aligning parent's top with child's bottom."""
+    child = Resource("child", size_x=100, size_y=100, size_z=5)
+    self.parent.assign_child_by_anchor(
+      child,
+      parent_anchor=("l", "f", "t"),
+      child_anchor=("l", "f", "b"),
+    )
+    # Parent LFT is at (0, 0, 10)
+    # Child LFB is at (0, 0, 0)
+    # Child LFB should be at (0-0, 0-0, 10-0) = (0, 0, 10)
+    self.assertEqual(child.location, Coordinate(0, 0, 10))
+    parent_lft = self.parent.get_absolute_location(x="l", y="f", z="t")
+    child_lfb = child.get_absolute_location(x="l", y="f", z="b")
+    self.assertEqual(parent_lft, child_lfb)
+
+  def test_centered_stacking(self):
+    """Test stacking with center alignment in x and y."""
+    child = Resource("child", size_x=50, size_y=50, size_z=5)
+    self.parent.assign_child_by_anchor(
+      child,
+      parent_anchor=("c", "c", "t"),
+      child_anchor=("c", "c", "b"),
+    )
+    # Parent CCT is at (50, 50, 10)
+    # Child CCB is at (25, 25, 0)
+    # Child LFB should be at (50-25, 50-25, 10-0) = (25, 25, 10)
+    self.assertEqual(child.location, Coordinate(25, 25, 10))
+
+  def test_mixed_anchors(self):
+    """Test various mixed anchor combinations."""
+    child = Resource("child", size_x=30, size_y=20, size_z=4)
+    self.parent.assign_child_by_anchor(
+      child,
+      parent_anchor=("l", "c", "b"),
+      child_anchor=("r", "c", "t"),
+    )
+    # Parent LCB is at (0, 50, 0)
+    # Child RCT is at (30, 10, 4)
+    # Child LFB should be at (0-30, 50-10, 0-4) = (-30, 40, -4)
+    self.assertEqual(child.location, Coordinate(-30, 40, -4))
+    parent_lcb = self.parent.get_absolute_location(x="l", y="c", z="b")
+    child_rct = child.get_absolute_location(x="r", y="c", z="t")
+    self.assertEqual(parent_lcb, child_rct)
+
+  def test_all_x_anchor_combinations(self):
+    """Test all x-axis anchor combinations."""
+    for parent_x, child_x in [
+      ("l", "l"),
+      ("l", "c"),
+      ("l", "r"),
+      ("c", "l"),
+      ("c", "c"),
+      ("c", "r"),
+      ("r", "l"),
+      ("r", "c"),
+      ("r", "r"),
+    ]:
+      with self.subTest(parent_x=parent_x, child_x=child_x):
+        child = Resource(f"child_{parent_x}_{child_x}", size_x=40, size_y=40, size_z=5)
+        parent = Resource("parent_temp", size_x=100, size_y=100, size_z=10)
+        parent.location = Coordinate.zero()
+        parent.assign_child_by_anchor(
+          child,
+          parent_anchor=(parent_x, "c", "b"),
+          child_anchor=(child_x, "c", "b"),
+        )
+        # Verify anchors align
+        parent_anchor_pos = parent.get_absolute_location(x=parent_x, y="c", z="b")
+        child_anchor_pos = child.get_absolute_location(x=child_x, y="c", z="b")
+        self.assertEqual(parent_anchor_pos, child_anchor_pos)
+
+  def test_all_y_anchor_combinations(self):
+    """Test all y-axis anchor combinations."""
+    for parent_y, child_y in [
+      ("f", "f"),
+      ("f", "c"),
+      ("f", "b"),
+      ("c", "f"),
+      ("c", "c"),
+      ("c", "b"),
+      ("b", "f"),
+      ("b", "c"),
+      ("b", "b"),
+    ]:
+      with self.subTest(parent_y=parent_y, child_y=child_y):
+        child = Resource(f"child_{parent_y}_{child_y}", size_x=40, size_y=40, size_z=5)
+        parent = Resource("parent_temp", size_x=100, size_y=100, size_z=10)
+        parent.location = Coordinate.zero()
+        parent.assign_child_by_anchor(
+          child,
+          parent_anchor=("c", parent_y, "b"),
+          child_anchor=("c", child_y, "b"),
+        )
+        # Verify anchors align
+        parent_anchor_pos = parent.get_absolute_location(x="c", y=parent_y, z="b")
+        child_anchor_pos = child.get_absolute_location(x="c", y=child_y, z="b")
+        self.assertEqual(parent_anchor_pos, child_anchor_pos)
+
+  def test_all_z_anchor_combinations(self):
+    """Test all z-axis anchor combinations."""
+    for parent_z, child_z in [
+      ("b", "b"),
+      ("b", "c"),
+      ("b", "t"),
+      ("c", "b"),
+      ("c", "c"),
+      ("c", "t"),
+      ("t", "b"),
+      ("t", "c"),
+      ("t", "t"),
+    ]:
+      with self.subTest(parent_z=parent_z, child_z=child_z):
+        child = Resource(f"child_{parent_z}_{child_z}", size_x=40, size_y=40, size_z=5)
+        parent = Resource("parent_temp", size_x=100, size_y=100, size_z=10)
+        parent.location = Coordinate.zero()
+        parent.assign_child_by_anchor(
+          child,
+          parent_anchor=("c", "c", parent_z),
+          child_anchor=("c", "c", child_z),
+        )
+        # Verify anchors align
+        parent_anchor_pos = parent.get_absolute_location(x="c", y="c", z=parent_z)
+        child_anchor_pos = child.get_absolute_location(x="c", y="c", z=child_z)
+        self.assertEqual(parent_anchor_pos, child_anchor_pos)
+
+  def test_reassign_parameter(self):
+    """Test that reassign parameter is passed through correctly."""
+    child = Resource("child", size_x=50, size_y=50, size_z=5)
+    parent2 = Resource("parent2", size_x=100, size_y=100, size_z=10)
+    parent2.location = Coordinate.zero()
+
+    self.parent.assign_child_by_anchor(
+      child, parent_anchor=("c", "c", "b"), child_anchor=("c", "c", "b")
+    )
+    self.assertEqual(child.parent, self.parent)
+
+    # Reassigning to a different parent should work with reassign=True
+    parent2.assign_child_by_anchor(
+      child, parent_anchor=("l", "f", "b"), child_anchor=("l", "f", "b"), reassign=True
+    )
+    self.assertEqual(child.parent, parent2)
+    self.assertEqual(child.location, Coordinate(0, 0, 0))
+
+  def test_callbacks_triggered(self):
+    """Test that assignment callbacks are triggered."""
+    child = Resource("child", size_x=50, size_y=50, size_z=5)
+    mock_function = unittest.mock.Mock()
+    self.parent.register_did_assign_resource_callback(mock_function)
+    self.parent.assign_child_by_anchor(
+      child,
+      parent_anchor=("c", "c", "b"),
+      child_anchor=("c", "c", "b"),
+    )
+    mock_function.assert_called_once_with(child)
+
+  def test_long_form_anchor_names(self):
+    """Test that long-form anchor names (left, center, right, etc.) work."""
+    child = Resource("child", size_x=50, size_y=50, size_z=5)
+    self.parent.assign_child_by_anchor(
+      child,
+      parent_anchor=("center", "center", "bottom"),
+      child_anchor=("center", "center", "bottom"),
+    )
+    # Should work the same as ("c", "c", "b")
+    self.assertEqual(child.location, Coordinate(25, 25, 0))
+    parent_ccb = self.parent.get_absolute_location(x="c", y="c", z="b")
+    child_ccb = child.get_absolute_location(x="c", y="c", z="b")
+    self.assertEqual(parent_ccb, child_ccb)
+
+  def test_string_anchor_syntax(self):
+    """Test that 3-character string anchor syntax works."""
+    child = Resource("child", size_x=50, size_y=50, size_z=5)
+    self.parent.assign_child_by_anchor(
+      child,
+      parent_anchor="ccb",
+      child_anchor="ccb",
+    )
+    # Should work the same as ("c", "c", "b")
+    self.assertEqual(child.location, Coordinate(25, 25, 0))
+    parent_ccb = self.parent.get_absolute_location(x="c", y="c", z="b")
+    child_ccb = child.get_absolute_location(x="c", y="c", z="b")
+    self.assertEqual(parent_ccb, child_ccb)
+
+  def test_string_anchor_stacking(self):
+    """Test string syntax for stacking resources."""
+    child = Resource("child", size_x=100, size_y=100, size_z=5)
+    self.parent.assign_child_by_anchor(
+      child,
+      parent_anchor="lft",
+      child_anchor="lfb",
+    )
+    self.assertEqual(child.location, Coordinate(0, 0, 10))
+    parent_lft = self.parent.get_absolute_location(x="l", y="f", z="t")
+    child_lfb = child.get_absolute_location(x="l", y="f", z="b")
+    self.assertEqual(parent_lft, child_lfb)
+
+  def test_mixed_string_and_tuple_anchors(self):
+    """Test mixing string and tuple anchor syntax."""
+    child = Resource("child", size_x=60, size_y=40, size_z=8)
+    self.parent.assign_child_by_anchor(
+      child,
+      parent_anchor="rbt",
+      child_anchor=("r", "b", "t"),
+    )
+    # Parent RBT is at (100, 100, 10)
+    # Child RBT is at (60, 40, 8)
+    # Child LFB should be at (100-60, 100-40, 10-8) = (40, 60, 2)
+    self.assertEqual(child.location, Coordinate(40, 60, 2))
+    parent_rbt = self.parent.get_absolute_location(x="r", y="b", z="t")
+    child_rbt = child.get_absolute_location(x="r", y="b", z="t")
+    self.assertEqual(parent_rbt, child_rbt)
+
+  def test_invalid_string_anchor_length(self):
+    """Test that invalid string anchor lengths raise errors."""
+    child = Resource("child", size_x=50, size_y=50, size_z=5)
+    with self.assertRaises(ValueError) as context:
+      self.parent.assign_child_by_anchor(child, parent_anchor="cc", child_anchor="ccb")
+    self.assertIn("must be exactly 3 characters", str(context.exception))
+
+    with self.assertRaises(ValueError) as context:
+      self.parent.assign_child_by_anchor(child, parent_anchor="ccb", child_anchor="ccbb")
+    self.assertIn("must be exactly 3 characters", str(context.exception))


### PR DESCRIPTION
## Summary

Adds a new `assign_child_by_anchor()` method to the `Resource` class that allows assigning child resources by aligning anchor points instead of specifying absolute coordinates. This provides a more intuitive and flexible way to position resources relative to each other.

### Key Features

- **Anchor-based alignment**: Align any combination of anchors (left/center/right, front/center/back, bottom/center/top)
- **Dual syntax support**: 
  - Tuple syntax: `parent_anchor=("c", "c", "b")`
  - String syntax: `parent_anchor="ccb"` (more concise)
- **Default behavior**: Defaults to left-front-bottom (LFB) alignment
- **Full integration**: Maintains all existing callbacks, validation, and reassignment logic

### Example Usage

```python
# Default: align LFB of both resources
parent.assign_child_by_anchor(child)

# Center a child resource
parent.assign_child_by_anchor(child, parent_anchor="ccb", child_anchor="ccb")

# Stack resources on top of each other
parent.assign_child_by_anchor(child, parent_anchor="lft", child_anchor="lfb")
```

### Implementation Details

- Added helper function `_compute_location_from_anchors()` to calculate the location from anchor specifications
- Method internally calls `assign_child_resource()` with computed location
- Supports validation of string anchor length (must be exactly 3 characters)
- Uses named arguments for clarity

## Test Plan

- [x] 17 comprehensive unit tests added covering:
  - Default LFB alignment
  - All x, y, and z anchor combinations (27 subtests)
  - Center-center-bottom alignment
  - Corner alignments (LFB, RBT)
  - Stacking operations
  - Mixed anchor combinations
  - String and tuple syntax
  - Mixed string/tuple usage
  - Long-form anchor names ("center" vs "c")
  - Invalid string anchor length handling
  - Reassignment between parents
  - Callback triggering
- [x] All 48 resource tests pass
- [x] Pre-commit hooks pass (formatting, linting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)