### PR TITLE
Fix STARChatterboxBackend.stop() error

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_chatterbox.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_chatterbox.py
@@ -71,6 +71,10 @@ class STARChatterboxBackend(STARBackend):
     else:
       self._head96_information = None
 
+  async def stop(self):
+    await LiquidHandlerBackend.stop(self)
+    self._setup_done = False
+
   # # # # # # # # Low-level command sending/receiving # # # # # # # #
 
   async def _write_and_read_command(


### PR DESCRIPTION
## Summary
- Override `stop()` in `STARChatterboxBackend` to skip USB cleanup
- The chatterbox backend doesn't use a real USB connection, so calling the parent's `io.stop()` was causing errors

Fixes #858

## Test plan
- [x] Verified `lh.stop()` completes without error using `STARChatterboxBackend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)