### PR TITLE
add corning fb plate compute volume

### DIFF
--- a/pylabrobot/resources/corning/plates.py
+++ b/pylabrobot/resources/corning/plates.py
@@ -1,7 +1,9 @@
 """ Corning plates. """
 
 from pylabrobot.resources.height_volume_functions import (
+  calculate_liquid_height_container_1segment_round_fbottom,
   calculate_liquid_height_in_container_2segments_square_vbottom,
+  calculate_liquid_volume_container_1segment_round_fbottom,
   calculate_liquid_volume_container_2segments_square_vbottom,
 )
 from pylabrobot.resources.plate import Lid, Plate
@@ -58,6 +60,8 @@ def Cor_96_wellplate_360ul_Fb(name: str, with_lid: bool = False) -> Plate:
       bottom_type=WellBottomType.FLAT,
       cross_section_type=CrossSectionType.CIRCLE,
       max_volume=360,
+      compute_volume_from_height=_compute_volume_from_height_Cor_96_wellplate_360ul_Fb,
+      compute_height_from_volume=_compute_height_from_volume_Cor_96_wellplate_360ul_Fb,
     ),
   )
 
@@ -74,6 +78,19 @@ def Cor_96_wellplate_360ul_Fb_Lid(name: str) -> Lid:
     size_z=8.9,  # measure the total z height
     nesting_z_height=7.6,  # measure overlap between lid and plate
     model="Cor_96_wellplate_360ul_Fb_Lid",
+  )
+
+
+# Volume-height functions
+def _compute_volume_from_height_Cor_96_wellplate_360ul_Fb(h: float) -> float:
+  return calculate_liquid_volume_container_1segment_round_fbottom(
+    d=6.86, h_cylinder=10.67, liquid_height=h
+  )
+
+
+def _compute_height_from_volume_Cor_96_wellplate_360ul_Fb(liquid_volume: float) -> float:
+  return calculate_liquid_height_container_1segment_round_fbottom(
+    d=6.86, h_cylinder=10.67, liquid_volume=liquid_volume
   )
 
 


### PR DESCRIPTION
addded the appropriate compute_volume_from_height and compute_height_from_volume functions for Cor_96_wellplate_360ul_Fb in plates.py using standard cylinder volume calculations based on the well's dimensions 