### PR TITLE
Expose `STARBackend.iswap_rotation_drive_move_y()`

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -9871,6 +9871,64 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     iswap_y_pos = resp["ry"][1]  # 0 = FW counter, 1 = HW counter
     return round(STARBackend.y_drive_increment_to_mm(iswap_y_pos), 1)
 
+  # Vertical drop from the iSWAP rotation drive plane to the gripper finger
+  # plane. R0 RZ is calibrated to the finger plane; the rotation drive sits
+  # 13 mm above it.
+  iswap_rotation_drive_z_offset_above_finger_mm = 13.0
+
+  async def iswap_rotation_drive_request_z(self) -> float:
+    """Request iSWAP rotation drive Z position (deck coordinates), in mm.
+
+    Adds the 13 mm structural offset to the gripper finger plane (C0 QG).
+    """
+    if not self.extended_conf.left_x_drive.iswap_installed:
+      raise RuntimeError("iSWAP is not installed")
+    finger_plane_z = (await self.request_iswap_position()).z
+    return finger_plane_z + STARBackend.iswap_rotation_drive_z_offset_above_finger_mm
+
+  async def iswap_rotation_drive_request_position(self) -> Coordinate:
+    """Position of the iSWAP rotation drive (joint 1) in deck coordinates, mm."""
+    return Coordinate(
+      x=await self.iswap_rotation_drive_request_x(),
+      y=await self.iswap_rotation_drive_request_y(),
+      z=await self.iswap_rotation_drive_request_z(),
+    )
+
+  async def experimental_iswap_rotation_drive_move_x(
+    self,
+    x: float,
+    acceleration_level: int = 3,
+    current_protection_limiter: int = 7,
+  ):
+    """Move the iSWAP rotation drive to an absolute X position (deck coordinates).
+
+    Thin wrapper around `x_arm_move` that translates rotation-drive X into
+    X-arm carriage X using the cached `kg` offset.
+
+    Args:
+      x: Target rotation-drive X coordinate in mm.
+      acceleration_level: Acceleration index (hardware units), 1-5. Default 3.
+      current_protection_limiter: Motor current limit (hardware units), 0-7. Default 7.
+    """
+    # TODO: remove "experimental_" prefix once x_arm_move has been optimised
+
+    if not self.extended_conf.left_x_drive.iswap_installed:
+      raise RuntimeError("iSWAP is not installed")
+    if self._iswap_rotation_drive_x_offset_mm is None:
+      self._iswap_rotation_drive_x_offset_mm = await self._iswap_rotation_drive_request_x_offset()
+    kg = self._iswap_rotation_drive_x_offset_mm
+
+    x_min = 90.0 - kg
+    x_max = 1350.0 - kg
+    if not (x_min <= x <= x_max):
+      raise ValueError(f"x must be between {x_min} and {x_max} mm, is {x}")
+
+    return await self.experimental_x_arm_move(
+      x=x + kg,
+      acceleration_level=acceleration_level,
+      current_protection_limiter=current_protection_limiter,
+    )
+
   async def iswap_rotation_drive_move_y(
     self,
     y: float,
@@ -9879,7 +9937,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     current_protection_limiter: int = 7,
     make_space: bool = False,
   ):
-    """Move the iSWAP rotation drive to an absolute Y position (R0 YA).
+    """Move the iSWAP rotation drive to an absolute Y position.
 
     Args:
       y: Target Y coordinate in mm.
@@ -9948,64 +10006,6 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       yv=f"{round(speed_increments):04}",
       yr=f"{int(acceleration_level)}",
       yw=f"{int(current_protection_limiter)}",
-    )
-
-  # Vertical drop from the iSWAP rotation drive plane to the gripper finger
-  # plane. R0 RZ is calibrated to the finger plane; the rotation drive sits
-  # 13 mm above it.
-  iswap_rotation_drive_z_offset_above_finger_mm = 13.0
-
-  async def iswap_rotation_drive_request_z(self) -> float:
-    """Request iSWAP rotation drive Z position (deck coordinates), in mm.
-
-    Adds the 13 mm structural offset to the gripper finger plane (C0 QG).
-    """
-    if not self.extended_conf.left_x_drive.iswap_installed:
-      raise RuntimeError("iSWAP is not installed")
-    finger_plane_z = (await self.request_iswap_position()).z
-    return finger_plane_z + STARBackend.iswap_rotation_drive_z_offset_above_finger_mm
-
-  async def iswap_rotation_drive_request_position(self) -> Coordinate:
-    """Position of the iSWAP rotation drive (joint 1) in deck coordinates, mm."""
-    return Coordinate(
-      x=await self.iswap_rotation_drive_request_x(),
-      y=await self.iswap_rotation_drive_request_y(),
-      z=await self.iswap_rotation_drive_request_z(),
-    )
-
-  async def experimental_iswap_rotation_drive_move_x(
-    self,
-    x: float,
-    acceleration_level: int = 3,
-    current_protection_limiter: int = 7,
-  ):
-    """Move the iSWAP rotation drive to an absolute X position (deck coordinates).
-
-    Thin wrapper around `x_arm_move` that translates rotation-drive X into
-    X-arm carriage X using the cached `kg` offset.
-
-    Args:
-      x: Target rotation-drive X coordinate in mm.
-      acceleration_level: Acceleration index (hardware units), 1-5. Default 3.
-      current_protection_limiter: Motor current limit (hardware units), 0-7. Default 7.
-    """
-    # TODO: remove "experimental_" prefix once x_arm_move has been optimised
-
-    if not self.extended_conf.left_x_drive.iswap_installed:
-      raise RuntimeError("iSWAP is not installed")
-    if self._iswap_rotation_drive_x_offset_mm is None:
-      self._iswap_rotation_drive_x_offset_mm = await self._iswap_rotation_drive_request_x_offset()
-    kg = self._iswap_rotation_drive_x_offset_mm
-
-    x_min = 90.0 - kg
-    x_max = 1350.0 - kg
-    if not (x_min <= x <= x_max):
-      raise ValueError(f"x must be between {x_min} and {x_max} mm, is {x}")
-
-    return await self.experimental_x_arm_move(
-      x=x + kg,
-      acceleration_level=acceleration_level,
-      current_protection_limiter=current_protection_limiter,
     )
 
   async def iswap_rotation_drive_request_predefined_positions(self) -> Dict[str, int]:

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -9824,6 +9824,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
   iswap_rotation_drive_deg_per_increment = 0.00309619077
   iswap_rotation_drive_y_speed_increment_range = (50, 8_000)
   iswap_rotation_drive_diameter = 30.5
+  iswap_rotation_drive_safety_radius = 90.0
 
   class RotationDriveOrientation(enum.Enum):
     LEFT = 1
@@ -9939,6 +9940,12 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
   ):
     """Move the iSWAP rotation drive to an absolute Y position.
 
+    To stay clear of channel 0 regardless of the current W-axis angle, the
+    iSWAP envelope is treated as a circle of radius
+    `iswap_rotation_drive_diameter / 2 + iswap_rotation_drive_safety_radius`.
+    The safety radius bounds the link-1 and protrusion sweep across all
+    rotation poses.
+
     Args:
       y: Target Y coordinate in mm.
       speed: Max velocity in mm/sec. Default 220.0.
@@ -9951,7 +9958,9 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     if not self.extended_conf.left_x_drive.iswap_installed:
       raise RuntimeError("iSWAP is not installed")
 
-    iswap_radius = STARBackend.iswap_rotation_drive_diameter / 2
+    iswap_radius = (
+      STARBackend.iswap_rotation_drive_diameter / 2 + STARBackend.iswap_rotation_drive_safety_radius
+    )
     channel_0_radius = self._channels_minimum_y_spacing[0] / 2
     channel_0_y = await self.request_y_pos_channel_n(0)
 

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -9775,6 +9775,8 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
   iswap_rotation_drive_min_increment = -30032  # ~ -93 deg
   iswap_rotation_drive_max_increment = 30032  # ~ +93 deg
   iswap_rotation_drive_deg_per_increment = 0.00309619077
+  iswap_rotation_drive_y_speed_increment_range = (50, 8_000)
+  iswap_rotation_drive_diameter = 30.5
 
   class RotationDriveOrientation(enum.Enum):
     LEFT = 1
@@ -9821,6 +9823,85 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     resp = await self.send_command(module="R0", command="RY", fmt="ry##### (n)")
     iswap_y_pos = resp["ry"][1]  # 0 = FW counter, 1 = HW counter
     return round(STARBackend.y_drive_increment_to_mm(iswap_y_pos), 1)
+
+  async def iswap_rotation_drive_move_y(
+    self,
+    y: float,
+    speed: float = 220.0,
+    acceleration_level: int = 2,
+    current_protection_limiter: int = 7,
+    make_space: bool = False,
+  ):
+    """Move the iSWAP rotation drive to an absolute Y position (R0 YA).
+
+    Args:
+      y: Target Y coordinate in mm.
+      speed: Max velocity in mm/sec. Default 220.0.
+      acceleration_level: Acceleration index, 1 or 2. Default 2.
+      current_protection_limiter: Motor current limit, 0-7. Default 7.
+      make_space: If True, reposition pipetting channels in a single
+        synchronous JY move when channel 0 is in the way and can be cleared.
+        If False, raise so the caller decides.
+    """
+    if not self.extended_conf.left_x_drive.iswap_installed:
+      raise RuntimeError("iSWAP is not installed")
+
+    iswap_radius = STARBackend.iswap_rotation_drive_diameter / 2
+    channel_0_radius = self._channels_minimum_y_spacing[0] / 2
+    channel_0_y = await self.request_y_pos_channel_n(0)
+
+    compressed_channel_0_y = self.extended_conf.left_arm_min_y_position + sum(
+      self._channels_minimum_y_spacing[1:]
+    )
+
+    max_y = self.extended_conf.pip_maximal_y_position
+    absolute_min_y = self.extended_conf.left_arm_min_y_position
+    if not (absolute_min_y <= y <= max_y):
+      raise ValueError(f"y must be between {absolute_min_y} and {max_y} mm, got {y} mm")
+
+    target_channel_0_y = y - channel_0_radius - iswap_radius
+    if channel_0_y > target_channel_0_y:
+      if target_channel_0_y < compressed_channel_0_y:
+        raise ValueError(
+          f"y={y} mm is unreachable: would require channel 0 at "
+          f"{target_channel_0_y} mm, below the compressed floor "
+          f"{compressed_channel_0_y} mm"
+        )
+      if not make_space:
+        raise ValueError(
+          f"y={y} mm requires channel 0 at <= {target_channel_0_y} mm "
+          f"(currently {channel_0_y} mm); pass make_space=True to "
+          f"reposition channels"
+        )
+      await self.move_all_channels_in_z_safety()
+      await self.position_channels_in_y_direction({0: target_channel_0_y}, make_space=True)
+
+    speed_increments = STARBackend.mm_to_y_drive_increment(speed)
+    speed_min, speed_max = STARBackend.iswap_rotation_drive_y_speed_increment_range
+    if not (speed_min <= speed_increments <= speed_max):
+      raise ValueError(
+        f"speed must be between "
+        f"{STARBackend.y_drive_increment_to_mm(speed_min)} and "
+        f"{STARBackend.y_drive_increment_to_mm(speed_max)} mm/sec, "
+        f"got {speed} mm/sec"
+      )
+
+    if not (1 <= acceleration_level <= 2):
+      raise ValueError(f"acceleration_level must be between 1 and 2, got {acceleration_level}")
+
+    if not (0 <= current_protection_limiter <= 7):
+      raise ValueError(
+        f"current_protection_limiter must be between 0 and 7, got {current_protection_limiter}"
+      )
+
+    await self.send_command(
+      module="R0",
+      command="YA",
+      ya=f"{round(STARBackend.mm_to_y_drive_increment(y)):05}",
+      yv=f"{round(speed_increments):04}",
+      yr=f"{int(acceleration_level)}",
+      yw=f"{int(current_protection_limiter)}",
+    )
 
   # Vertical drop from the iSWAP rotation drive plane to the gripper finger
   # plane. R0 RZ is calibrated to the finger plane; the rotation drive sits


### PR DESCRIPTION
### Tame the iSWAP - Part 7

The center of the rotation drive is the "base of the SCARA part of the iSWAP".

In the previous parts I've exposed requesting the position information of it, then added it's movement in X.

In this PR, I'm adding its movement in Y.

Because the iSWAP is not alone on the rail / its X-coordinate, this is the PR in which I am adding the **iSWAP safety features in the Y dimension**:

-> from now on you can no longer crash your iSWAP into ...

- the back of the arm
- channel_0

Because it is tedious to always think about arm positions I added `make_space` argument to:

```python
  async def iswap_rotation_drive_move_y(
    self,
    y: float,
    speed: float = 220.0,
    acceleration_level: int = 2,
    current_protection_limiter: int = 7,
    make_space: bool = False,
  )
```
...adapted from `position_channels_in_y_direction`'s `make_space`

To make this calculation possible I took the iSWAP channel diameter to be `30.5` mm, as described in the operator manual - see #1011 

---

Please let me know whether you think we should make `make_space: bool = False` by default; it might help people but does introduce implicit behaviour - though expected behaviour?