### PR TITLE
Support custom deserialize methods in serializer

### DIFF
--- a/pylabrobot/serializer.py
+++ b/pylabrobot/serializer.py
@@ -143,6 +143,8 @@ def deserialize(data: JSON, allow_marshal: bool = False) -> Any:
         return types.CellType(deserialize(data["contents"], allow_marshal=allow_marshal))
       klass = get_plr_class_from_string(klass_type)
       params = {k: deserialize(v, allow_marshal=allow_marshal) for k, v in data.items()}
+      if "deserialize" in klass.__dict__:
+        return klass.deserialize(params)
       return klass(**params)
     return {k: deserialize(v, allow_marshal=allow_marshal) for k, v in data.items()}
   if isinstance(data, object):

--- a/pylabrobot/tests/serializer_tests.py
+++ b/pylabrobot/tests/serializer_tests.py
@@ -50,3 +50,24 @@ def test_serialize_deserialize_special_floats():
   assert deserialize(serialize(float("-inf"))) == -math.inf
   result = deserialize(serialize(float("nan")))
   assert math.isnan(result)
+
+
+def test_deserialize_calls_custom_deserialize_method():
+  """Test that deserialize() calls a class's custom deserialize method when defined."""
+  from pylabrobot.resources.tip import Tip
+  from pylabrobot.resources.tip_rack import TipSpot
+
+  def make_tip(name):
+    return Tip(
+      name=name, total_tip_length=50, has_filter=False, maximal_volume=300, fitting_depth=8
+    )
+
+  ts = TipSpot(name="A1", size_x=9, size_y=9, make_tip=make_tip)
+  data = ts.serialize()
+
+  # TipSpot.serialize() includes 'prototype_tip' which TipSpot.__init__ doesn't accept.
+  # This only works because deserialize() calls TipSpot.deserialize() which handles it.
+  assert "prototype_tip" in data
+  result = deserialize(data)
+  assert isinstance(result, TipSpot)
+  assert result.name == "A1"


### PR DESCRIPTION
## Summary
- When deserializing a class, check if it defines a `deserialize` method in its own `__dict__` (not inherited) and call it
- This enables classes like `TipSpot` to handle custom serialization fields (e.g., `prototype_tip`) that aren't `__init__` parameters

## Test plan
- [x] Added test `test_deserialize_calls_custom_deserialize_method` 
- [x] All 821 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)