### PR TITLE
Update `STARBackend` Tip Presence Check Commands

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -7652,7 +7652,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
 
     Returns:
       dictionary with key qh:
-        qh: 0 = no tips, 1 = TipRack are picked up
+        qh: 0 = no tips, 1 = tips are picked up
     """
     warnings.warn(  # TODO: remove 2026-06
       "`request_tip_presence_in_core_96_head` is deprecated and will be "
@@ -7672,7 +7672,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
 
     Returns:
       0 = no tips
-      1 = TipRack are picked up
+      1 = firmware believes tips are on the 96-head
     """
     resp = await self.send_command(module="C0", command="QH", fmt="qh#")
 


### PR DESCRIPTION
### Problem

Currently `STARBackend.request_tip_presence()` and `STARBackend.request_tip_presence_in_core_96_head()` appear to do the same task, just for single channels and the 96-head, respectively.
This is incorrect.

- `STARBackend.request_tip_presence()` is a MEASUREMENT command, i.e. it measures the sleeve sensors on all channels to return the true state of tip presence on channels.
- `STARBackend.request_tip_presence_in_core_96_head()` is a MEM-READ command, i.e. it reads the STAR(let)'s internal memory which keeps a record of all tip_pickup96 and tip_drop96 commands that have occurred.
Importantly this means _no measurement is being made_. Combined with the absence of a tip pickup/drop sensor during these operations, no error _can_ be raised by the firmware if  tip_pickup96 is performed on an empty tiprack.

(Also `STARBackend.request_tip_presence_in_core_96_head()` still returns the firmware parsed dictionary rather than the actual 0/1 state of tip presence)

### This PR

In alignment with the [Standardised PLR Command Prefix Proposal](https://discuss.pylabrobot.org/t/standardised-plr-command-prefix-proposal/403/4), I have renamed these `STARBackend` methods to represent their correct command type:

- `STARBackend.request_tip_presence()` -> `STARBackend.channels_measure_tip_presence() -> List[in]`
- `STARBackend.request_tip_presence_in_core_96_head()` -> `STARBackend.head96_request_tip_presence() -> int`

-> Please let me know whether you think `STARBackend.channels_sense_tip_presence() -> List[int]` is a preferred name for this MEASUREMENT command. I think either could work well and have no preference :)

Current version have been given deprecation warnings with a 5 month update period (>2026-06) before deletion of the old methods.