### PR TITLE
bioshake: add delay after stop shake

### DIFF
--- a/pylabrobot/heating_shaking/bioshake_backend.py
+++ b/pylabrobot/heating_shaking/bioshake_backend.py
@@ -185,7 +185,7 @@ class BioShake(HeaterShakerBackend):
     )
     await self.start_shaking(speed=speed, acceleration=acceleration)
 
-  async def stop_shaking(self, deceleration: int = 0, sleep_time_after_stop: int = 3):
+  async def stop_shaking(self, deceleration: int = 0):
     # Check if decel is an integer
     if isinstance(deceleration, float):
       if not deceleration.is_integer():  # type: ignore[attr-defined] # mypy is retarded
@@ -214,6 +214,7 @@ class BioShake(HeaterShakerBackend):
     # The BioShake 3000 ELM firmware needs the motor to fully decelerate
     # before the edge-locking mechanism (ELM) can operate. Without this
     # delay, subsequent setElmUnlockPos commands return 'e' (error).
+    sleep_time_after_stop = 3
     await asyncio.sleep(sleep_time_after_stop)
 
   @property


### PR DESCRIPTION
The BioShake 3000 ELM firmware needs ~3 seconds after shakeOff for the motor to fully decelerate before the edge-locking mechanism (ELM) can operate. Without this, setElmUnlockPos returns e (error).

Fix: Added asyncio.sleep(sleep_time_after_shake) at the end of BioShake.stop_shaking() in bioshake_backend.py. This way all callers automatically get the required settling delay.