### PR TITLE
Add optional name parameter to LiquidHandler

### DIFF
--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -106,6 +106,7 @@ class LiquidHandler(Resource, Machine):
     backend: LiquidHandlerBackend,
     deck: Deck,
     default_offset_head96: Optional[Coordinate] = None,
+    name: Optional[str] = None,
   ):
     """Initialize a LiquidHandler.
 
@@ -113,11 +114,12 @@ class LiquidHandler(Resource, Machine):
       backend: Backend to use.
       deck: Deck to use.
       default_offset_head96: Base offset applied to all 96-head operations.
+      name: Name of the liquid handler. If not provided, defaults to ``lh_{deck.name}``.
     """
 
     Resource.__init__(
       self,
-      name=f"lh_{deck.name}",
+      name=name if name is not None else f"lh_{deck.name}",
       size_x=deck._size_x,
       size_y=deck._size_y,
       size_z=deck._size_z,

--- a/pylabrobot/liquid_handling/liquid_handler_tests.py
+++ b/pylabrobot/liquid_handling/liquid_handler_tests.py
@@ -169,6 +169,17 @@ class TestLiquidHandlerLayout(unittest.IsolatedAsyncioTestCase):
     with self.assertRaises(ResourceNotFoundError):
       self.lh.deck.get_resource("unknown resource")
 
+  def test_name_parameter(self):
+    # Default name is derived from deck name
+    deck = STARLetDeck()
+    lh = LiquidHandler(_create_mock_backend(), deck=deck)
+    self.assertEqual(lh.name, f"lh_{deck.name}")
+
+    # Custom name
+    deck2 = STARLetDeck()
+    lh2 = LiquidHandler(_create_mock_backend(), deck=deck2, name="my_liquid_handler")
+    self.assertEqual(lh2.name, "my_liquid_handler")
+
   def test_subcoordinates(self):
     tip_car = TIP_CAR_480_A00(name="tip_carrier")
     tip_car[0] = hamilton_96_tiprack_300uL_filter(name="tip_rack_01")


### PR DESCRIPTION
## Summary
- Adds an optional `name` parameter to `LiquidHandler.__init__`
- If not provided, defaults to current behavior (`lh_{deck.name}`)
- Allows users to specify a custom name for their liquid handler

## Test plan
- [x] Added test for both default and custom name behavior
- [x] All existing tests pass (45/45)

🤖 Generated with [Claude Code](https://claude.com/claude-code)