### PR TITLE
Add bioER plate height volume calcs

### DIFF
--- a/pylabrobot/resources/bioer/plates.py
+++ b/pylabrobot/resources/bioer/plates.py
@@ -16,12 +16,13 @@ from pylabrobot.resources.well import (
 _A3 = 2.34770904e-09
 _A2 = -9.12279010e-06
 _A1 = 2.68872240e-02
-_A0 = 2.06530412e+00
+_A0 = 2.06530412e00
 
 # ---- Geometry / limits (from your earlier spec & measurements) ----
-_WELL_TOP_SIDE_MM = 8.25      # inner opening (square), mm
-_WELL_DEPTH_MM    = 42.4      # well depth, mm
-_MAX_VOL_UL       = 2200.0    # vendor spec, µL
+_WELL_TOP_SIDE_MM = 8.25  # inner opening (square), mm
+_WELL_DEPTH_MM = 42.4  # well depth, mm
+_MAX_VOL_UL = 2200.0  # vendor spec, µL
+
 
 # Monotone cubic on [0, MAX_VOL] from your data — use binary search for inversion
 def _height_from_volume_poly(vol_ul: float) -> float:
@@ -34,6 +35,7 @@ def _height_from_volume_poly(vol_ul: float) -> float:
   if h > _WELL_DEPTH_MM:
     return _WELL_DEPTH_MM
   return h
+
 
 def _volume_from_height_poly(h_mm: float, *, tol: float = 1e-6, max_iter: int = 64) -> float:
   """Volume (µL) from height (mm) by inverting the cubic with binary search."""
@@ -55,6 +57,7 @@ def _volume_from_height_poly(h_mm: float, *, tol: float = 1e-6, max_iter: int = 
       hi = mid
   return 0.5 * (lo + hi)
 
+
 def BioER_96_wellplate_Vb_2200uL(name: str) -> Plate:
   """BioER Cat. No. BSH06M1T-A (KingFisher-compatible)
   Spec: https://en.bioer.com/uploadfiles/2024/05/20240513165756879.pdf
@@ -63,9 +66,9 @@ def BioER_96_wellplate_Vb_2200uL(name: str) -> Plate:
     "size_x": _WELL_TOP_SIDE_MM,
     "size_y": _WELL_TOP_SIDE_MM,
     "size_z": _WELL_DEPTH_MM,
-    "bottom_type": WellBottomType.V,              # physical bottom shape
+    "bottom_type": WellBottomType.V,  # physical bottom shape
     "cross_section_type": CrossSectionType.RECTANGLE,
-    "material_z_thickness": 0.8,                  # measured
+    "material_z_thickness": 0.8,  # measured
     "max_volume": _MAX_VOL_UL,
     # ---- height<->volume mapping used by PLR ----
     "compute_height_from_volume": lambda vol_ul: _height_from_volume_poly(vol_ul),
@@ -74,20 +77,20 @@ def BioER_96_wellplate_Vb_2200uL(name: str) -> Plate:
 
   return Plate(
     name=name,
-    size_x=127.1,   # spec
-    size_y=85.0,    # spec
-    size_z=44.2,    # spec
+    size_x=127.1,  # spec
+    size_y=85.0,  # spec
+    size_z=44.2,  # spec
     lid=None,
     model=BioER_96_wellplate_Vb_2200uL.__name__,
     ordered_items=create_ordered_items_2d(
       Well,
-      num_items_x=12,           # spec
-      num_items_y=8,            # spec
-      dx=9.5,                   # measured (column pitch)
-      dy=7.5,                   # measured (row pitch)
-      dz=6.0,                   # calibrated (mounting offset for your deck)
-      item_dx=9.0,              # measured
-      item_dy=9.0,              # measured
+      num_items_x=12,  # spec
+      num_items_y=8,  # spec
+      dx=9.5,  # measured (column pitch)
+      dy=7.5,  # measured (row pitch)
+      dz=6.0,  # calibrated (mounting offset for your deck)
+      item_dx=9.0,  # measured
+      item_dy=9.0,  # measured
       **well_kwargs,
     ),
   )


### PR DESCRIPTION
This PR adds volume<=>height calculations for the BioER deepwell plate. The relationship was fitted with a polynomial as it proved more accurate than a circular conical frustum. 


Volume (µL) | Height (mm)
-- | --
75 | 3.85
100 | 4.51
200 | 7.44
300 | 9.42
500 | 13.87
600 | 15.30
750 | 17.76
1000 | 22.08
1500 | 30.00
2000 | 38.07

<img width="1436" height="947" alt="BioER_plate_height_vs_volume" src="https://github.com/user-attachments/assets/20f4e617-2949-4fc5-a503-88eef7c3ed64" />

<img width="710" height="187" alt="image" src="https://github.com/user-attachments/assets/2e778443-117c-46e5-b5fa-9df647558e6f" />
