### PR TITLE
feat: add maintenance mode command for Inheco SCILABackend

### DIFF
--- a/pylabrobot/storage/inheco/scila/scila_backend.py
+++ b/pylabrobot/storage/inheco/scila/scila_backend.py
@@ -88,6 +88,14 @@ class SCILABackend(MachineBackend):
     await self._sila_interface.send_command("PrepareForOutput", position=drawer_id)
     await self._sila_interface.send_command("CloseDoor")
 
+  async def maintenance(self) -> None:
+    """Put the SCILA into maintenance mode.
+
+    This maps to the SiLA `Maintenance` command, which opens all drawers and then powers the
+    device off.
+    """
+    await self._sila_interface.send_command("Maintenance")
+
   async def request_drawer_statuses(self) -> Dict[int, DrawerStatus]:
     root = await self._sila_interface.send_command("GetDoorStatus")
     params = _get_params(root, ["Drawer1", "Drawer2", "Drawer3", "Drawer4"])

--- a/pylabrobot/storage/inheco/scila/scila_backend_tests.py
+++ b/pylabrobot/storage/inheco/scila/scila_backend_tests.py
@@ -121,6 +121,10 @@ class TestSCILABackend(unittest.IsolatedAsyncioTestCase):
     with self.assertRaises(ValueError):
       await self.backend.close(5)
 
+  async def test_maintenance(self):
+    await self.backend.maintenance()
+    self.mock_sila_interface.send_command.assert_called_with("Maintenance")
+
   async def test_request_drawer_status(self):
     self.mock_sila_interface.send_command.return_value = ET.fromstring(
       "<Response>"


### PR DESCRIPTION
Tested locally. Confirmed working. 
Device will shutdown after this command is sent.
Requires manual power on.