### PR TITLE
Add pip channel hardware configuration query (VW command)

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -1723,8 +1723,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       self._channels_minimum_y_spacing = await self.channels_request_y_minimum_spacing()
 
       # Cache per-channel hardware configuration for version-specific behavior
-      assert self._num_channels is not None
-      for ch in range(self._num_channels):
+      for ch in range(self.num_channels):
         hw_tokens = await self._pip_channel_request_configuration(ch)
         self._pip_channel_information.append(
           PipChannelInformation(

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -1285,6 +1285,21 @@ class ExtendedConfiguration:
 
 
 @dataclass
+class PipChannelInformation:
+  """Installed hardware information for a single pipetting channel (VW command)."""
+
+  ChannelType = Literal["ML_STAR", "ML_STAR_RPC"]
+  HeadType = Literal["ML_STAR", "ML_STAR_PLE", "ML_STAR_RPC"]
+  StopDiscType = Literal["core_i", "core_ii"]
+  PressureADC = Literal["Renesas_X9268", "Analog_Devices_AD5263"]
+
+  channel_type: ChannelType
+  head_type: HeadType
+  stop_disc_type: StopDiscType
+  pressure_adc: PressureADC
+
+
+@dataclass
 class Head96Information:
   """Information about the installed 96-head."""
 
@@ -1351,6 +1366,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     self._unsafe = UnSafe(self)
 
     self._iswap_version: Optional[str] = None  # loaded lazily
+    self._pip_channel_information: List[PipChannelInformation] = []
 
     self._default_1d_symbology: Barcode1DSymbology = "Code 128 (Subset B and C)"
 
@@ -1513,6 +1529,27 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       str,
       (await self.send_command(STARBackend.channel_id(channel), "RF", fmt="rf" + "&" * 17))["rf"],
     )
+
+  async def _pip_channel_request_configuration(self, channel: int) -> List[str]:
+    """Request installed hardware for a pipetting channel (raw) using the VW command.
+
+    The instrument returns four space-separated values. This method returns
+    those values as raw string tokens without decoding them, but the following
+    indices are currently understood:
+
+        - index 0: channel_type (codes: 0=ML_STAR, 1=ML_STAR_RPC)
+        - index 1: head_type (codes: 0=ML_STAR, 1=ML_STAR_PLE, 2=ML_STAR_RPC)
+        - index 2: stop_disc_type (codes: 0=CO-RE_I, 1=CO-RE_II)
+        - index 3: pressure_adc (codes: 0=Renesas_X9268, 1=Analog_Devices_AD5263)
+
+    Args:
+      channel: 0-indexed channel number.
+
+    Returns:
+      Raw positional tokens extracted from the VW response.
+    """
+    resp: str = await self.send_command(STARBackend.channel_id(channel), "VW")
+    return resp.split("vw")[-1].strip().split()
 
   def get_id_from_fw_response(self, resp: str) -> Optional[int]:
     """Get the id from a firmware response."""
@@ -1684,6 +1721,35 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       if (not initialized or any(tip_presences)) and not skip_pip:
         await self.initialize_pip()
       self._channels_minimum_y_spacing = await self.channels_request_y_minimum_spacing()
+
+      # Cache per-channel hardware configuration for version-specific behavior
+      channel_type_map: dict[str, PipChannelInformation.ChannelType] = {
+        "0": "ML_STAR",
+        "1": "ML_STAR_RPC",
+      }
+      head_type_map: dict[str, PipChannelInformation.HeadType] = {
+        "0": "ML_STAR",
+        "1": "ML_STAR_PLE",
+        "2": "ML_STAR_RPC",
+      }
+      stop_disc_map: dict[str, PipChannelInformation.StopDiscType] = {
+        "0": "core_i",
+        "1": "core_ii",
+      }
+      adc_map: dict[str, PipChannelInformation.PressureADC] = {
+        "0": "Renesas_X9268",
+        "1": "Analog_Devices_AD5263",
+      }
+      for ch in range(self._num_channels):
+        hw_tokens = await self._pip_channel_request_configuration(ch)
+        self._pip_channel_information.append(
+          PipChannelInformation(
+            channel_type=channel_type_map.get(hw_tokens[0], hw_tokens[0]),
+            head_type=head_type_map.get(hw_tokens[1], hw_tokens[1]),
+            stop_disc_type=stop_disc_map.get(hw_tokens[2], hw_tokens[2]),
+            pressure_adc=adc_map.get(hw_tokens[3], hw_tokens[3]),
+          )
+        )
 
     async def set_up_autoload():
       if self.machine_conf.auto_load_installed and not skip_autoload:

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -1735,9 +1735,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
             if hw_tokens[1] == "2"
             else "ML_STAR",
             stop_disc_type="core_i" if hw_tokens[2] == "0" else "core_ii",
-            pressure_adc="Analog_Devices_AD5263"
-            if hw_tokens[3] == "1"
-            else "Renesas_X9268",
+            pressure_adc="Analog_Devices_AD5263" if hw_tokens[3] == "1" else "Renesas_X9268",
           )
         )
 

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -1723,31 +1723,21 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       self._channels_minimum_y_spacing = await self.channels_request_y_minimum_spacing()
 
       # Cache per-channel hardware configuration for version-specific behavior
-      channel_type_map: dict[str, PipChannelInformation.ChannelType] = {
-        "0": "ML_STAR",
-        "1": "ML_STAR_RPC",
-      }
-      head_type_map: dict[str, PipChannelInformation.HeadType] = {
-        "0": "ML_STAR",
-        "1": "ML_STAR_PLE",
-        "2": "ML_STAR_RPC",
-      }
-      stop_disc_map: dict[str, PipChannelInformation.StopDiscType] = {
-        "0": "core_i",
-        "1": "core_ii",
-      }
-      adc_map: dict[str, PipChannelInformation.PressureADC] = {
-        "0": "Renesas_X9268",
-        "1": "Analog_Devices_AD5263",
-      }
+      assert self._num_channels is not None
       for ch in range(self._num_channels):
         hw_tokens = await self._pip_channel_request_configuration(ch)
         self._pip_channel_information.append(
           PipChannelInformation(
-            channel_type=channel_type_map.get(hw_tokens[0], hw_tokens[0]),
-            head_type=head_type_map.get(hw_tokens[1], hw_tokens[1]),
-            stop_disc_type=stop_disc_map.get(hw_tokens[2], hw_tokens[2]),
-            pressure_adc=adc_map.get(hw_tokens[3], hw_tokens[3]),
+            channel_type="ML_STAR_RPC" if hw_tokens[0] == "1" else "ML_STAR",
+            head_type="ML_STAR_PLE"
+            if hw_tokens[1] == "1"
+            else "ML_STAR_RPC"
+            if hw_tokens[1] == "2"
+            else "ML_STAR",
+            stop_disc_type="core_i" if hw_tokens[2] == "0" else "core_ii",
+            pressure_adc="Analog_Devices_AD5263"
+            if hw_tokens[3] == "1"
+            else "Renesas_X9268",
           )
         )
 

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -1530,26 +1530,24 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       (await self.send_command(STARBackend.channel_id(channel), "RF", fmt="rf" + "&" * 17))["rf"],
     )
 
-  async def _pip_channel_request_configuration(self, channel: int) -> List[str]:
-    """Request installed hardware for a pipetting channel (raw) using the VW command.
-
-    The instrument returns four space-separated values. This method returns
-    those values as raw string tokens without decoding them, but the following
-    indices are currently understood:
-
-        - index 0: channel_type (codes: 0=ML_STAR, 1=ML_STAR_RPC)
-        - index 1: head_type (codes: 0=ML_STAR, 1=ML_STAR_PLE, 2=ML_STAR_RPC)
-        - index 2: stop_disc_type (codes: 0=CO-RE_I, 1=CO-RE_II)
-        - index 3: pressure_adc (codes: 0=Renesas_X9268, 1=Analog_Devices_AD5263)
+  async def _pip_channel_request_configuration(self, channel: int) -> PipChannelInformation:
+    """Request installed hardware for a pipetting channel using the VW command.
 
     Args:
       channel: 0-indexed channel number.
-
-    Returns:
-      Raw positional tokens extracted from the VW response.
     """
     resp: str = await self.send_command(STARBackend.channel_id(channel), "VW")
-    return resp.split("vw")[-1].strip().split()
+    hw_tokens = resp.split("vw")[-1].strip().split()
+    return PipChannelInformation(
+      channel_type="ML_STAR_RPC" if hw_tokens[0] == "1" else "ML_STAR",
+      head_type="ML_STAR_PLE"
+      if hw_tokens[1] == "1"
+      else "ML_STAR_RPC"
+      if hw_tokens[1] == "2"
+      else "ML_STAR",
+      stop_disc_type="core_i" if hw_tokens[2] == "0" else "core_ii",
+      pressure_adc="Analog_Devices_AD5263" if hw_tokens[3] == "1" else "Renesas_X9268",
+    )
 
   def get_id_from_fw_response(self, resp: str) -> Optional[int]:
     """Get the id from a firmware response."""
@@ -1723,20 +1721,9 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       self._channels_minimum_y_spacing = await self.channels_request_y_minimum_spacing()
 
       # Cache per-channel hardware configuration for version-specific behavior
-      for ch in range(self.num_channels):
-        hw_tokens = await self._pip_channel_request_configuration(ch)
-        self._pip_channel_information.append(
-          PipChannelInformation(
-            channel_type="ML_STAR_RPC" if hw_tokens[0] == "1" else "ML_STAR",
-            head_type="ML_STAR_PLE"
-            if hw_tokens[1] == "1"
-            else "ML_STAR_RPC"
-            if hw_tokens[1] == "2"
-            else "ML_STAR",
-            stop_disc_type="core_i" if hw_tokens[2] == "0" else "core_ii",
-            pressure_adc="Analog_Devices_AD5263" if hw_tokens[3] == "1" else "Renesas_X9268",
-          )
-        )
+      self._pip_channel_information = [
+        await self._pip_channel_request_configuration(ch) for ch in range(self.num_channels)
+      ]
 
     async def set_up_autoload():
       if self.machine_conf.auto_load_installed and not skip_autoload:


### PR DESCRIPTION
## Summary
- Adds `PipChannelInformation` dataclass and `_pip_channel_request_configuration()` to query per-channel installed hardware via the firmware VW command
- Returns channel type, head type, stop disc type (CO-RE I/II), and pressure sensor ADC type for each pipetting channel
- Cached in `_pip_channel_information` during setup, matching the `_head96_information` pattern

## Test plan
- [x] 76 existing STAR tests pass
- [x] Verified on real hardware (STAR I390): all 8 channels return `vw0 0 1 0` (ML_STAR, ML_STAR head, CO-RE II, Renesas X9268)
- [ ] Verify on a machine with mixed channel types (e.g. RPC channels) if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)