### PR TITLE
Add the pedestal height to the _P version of the L5AC plate carrier

### DIFF
--- a/pylabrobot/resources/hamilton/plate_carriers.py
+++ b/pylabrobot/resources/hamilton/plate_carriers.py
@@ -475,6 +475,7 @@ def PLT_CAR_L5AC_P_A00(name: str) -> PlateCarrier:
       resource_size_x=126.8,
       resource_size_y=85.8,
       name_prefix=name,
+      pedestal_size_z=-4.74,
     ),
     model="PLT_CAR_L5AC_P_A00",
   )


### PR DESCRIPTION
PLT_CAR_L5AC_P_A00 is missing pedestal_size_z.

Measuring this inhouse with calipers results in -4.74 mm, same as PLT_CAR_L5AC_A00.