### PR TITLE
make sure liquid handler can restore state before connecting

### DIFF
--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -207,7 +207,7 @@ class LiquidHandler(Resource, Machine):
     state of the liquid handler and all children (the deck)."""
 
     head_state = state["head_state"]
-    if head_state and not getattr(self, "head", None):
+    if head_state and self.head == {}:
       # we haven't connected with a backend yet, so we don't know the number of channels.
       # Let's assume that the state accurately describes the number of channels.
       self.head = {c: TipTracker(thing=f"Channel {c}") for c in head_state}
@@ -216,7 +216,7 @@ class LiquidHandler(Resource, Machine):
 
     head96_state = state.get("head96_state", {})
     if head96_state:
-      if not getattr(self, "head96", None):
+      if self.head96 == {}:
         self.head96 = {c: TipTracker(thing=f"Channel {c}") for c in head96_state}
       for channel, tracker_state in head96_state.items():
         self.head96[channel].load_state(tracker_state)

--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -207,11 +207,17 @@ class LiquidHandler(Resource, Machine):
     state of the liquid handler and all children (the deck)."""
 
     head_state = state["head_state"]
+    if head_state and not getattr(self, "head", None):
+      # we haven't connected with a backend yet, so we don't know the number of channels.
+      # Let's assume that the state accurately describes the number of channels.
+      self.head = {c: TipTracker(thing=f"Channel {c}") for c in head_state}
     for channel, tracker_state in head_state.items():
       self.head[channel].load_state(tracker_state)
 
     head96_state = state.get("head96_state", {})
-    if head96_state and self.head96:
+    if head96_state:
+      if not getattr(self, "head96", None):
+        self.head96 = {c: TipTracker(thing=f"Channel {c}") for c in head96_state}
       for channel, tracker_state in head96_state.items():
         self.head96[channel].load_state(tracker_state)
 


### PR DESCRIPTION
Currently, attempting to restore a liquid handler state before the first `.setup()` call may fail because the serialized state may contain head state information, but the liquid handler doesn't know about it's heads yet. However, restoring the state after `.setup()` is semantically wrong: Both `.setup()` and `.stop()` may actively change the effective state, so, neither of these calls should intervene between a safe/restore cycle. This PR solves this by initializing the head state upon load if no head state has been initialized before. That is a) the correct thing to do, and b) still allows a backend to update the frontend with new state information if it is capable of tip presence detection.