### PR TITLE
Expose `iSWAPBackend.rotation_drive_request_position()`

### DIFF
--- a/pylabrobot/hamilton/liquid_handlers/star/iswap.py
+++ b/pylabrobot/hamilton/liquid_handlers/star/iswap.py
@@ -49,6 +49,7 @@ class iSWAPBackend(OrientableGripperArmBackend):
     self.traversal_height = traversal_height
     self._version: Optional[str] = None
     self._parked: Optional[bool] = None
+    self._rotation_drive_x_offset: Optional[float] = None  # cached in _on_setup
 
   @property
   def version(self) -> str:
@@ -95,6 +96,9 @@ class iSWAPBackend(OrientableGripperArmBackend):
 
     if self._version is None:
       self._version = await self._request_version()
+
+    if self._rotation_drive_x_offset is None:
+      self._rotation_drive_x_offset = await self._rotation_drive_request_x_offset()
 
   async def _request_version(self) -> str:
     """Request the iSWAP firmware version from the device."""
@@ -298,7 +302,7 @@ class iSWAPBackend(OrientableGripperArmBackend):
       f"Expected one of {list(wrist_orientation_to_motor_increment_dict)}."
     )
 
-  async def rotation_drive_request_x_offset(self) -> float:
+  async def _rotation_drive_request_x_offset(self) -> float:
     """Read the X-offset i.e. X-axis center <-> iSWAP rotation drive, in mm.
 
     Stored in the master EEPROM as parameter ``kg`` (set via ``C0:AG`` —
@@ -306,6 +310,7 @@ class iSWAPBackend(OrientableGripperArmBackend):
     Previously measured to be 32.8 mm by contributor;
     per-machine calibrated during service. Required for deriving the
     iSWAP rotation drive's deck X coordinate from the X-arm carriage center.
+    Cached on the backend as ``_rotation_drive_x_offset`` during setup.
     """
     resp = await self.driver.send_command(module="C0", command="RA", ra="kg", fmt="kg###")
     return cast(int, resp["kg"]) / 10.0
@@ -318,14 +323,14 @@ class iSWAPBackend(OrientableGripperArmBackend):
     """Position of the iSWAP rotation drive (joint 0) in deck coordinates, mm."""
     if not self.driver.extended_conf.left_x_drive.iswap_installed:  # type: ignore[union-attr]
       raise RuntimeError("iSWAP is not installed")
+    assert self._rotation_drive_x_offset is not None, "Call setup() first"
 
     x_arm_center = await self.driver.left_x_arm.request_position()  # type: ignore[union-attr]
-    iswap_x_offset = await self.rotation_drive_request_x_offset()
     rotation_drive_y = await self.rotation_drive_request_y()
     finger_loc = (await self.request_gripper_location()).location
 
     return Coordinate(
-      x=x_arm_center - iswap_x_offset,
+      x=x_arm_center - self._rotation_drive_x_offset,
       y=rotation_drive_y,
       z=finger_loc.z + self.rotation_drive_z_offset_above_finger,
     )

--- a/pylabrobot/hamilton/liquid_handlers/star/iswap.py
+++ b/pylabrobot/hamilton/liquid_handlers/star/iswap.py
@@ -239,12 +239,12 @@ class iSWAPBackend(OrientableGripperArmBackend):
 
   # -- rotation / wrist drive ------------------------------------------------
 
-  async def request_rotation_drive_position_increments(self) -> int:
-    """Query the iSWAP rotation drive position in increments (R0 RW)."""
+  async def rotation_drive_request_angle_increments(self) -> int:
+    """Query the iSWAP rotation drive angle in increments (R0 RW)."""
     response = await self.driver.send_command(module="R0", command="RW", fmt="rw######")
     return cast(int, response["rw"])
 
-  async def request_rotation_drive_orientation(self) -> "iSWAPBackend.RotationDriveOrientation":
+  async def rotation_drive_request_orientation(self) -> "iSWAPBackend.RotationDriveOrientation":
     """Request the iSWAP rotation drive orientation.
 
     Uses empirically determined increment values:
@@ -258,19 +258,19 @@ class iSWAPBackend(OrientableGripperArmBackend):
       RDO.PARKED_RIGHT: range(29450, 29550),
     }
 
-    motor_position_increments = await self.request_rotation_drive_position_increments()
+    motor_angle_increments = await self.rotation_drive_request_angle_increments()
 
     for orientation, increment_range in rotation_orientation_to_motor_increment_dict.items():
-      if motor_position_increments in increment_range:
+      if motor_angle_increments in increment_range:
         return orientation
 
     raise ValueError(
-      f"Unknown rotation orientation: {motor_position_increments}. "
+      f"Unknown rotation orientation: {motor_angle_increments}. "
       f"Expected one of {list(rotation_orientation_to_motor_increment_dict.values())}."
     )
 
-  async def request_wrist_drive_position_increments(self) -> int:
-    """Query the iSWAP wrist drive position in increments (R0 RT)."""
+  async def request_wrist_drive_angle_increments(self) -> int:
+    """Query the iSWAP wrist drive angle in increments (R0 RT)."""
     response = await self.driver.send_command(module="R0", command="RT", fmt="rt######")
     return cast(int, response["rt"])
 
@@ -287,15 +287,47 @@ class iSWAPBackend(OrientableGripperArmBackend):
       WDO.REVERSE: range(26_802, 26_902),
     }
 
-    motor_position_increments = await self.request_wrist_drive_position_increments()
+    motor_angle_increments = await self.request_wrist_drive_angle_increments()
 
     for orientation, increment_range in wrist_orientation_to_motor_increment_dict.items():
-      if motor_position_increments in increment_range:
+      if motor_angle_increments in increment_range:
         return orientation
 
     raise ValueError(
-      f"Unknown wrist orientation: {motor_position_increments}. "
+      f"Unknown wrist orientation: {motor_angle_increments}. "
       f"Expected one of {list(wrist_orientation_to_motor_increment_dict)}."
+    )
+
+  async def rotation_drive_request_x_offset(self) -> float:
+    """Read the X-offset i.e. X-axis center <-> iSWAP rotation drive, in mm.
+
+    Stored in the master EEPROM as parameter ``kg`` (set via ``C0:AG`` —
+    see ``driver.set_x_offset_x_axis_iswap``).
+    Previously measured to be 32.8 mm by contributor;
+    per-machine calibrated during service. Required for deriving the
+    iSWAP rotation drive's deck X coordinate from the X-arm carriage center.
+    """
+    resp = await self.driver.send_command(module="C0", command="RA", ra="kg", fmt="kg###")
+    return cast(int, resp["kg"]) / 10.0
+
+  # Vertical drop from the iSWAP rotation drive plane to the gripper
+  # finger plane, per VENUS Programmer Guide §15.1.1.
+  rotation_drive_z_offset_above_finger = 13.0
+
+  async def rotation_drive_request_position(self) -> Coordinate:
+    """Position of the iSWAP rotation drive (joint 0) in deck coordinates, mm."""
+    if not self.driver.extended_conf.left_x_drive.iswap_installed:  # type: ignore[union-attr]
+      raise RuntimeError("iSWAP is not installed")
+
+    x_arm_center = await self.driver.left_x_arm.request_position()  # type: ignore[union-attr]
+    iswap_x_offset = await self.rotation_drive_request_x_offset()
+    rotation_drive_y = await self.rotation_drive_request_y()
+    finger_loc = (await self.request_gripper_location()).location
+
+    return Coordinate(
+      x=x_arm_center - iswap_x_offset,
+      y=rotation_drive_y,
+      z=finger_loc.z + self.rotation_drive_z_offset_above_finger,
     )
 
   async def rotate(
@@ -357,7 +389,7 @@ class iSWAPBackend(OrientableGripperArmBackend):
       tw=wrist_protection,
     )
 
-  async def rotate_rotation_drive(
+  async def rotation_drive_rotate(
     self, orientation: "iSWAPBackend.RotationDriveOrientation"
   ) -> None:
     """Rotate the rotation drive to the given orientation (R0 WP)."""

--- a/pylabrobot/hamilton/liquid_handlers/star/pip_channel.py
+++ b/pylabrobot/hamilton/liquid_handlers/star/pip_channel.py
@@ -334,20 +334,17 @@ class PIPChannel:
       zj=f"{round(z * 10):04}",
     )
 
-  # -- C0:RA  request X position ------------------------------------------------
-
+  # -- delegate to left_x_arm (C0 RX) — channels share the X carriage ----------
+  # TODO: we assume `C0RX` references the center of the x-arm, figure out what it
+  # references for half-arms (see issue 822 and new Fluid Motion STAR)
+  
   async def request_x_pos(self) -> float:
     """Request current X-position of this channel (mm).
 
     All PIP channels share the same X arm, so this returns the arm position.
     """
-    resp = await self.driver.send_command(
-      module="C0",
-      command="RA",
-      fmt="ra#####",
-      pn=f"{self.index + 1:02}",
-    )
-    return float(resp["ra"] / 10)
+    assert self.driver.left_x_arm is not None, "left_x_arm not set; call driver.setup() first"
+    return await self.driver.left_x_arm.request_position()
 
   # -- C0:RB  request Y position ------------------------------------------------
 

--- a/pylabrobot/legacy/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/legacy/liquid_handling/backends/hamilton/STAR_backend.py
@@ -7171,16 +7171,16 @@ class STARBackend(HamiltonLiquidHandler):
 
   async def request_iswap_rotation_drive_position_increments(self) -> int:
     """Deprecated: use ``star.iswap.request_rotation_drive_position_increments()``."""
-    return await self._iswap.request_rotation_drive_position_increments()
+    return await self._iswap.rotation_drive_request_angle_increments()
 
   async def request_iswap_rotation_drive_orientation(self) -> "RotationDriveOrientation":
     """Deprecated: use ``star.iswap.request_rotation_drive_orientation()``."""
-    new_orient = await self._iswap.request_rotation_drive_orientation()
+    new_orient = await self._iswap.rotation_drive_request_orientation()
     return STARBackend.RotationDriveOrientation(new_orient.value)
 
   async def request_iswap_wrist_drive_position_increments(self) -> int:
     """Deprecated: use ``star.iswap.request_wrist_drive_position_increments()``."""
-    return await self._iswap.request_wrist_drive_position_increments()
+    return await self._iswap.request_wrist_drive_angle_increments()
 
   async def request_iswap_wrist_drive_orientation(self) -> "WristDriveOrientation":
     """Deprecated: use ``star.iswap.request_wrist_drive_orientation()``."""
@@ -7751,7 +7751,7 @@ class STARBackend(HamiltonLiquidHandler):
 
   async def rotate_iswap_rotation_drive(self, orientation: RotationDriveOrientation):
     """Deprecated: use ``star.iswap.rotate_rotation_drive()``."""
-    return await self._iswap.rotate_rotation_drive(orientation)  # type: ignore[arg-type]
+    return await self._iswap.rotation_drive_rotate(orientation)  # type: ignore[arg-type]
 
   class WristDriveOrientation(enum.Enum):
     RIGHT = 1


### PR DESCRIPTION
It is time to re-start "Epic: Tame the iSWAP" ... a series of tasks/PRs aimed at making this unpredictable beast more reliable, predictable and ready for our agents.

This is PR 0 of many to come... 

Adds `iSWAPBackend.rotation_drive_request_position()` - returns the iSWAP rotation drive position as a `Coordinate` in deck space - plus the supporting `rotation_drive_request_x_offset()` read of EEPROM `kg` via `C0:RA`.
Also renames a few drive methods so naming reflects what they actually return.

## Problem

The iSWAP arm is a 2-link planar manipulator (L1 = L2 = 138 mm) whose base — the **rotation drive** — sits at a fixed offset from the X-arm carriage.
Every kinematic calculation on the iSWAP — forward kinematics from joint angles to gripper pose, inverse kinematics from a target plate pose to joint angles, reachable-workspace and collision checks — starts from that base point in deck coordinates.
Without it, there is no anchor to put the arm geometry on the deck.

Today the rotation drive's deck position has to be reconstructed by hand from three separate reads:

1. X-arm carriage center,
2. the per-machine X offset stored as EEPROM `kg` (set during service, currently exposed nowhere in PLR),
3. rotation-drive Y from `request_gripper_y_position`, and the 13 mm vertical drop from the rotation-drive plane to the gripper finger plane to recover Z.

<img width="1020" height="964" alt="Screenshot 2026-04-26 at 20 07 38" src="https://github.com/user-attachments/assets/94d17154-c360-4a76-903c-2bc15ff331de" />


This is the foundational primitive for moving iSWAP path planning out of C0's firmware macros (`PG`, `PP`) and into PLR — the larger "tame the iSWAP" goal.
Until joint 0 is queryable as a `Coordinate`, none of the downstream kinematic work can land cleanly.

Separately, the existing `request_{rotation,wrist}_drive_position_increments` methods return an **angle** in motor increments, not a spatial position — the name was misleading and now actively collides with the new `rotation_drive_request_position()`, which really does return a `Coordinate`.

## PR content / solution

**New on `iSWAPBackend`:**
- `rotation_drive_request_x_offset() -> float` — reads EEPROM `kg` via `C0:RA` (mm, /10). Per-machine, set at service.
- `rotation_drive_z_offset_above_finger = 13.0` — class constant for the rotation-drive-to-finger vertical offset.
- `rotation_drive_request_position() -> Coordinate` — composes X-arm center − `kg`, rotation-drive Y, finger Z + 13 mm. 
Raises `RuntimeError` if no iSWAP is installed.

**Renames (angle ≠ position):**
- `request_rotation_drive_position_increments` → `rotation_drive_request_angle_increments`
- `request_rotation_drive_orientation`         → `rotation_drive_request_orientation`
- `request_wrist_drive_position_increments`    → `request_wrist_drive_angle_increments`
- `rotate_rotation_drive`                      → `rotation_drive_rotate`

**Legacy backend (`legacy/.../STAR_backend.py`):**
- 4 deprecation shim bodies updated to delegate to the new method names.
- Existing `"""Deprecated: use ..."""` docstrings left untouched (no new deprecation messaging introduced).
