### PR TITLE
Implement probe_liquid_heights in STARChatterboxBackend

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_chatterbox.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_chatterbox.py
@@ -314,5 +314,22 @@ class STARChatterboxBackend(STARBackend):
   async def position_channels_in_y_direction(self, ys, make_space=True):
     print("positioning channels in y:", ys, "make_space:", make_space)
 
+  async def probe_liquid_heights(
+    self,
+    containers,
+    use_channels=None,
+    resource_offsets=None,
+    lld_mode=None,
+    search_speed=10.0,
+    n_replicates=1,
+    min_traverse_height_at_beginning_of_command=None,
+    min_traverse_height_during_command=None,
+    z_position_at_end_of_command=None,
+    move_to_z_safety_after=None,
+  ) -> List[float]:
+    """Return liquid heights from the volume tracker using each container's
+    height-from-volume function. No physical probing in simulation."""
+    return [c.compute_height_from_volume(c.tracker.get_used_volume()) for c in containers]
+
   async def request_pip_height_last_lld(self):
     return list(range(12))


### PR DESCRIPTION
## What
Implements `probe_liquid_heights` on `STARChatterboxBackend` by reading
each container's tracked volume and converting to height via
`compute_height_from_volume`. Previously the method did not exist on
chatterbox — protocols calling it crashed under simulation.

## Why
Keeps chatterbox at API parity with the real `STARBackend` so protocols
that probe liquid heights (e.g. input-volume sanity checks) run
unmodified under simulation.

## Implementation
Returns a list of heights computed from the volume tracker. Parameters
matching the real-backend signature (`use_channels`, `resource_offsets`,
`lld_mode`, `search_speed`, `n_replicates`, traverse-height args,
`move_to_z_safety_after`) are accepted for parity but have no effect —
no physical probing happens in simulation.

## Follow-up
Will be upgraded in #949 (*Encapsulate pipette batch scheduling into
backend-agnostic module*), which rewrites the real-backend
`probe_liquid_heights`. Once #949 lands, this chatterbox implementation
will be updated to match the new signature.