### PR TITLE
Arms: rename GripDirection→GripperDirection (string literal); rotate convention so 0°=+X

### DIFF
--- a/docs/api/pylabrobot.arms.rst
+++ b/docs/api/pylabrobot.arms.rst
@@ -38,5 +38,5 @@ Types
   :nosignatures:
   :recursive:
 
-    standard.GripperLocation
-    standard.GripDirection
+    standard.CartesianPose
+    standard.GripperDirection

--- a/docs/user_guide/capabilities/arms.md
+++ b/docs/user_guide/capabilities/arms.md
@@ -52,19 +52,29 @@ await lh.iswap.move_resource(
 
 ### OrientableArm: grip direction
 
-```python
-from pylabrobot.capabilities.arms.standard import GripDirection
+`direction` is the world yaw of the gripper's front finger, in degrees,
+**CCW about +Z with 0° = +X**. You can pass a float, or one of the
+cardinal-direction strings:
 
-await lh.iswap.pick_up_resource(plate, direction=GripDirection.LEFT)
-await lh.iswap.drop_resource(reader, direction=GripDirection.FRONT)
+```python
+await lh.iswap.pick_up_resource(plate, direction="left")     # = 180°
+await lh.iswap.drop_resource(reader, direction="front")      # = 270°
+await lh.iswap.move_to_location(coord, direction=45.0)       # 45° CCW from +X
 ```
+
+| String      | Degrees | World axis (deck frame) |
+|:------------|--------:|:------------------------|
+| `"right"`   |   `0°`  | `+X`                    |
+| `"back"`    |  `90°`  | `+Y`                    |
+| `"left"`    | `180°`  | `-X`                    |
+| `"front"`   | `270°`  | `-Y`                    |
 
 ## Tips and gotchas
 
 - **Coordinates are in the reference resource's frame** (typically the deck). The arm computes gripper target coordinates from the resource's position, dimensions, and the destination type.
 - **`pickup_distance_from_bottom`** controls how far up from the bottom of the resource the gripper grips. If `None`, the resource's `preferred_pickup_location` is used, or a default of 5 mm from the top (`size_z - 5`).
 - **Resource tree is updated automatically.** After a successful `drop_resource`, the resource is unassigned from its old parent and assigned to the destination.
-- **`GripOrientation`** is either a {class}`~pylabrobot.capabilities.arms.standard.GripDirection` enum (`FRONT`, `RIGHT`, `BACK`, `LEFT`) or a float in degrees.
+- **`GripperOrientation`** is either a {data}`~pylabrobot.capabilities.arms.standard.GripperDirection` string literal (`"front"`, `"right"`, `"back"`, `"left"`) or a float in degrees, measured CCW about world +Z with 0° = +X.
 - **`request_gripper_pose()`** queries the hardware for the current end effector position. `get_picked_up_resource()` returns the internally tracked state (no hardware call).
 
 ## Supported hardware

--- a/docs/user_guide/hamilton/star/hardware/replacing-iswap.md
+++ b/docs/user_guide/hamilton/star/hardware/replacing-iswap.md
@@ -84,11 +84,10 @@ await star.driver.iswap.reengage_break()  # firmware command "R0BO"
 
 ```python
 from pylabrobot.hamilton.liquid_handlers.star.iswap import iSWAPBackend
-from pylabrobot.capabilities.arms.standard import GripDirection
 
 await star.driver.iswap.rotate(
   rotation_drive=iSWAPBackend.RotationDriveOrientation.RIGHT,
-  grip_direction=GripDirection.BACK,
+  grip_direction="back",
 )
 ```
 
@@ -97,7 +96,7 @@ await star.driver.iswap.rotate(
 ```python
 await star.driver.iswap.rotate(
   rotation_drive=iSWAPBackend.RotationDriveOrientation.LEFT,
-  grip_direction=GripDirection.BACK,
+  grip_direction="back",
 )
 ```
 

--- a/docs/user_guide/hamilton/star/iswap.ipynb
+++ b/docs/user_guide/hamilton/star/iswap.ipynb
@@ -160,47 +160,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-08 17:52:13,325 - pylabrobot.hamilton.liquid_handlers.star.iswap - INFO - [iSWAP] pick up plate: x=482.9, y=210.2, z=192.3, direction=270 deg, width=85.5 mm\n",
-      "2026-04-08 17:52:21,538 - pylabrobot.hamilton.liquid_handlers.star.iswap - INFO - [iSWAP] release plate: x=482.9, y=306.2, z=192.3, direction=270 deg, width=85.5 mm\n"
-     ]
-    }
-   ],
-   "source": [
-    "from pylabrobot.capabilities.arms.standard import GripDirection\n",
-    "\n",
-    "await star.iswap.pick_up_resource(plate, direction=GripDirection.LEFT)\n",
-    "await star.iswap.drop_resource(plate_carrier[2], direction=GripDirection.LEFT)"
-   ]
+   "outputs": [],
+   "source": "await star.iswap.pick_up_resource(plate, direction=\"left\")\nawait star.iswap.drop_resource(plate_carrier[2], direction=\"left\")"
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-08 17:52:27,002 - pylabrobot.hamilton.liquid_handlers.star.iswap - INFO - [iSWAP] pick up plate: x=482.9, y=306.2, z=192.3, direction=90 deg, width=85.5 mm\n",
-      "2026-04-08 17:52:33,870 - pylabrobot.hamilton.liquid_handlers.star.iswap - INFO - [iSWAP] release plate: x=482.9, y=210.2, z=192.3, direction=90 deg, width=85.5 mm\n"
-     ]
-    }
-   ],
-   "source": [
-    "await star.iswap.move_resource(\n",
-    "  plate, plate_carrier[1],\n",
-    "  pickup_backend_params=iSWAPBackend.PickUpParams(grip_strength=8),\n",
-    "  pickup_direction=GripDirection.RIGHT,\n",
-    "  drop_direction=GripDirection.RIGHT,\n",
-    ")"
-   ]
+   "outputs": [],
+   "source": "await star.iswap.move_resource(\n  plate, plate_carrier[1],\n  pickup_backend_params=iSWAPBackend.PickUpParams(grip_strength=8),\n  pickup_direction=\"right\",\n  drop_direction=\"right\",\n)"
   },
   {
    "cell_type": "markdown",
@@ -387,17 +357,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from pylabrobot.capabilities.arms.standard import GripDirection\n",
-    "\n",
-    "await star.driver.iswap.rotate(\n",
-    "  rotation_drive=iSWAPBackend.RotationDriveOrientation.RIGHT,\n",
-    "  grip_direction=GripDirection.LEFT,\n",
-    ")"
-   ]
+   "source": "await star.driver.iswap.rotate(\n  rotation_drive=iSWAPBackend.RotationDriveOrientation.RIGHT,\n  grip_direction=\"left\",\n)"
   },
   {
    "cell_type": "markdown",

--- a/pylabrobot/arms/arm_tests.py
+++ b/pylabrobot/arms/arm_tests.py
@@ -7,7 +7,6 @@ from pylabrobot.arms.backend import (
   OrientableGripperArmBackend,
 )
 from pylabrobot.arms.orientable_arm import OrientableArm
-from pylabrobot.arms.standard import GripDirection
 from pylabrobot.resources import Coordinate, Resource, ResourceHolder
 
 
@@ -138,21 +137,23 @@ class TestOrientableArm(unittest.IsolatedAsyncioTestCase):
 
   async def test_pick_up_front(self):
     await self.arm.pick_up_resource(
-      self.plate, pickup_distance_from_bottom=8, direction=GripDirection.FRONT
+      self.plate, pickup_distance_from_bottom=8, direction="front"
     )
     call = self.mock_backend.pick_up_at_location.call_args
     _assert_location(self, call, 165, 145, 58)
-    self.assertAlmostEqual(call.kwargs["direction"], 0.0)
-    # FRONT → X width = 120
+    # "front" = -Y in deck frame = 270° under the +X-is-zero convention.
+    self.assertAlmostEqual(call.kwargs["direction"], 270.0)
+    # "front" grips along the X axis → X width = 120
     self.assertAlmostEqual(call.kwargs["resource_width"], 120)
 
   async def test_pick_up_right(self):
     await self.arm.pick_up_resource(
-      self.plate, pickup_distance_from_bottom=8, direction=GripDirection.RIGHT
+      self.plate, pickup_distance_from_bottom=8, direction="right"
     )
     call = self.mock_backend.pick_up_at_location.call_args
-    self.assertAlmostEqual(call.kwargs["direction"], 90.0)
-    # RIGHT → Y width = 80
+    # "right" = +X = 0° under the +X-is-zero convention.
+    self.assertAlmostEqual(call.kwargs["direction"], 0.0)
+    # "right" grips along the Y axis → Y width = 80
     self.assertAlmostEqual(call.kwargs["resource_width"], 80)
 
   async def test_drop_at_location(self):
@@ -173,9 +174,9 @@ class TestOrientableArm(unittest.IsolatedAsyncioTestCase):
   async def test_move_plate(self):
     """Pick from site_a, drop at site_b."""
     await self.arm.pick_up_resource(
-      self.plate, pickup_distance_from_bottom=8, direction=GripDirection.FRONT
+      self.plate, pickup_distance_from_bottom=8, direction="front"
     )
-    await self.arm.drop_resource(self.site_b, direction=GripDirection.FRONT)
+    await self.arm.drop_resource(self.site_b, direction="front")
     drop_call = self.mock_backend.drop_at_location.call_args
     _assert_location(self, drop_call, 160, 340, 58)
     self.assertEqual(self.plate.parent.name, "site_b")

--- a/pylabrobot/capabilities/arms/architecture.md
+++ b/pylabrobot/capabilities/arms/architecture.md
@@ -1,5 +1,31 @@
 # Arms architecture
 
+## Coordinate convention
+
+Backends share one rotation convention so swapping a Hamilton iSWAP for a
+PreciseFlex (or any future arm) doesn't change what `direction` means at
+the call site.
+
+`direction` (and `CartesianPose.rotation.z`) is the world yaw of the
+gripper's *front finger*, in degrees, measured **CCW about world +Z
+(right-hand rule, looking down)** with **0° = +X**:
+
+| `direction` | World axis | `GripperDirection` (deck frame) |
+|------------:|:----------:|:--------------------------------|
+|        `0°` |   `+X`     | `"right"`                       |
+|       `90°` |   `+Y`     | `"back"`                        |
+|      `180°` |   `-X`     | `"left"`                        |
+|      `270°` |   `-Y`     | `"front"`                       |
+
+`GripperDirection = Literal["front", "back", "left", "right"]` is a
+string-literal alias for these cardinal degrees, used wherever a deck-
+relative label reads better than a raw number.
+
+The frontends accept `direction: Union[GripperDirection, float]` and
+resolve the label to degrees before handing it to the backend, so
+backend implementations only ever see the float — but every backend
+must interpret that float under the convention above.
+
 ## Frontend hierarchy (capabilities)
 
 ```

--- a/pylabrobot/capabilities/arms/arm.py
+++ b/pylabrobot/capabilities/arms/arm.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import List, Literal, Optional, Tuple, Union
 
 from pylabrobot.capabilities.arms.backend import GripperArmBackend, _BaseArmBackend
-from pylabrobot.capabilities.arms.standard import CartesianPose, GripDirection
+from pylabrobot.capabilities.arms.standard import CartesianPose, GripperDirection
 from pylabrobot.capabilities.capability import BackendParams, Capability
 from pylabrobot.legacy.tilting.tilter import Tilter
 from pylabrobot.resources import (
@@ -20,7 +20,7 @@ from pylabrobot.resources.rotation import Rotation
 
 logger = logging.getLogger(__name__)
 
-GripOrientation = Union[GripDirection, float]
+GripperOrientation = Union[GripperDirection, float]
 
 
 @dataclass

--- a/pylabrobot/capabilities/arms/arm_tests.py
+++ b/pylabrobot/capabilities/arms/arm_tests.py
@@ -7,7 +7,6 @@ from pylabrobot.capabilities.arms.backend import (
   OrientableGripperArmBackend,
 )
 from pylabrobot.capabilities.arms.orientable_arm import OrientableArm
-from pylabrobot.capabilities.arms.standard import GripDirection
 from pylabrobot.resources import Coordinate, Resource, ResourceHolder
 
 
@@ -138,21 +137,23 @@ class TestOrientableArm(unittest.IsolatedAsyncioTestCase):
 
   async def test_pick_up_front(self):
     await self.arm.pick_up_resource(
-      self.plate, pickup_distance_from_bottom=8, direction=GripDirection.FRONT
+      self.plate, pickup_distance_from_bottom=8, direction="front"
     )
     call = self.mock_backend.pick_up_at_location.call_args
     _assert_location(self, call, 165, 145, 58)
-    self.assertAlmostEqual(call.kwargs["direction"], 0.0)
-    # FRONT → X width = 120
+    # "front" = -Y in deck frame = 270° under the +X-is-zero convention.
+    self.assertAlmostEqual(call.kwargs["direction"], 270.0)
+    # "front" grips along the X axis → X width = 120
     self.assertAlmostEqual(call.kwargs["resource_width"], 120)
 
   async def test_pick_up_right(self):
     await self.arm.pick_up_resource(
-      self.plate, pickup_distance_from_bottom=8, direction=GripDirection.RIGHT
+      self.plate, pickup_distance_from_bottom=8, direction="right"
     )
     call = self.mock_backend.pick_up_at_location.call_args
-    self.assertAlmostEqual(call.kwargs["direction"], 90.0)
-    # RIGHT → Y width = 80
+    # "right" = +X = 0° under the +X-is-zero convention.
+    self.assertAlmostEqual(call.kwargs["direction"], 0.0)
+    # "right" grips along the Y axis → Y width = 80
     self.assertAlmostEqual(call.kwargs["resource_width"], 80)
 
   async def test_drop_at_location(self):
@@ -173,9 +174,9 @@ class TestOrientableArm(unittest.IsolatedAsyncioTestCase):
   async def test_move_plate(self):
     """Pick from site_a, drop at site_b."""
     await self.arm.pick_up_resource(
-      self.plate, pickup_distance_from_bottom=8, direction=GripDirection.FRONT
+      self.plate, pickup_distance_from_bottom=8, direction="front"
     )
-    await self.arm.drop_resource(self.site_b, direction=GripDirection.FRONT)
+    await self.arm.drop_resource(self.site_b, direction="front")
     drop_call = self.mock_backend.drop_at_location.call_args
     _assert_location(self, drop_call, 160, 340, 58)
     self.assertEqual(self.plate.parent.name, "site_b")

--- a/pylabrobot/capabilities/arms/orientable_arm.py
+++ b/pylabrobot/capabilities/arms/orientable_arm.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from pylabrobot.capabilities.arms.arm import GripperOrientation, _BaseArm, _PickedUpState
 from pylabrobot.capabilities.arms.backend import OrientableGripperArmBackend
@@ -15,7 +15,7 @@ from pylabrobot.resources.rotation import Rotation
 # PLR deck frame (+X = right, +Y = back), this maps to: right=+X,
 # back=+Y, left=-X, front=-Y. ``front`` lives at 270° (rather than -90°)
 # so the table reads top-to-bottom in CCW order from +X.
-_GRIPPER_DIRECTION_TO_DEGREES: dict = {
+_GRIPPER_DIRECTION_TO_DEGREES: Dict[GripperDirection, float] = {
   "right": 0.0,
   "back":  90.0,
   "left":  180.0,

--- a/pylabrobot/capabilities/arms/orientable_arm.py
+++ b/pylabrobot/capabilities/arms/orientable_arm.py
@@ -1,23 +1,36 @@
 from typing import List, Optional, Union
 
-from pylabrobot.capabilities.arms.arm import GripOrientation, _BaseArm, _PickedUpState
+from pylabrobot.capabilities.arms.arm import GripperOrientation, _BaseArm, _PickedUpState
 from pylabrobot.capabilities.arms.backend import OrientableGripperArmBackend
-from pylabrobot.capabilities.arms.standard import GripDirection
+from pylabrobot.capabilities.arms.standard import (
+  _GRIPPER_DIRECTION_VALUES,
+  GripperDirection,
+)
 from pylabrobot.capabilities.capability import BackendParams
 from pylabrobot.resources import Coordinate, Resource, ResourceHolder, ResourceStack
 from pylabrobot.resources.rotation import Rotation
 
-_GRIP_DIRECTION_TO_DEGREES = {
-  GripDirection.FRONT: 0.0,
-  GripDirection.RIGHT: 90.0,
-  GripDirection.BACK: 180.0,
-  GripDirection.LEFT: 270.0,
+# Cardinal-direction → degrees under the standard ``rotation.z = 0 → +X``
+# convention (CCW about world +Z, right-hand rule looking down). In the
+# PLR deck frame (+X = right, +Y = back), this maps to: right=+X,
+# back=+Y, left=-X, front=-Y. ``front`` lives at 270° (rather than -90°)
+# so the table reads top-to-bottom in CCW order from +X.
+_GRIPPER_DIRECTION_TO_DEGREES: dict = {
+  "right": 0.0,
+  "back":  90.0,
+  "left":  180.0,
+  "front": 270.0,
 }
 
 
-def _resolve_direction(direction: GripOrientation) -> float:
-  if isinstance(direction, GripDirection):
-    return _GRIP_DIRECTION_TO_DEGREES[direction]
+def _resolve_direction(direction: GripperOrientation) -> float:
+  if isinstance(direction, str):
+    if direction not in _GRIPPER_DIRECTION_VALUES:
+      raise ValueError(
+        f"direction must be one of {sorted(_GRIPPER_DIRECTION_VALUES)} or a float, "
+        f"got {direction!r}"
+      )
+    return _GRIPPER_DIRECTION_TO_DEGREES[direction]
   return direction
 
 
@@ -43,17 +56,21 @@ class OrientableArm(_BaseArm):
 
   @staticmethod
   def _resource_width_for_direction(resource: Resource, direction: float) -> float:
+    # Front-finger axis is `direction`; jaws come together perpendicular to
+    # it. At 0°/180° the finger points along ±X (right/left), so the jaws
+    # grip the resource along Y; at 90°/270° the finger points along ±Y
+    # (back/front) so they grip along X.
     # TODO: resource rotation is not taken into account here.
     if direction % 180 == 0:
-      return resource.get_absolute_size_x()
-    else:
       return resource.get_absolute_size_y()
+    else:
+      return resource.get_absolute_size_x()
 
   async def pick_up_at_location(
     self,
     location: Coordinate,
     resource_width: float,
-    direction: GripOrientation = 0.0,
+    direction: GripperOrientation = 0.0,
     backend_params: Optional[BackendParams] = None,
   ):
     if self.holding:
@@ -73,7 +90,7 @@ class OrientableArm(_BaseArm):
     resource: Resource,
     offset: Coordinate = Coordinate.zero(),
     pickup_distance_from_bottom: Optional[float] = None,
-    direction: GripOrientation = GripDirection.FRONT,
+    direction: GripperOrientation = "front",
     backend_params: Optional[BackendParams] = None,
   ):
     location, pickup_distance_from_bottom = self._prepare_pickup(
@@ -97,7 +114,7 @@ class OrientableArm(_BaseArm):
   async def drop_at_location(
     self,
     location: Coordinate,
-    direction: GripOrientation,
+    direction: GripperOrientation,
     backend_params: Optional[BackendParams] = None,
   ):
     if self._holding_resource_width is None:
@@ -114,7 +131,7 @@ class OrientableArm(_BaseArm):
     self,
     destination: Union[ResourceStack, ResourceHolder, Resource, Coordinate],
     offset: Coordinate = Coordinate.zero(),
-    direction: GripOrientation = GripDirection.FRONT,
+    direction: GripperOrientation = "front",
     backend_params: Optional[BackendParams] = None,
   ):
     resource = self._prepare_drop(destination)
@@ -135,7 +152,7 @@ class OrientableArm(_BaseArm):
   async def move_to_location(
     self,
     location: Coordinate,
-    direction: GripOrientation = 0.0,
+    direction: GripperOrientation = 0.0,
     backend_params: Optional[BackendParams] = None,
   ):
     await self.backend.move_to_location(
@@ -147,7 +164,7 @@ class OrientableArm(_BaseArm):
   async def move_picked_up_resource(
     self,
     to: Coordinate,
-    direction: GripOrientation,
+    direction: GripperOrientation,
     offset: Coordinate = Coordinate.zero(),
     backend_params: Optional[BackendParams] = None,
   ):
@@ -169,8 +186,8 @@ class OrientableArm(_BaseArm):
     pickup_offset: Coordinate = Coordinate.zero(),
     destination_offset: Coordinate = Coordinate.zero(),
     pickup_distance_from_bottom: Optional[float] = None,
-    pickup_direction: GripOrientation = GripDirection.FRONT,
-    drop_direction: GripOrientation = GripDirection.FRONT,
+    pickup_direction: GripperOrientation = "front",
+    drop_direction: GripperOrientation = "front",
     pickup_backend_params: Optional[BackendParams] = None,
     drop_backend_params: Optional[BackendParams] = None,
   ):

--- a/pylabrobot/capabilities/arms/standard.py
+++ b/pylabrobot/capabilities/arms/standard.py
@@ -1,6 +1,5 @@
-import enum
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, Literal, get_args
 
 from pylabrobot.resources import Coordinate, Rotation
 
@@ -15,11 +14,13 @@ class CartesianPose:
   rotation: Rotation
 
 
-class GripDirection(enum.Enum):
-  FRONT = enum.auto()
-  BACK = enum.auto()
-  LEFT = enum.auto()
-  RIGHT = enum.auto()
+# Cardinal directions in the deck frame. String-literal alias for
+# ``OrientableArm`` ``direction`` arguments. Mapped to degrees by
+# :data:`pylabrobot.capabilities.arms.orientable_arm._GRIPPER_DIRECTION_TO_DEGREES`
+# under the standard ``rotation.z = 0 → +X (CCW about +Z)`` convention:
+# ``"right" = 0°``, ``"back" = 90°``, ``"left" = 180°``, ``"front" = 270°``.
+GripperDirection = Literal["front", "back", "left", "right"]
+_GRIPPER_DIRECTION_VALUES = frozenset(get_args(GripperDirection))
 
 
 @dataclass(frozen=True)

--- a/pylabrobot/hamilton/liquid_handlers/star/iswap.py
+++ b/pylabrobot/hamilton/liquid_handlers/star/iswap.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, Optional, cast
 
 from pylabrobot.capabilities.arms.backend import OrientableGripperArmBackend
-from pylabrobot.capabilities.arms.standard import CartesianPose, GripDirection
+from pylabrobot.capabilities.arms.standard import CartesianPose, GripperDirection
 from pylabrobot.capabilities.capability import BackendParams
 from pylabrobot.resources import Coordinate
 from pylabrobot.resources.rotation import Rotation
@@ -21,11 +21,11 @@ logger = logging.getLogger(__name__)
 def _direction_degrees_to_grip_direction(degrees: float) -> int:
   """Convert rotation angle in degrees to firmware grip_direction (1-4).
 
-  Firmware:  1 = negative Y (front), 2 = positive X (right),
-             3 = positive Y (back),  4 = negative X (left).
+  User-facing convention: ``rotation.z = 0 → +X (CCW about +Z)``.
+  Firmware:  1 = -Y (front), 2 = +X (right), 3 = +Y (back), 4 = -X (left).
   """
   normalized = round(degrees) % 360
-  mapping = {0: 1, 90: 2, 180: 3, 270: 4}
+  mapping = {0: 2, 90: 3, 180: 4, 270: 1}
   if normalized not in mapping:
     raise ValueError(f"grip direction must be a multiple of 90 degrees, got {degrees}")
   return mapping[normalized]
@@ -301,7 +301,7 @@ class iSWAPBackend(OrientableGripperArmBackend):
   async def rotate(
     self,
     rotation_drive: "iSWAPBackend.RotationDriveOrientation",
-    grip_direction: GripDirection,
+    grip_direction: GripperDirection,
     gripper_velocity: int = 55_000,
     gripper_acceleration: int = 170,
     gripper_protection: Literal[0, 1, 2, 3, 4, 5, 6, 7] = 5,
@@ -334,16 +334,16 @@ class iSWAPBackend(OrientableGripperArmBackend):
     else:
       raise ValueError(f"Invalid rotation drive orientation: {rotation_drive}")
 
-    if grip_direction.value == GripDirection.FRONT.value:
+    if grip_direction == "front":
       position += 1
-    elif grip_direction.value == GripDirection.RIGHT.value:
+    elif grip_direction == "right":
       position += 2
-    elif grip_direction.value == GripDirection.BACK.value:
+    elif grip_direction == "back":
       position += 3
-    elif grip_direction.value == GripDirection.LEFT.value:
+    elif grip_direction == "left":
       position += 4
     else:
-      raise ValueError("Invalid grip direction")
+      raise ValueError(f"Invalid grip direction: {grip_direction!r}")
 
     await self.driver.send_command(
       module="R0",

--- a/pylabrobot/hamilton/liquid_handlers/star/misc/iswap_test.ipynb
+++ b/pylabrobot/hamilton/liquid_handlers/star/misc/iswap_test.ipynb
@@ -24,15 +24,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from pylabrobot.arms.orientable_arm import OrientableArm\n",
-    "from pylabrobot.arms.standard import GripDirection\n",
-    "from pylabrobot.hamilton.liquid_handlers.star.iswap import iSWAP\n",
-    "from pylabrobot.legacy.liquid_handling.backends.hamilton.STAR_backend import STARBackend\n",
-    "from pylabrobot.resources.corning.plates import Cor_96_wellplate_360ul_Fb\n",
-    "from pylabrobot.resources.hamilton.hamilton_decks import STARLetDeck\n",
-    "from pylabrobot.resources.hamilton.plate_carriers import PLT_CAR_L5AC_A00"
-   ]
+   "source": "from pylabrobot.arms.orientable_arm import OrientableArm\nfrom pylabrobot.hamilton.liquid_handlers.star.iswap import iSWAP\nfrom pylabrobot.legacy.liquid_handling.backends.hamilton.STAR_backend import STARBackend\nfrom pylabrobot.resources.corning.plates import Cor_96_wellplate_360ul_Fb\nfrom pylabrobot.resources.hamilton.hamilton_decks import STARLetDeck\nfrom pylabrobot.resources.hamilton.plate_carriers import PLT_CAR_L5AC_A00"
   },
   {
    "cell_type": "markdown",
@@ -164,33 +156,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "cmd C0PPid0030xs04604xd0yj2102yd0zj1923zd0gr1th2800te2800gw4go1308gb1245gt20ga0gc0\n",
-      "Picked up 'my_plate'\n"
-     ]
-    }
-   ],
-   "source": [
-    "await arm.pick_up_resource(\n",
-    "  plate,\n",
-    "  direction=GripDirection.FRONT,\n",
-    "  backend_params=iSWAP.PickUpParams(\n",
-    "    minimum_traverse_height=280.0,\n",
-    "    z_position_at_end=280.0,\n",
-    "    grip_strength=4,\n",
-    "    plate_width_tolerance=2.0,\n",
-    "    collision_control_level=0,\n",
-    "    fold_up_at_end=False,\n",
-    "  ),\n",
-    ")\n",
-    "print(f\"Picked up '{plate.name}'\")"
-   ]
+   "outputs": [],
+   "source": "await arm.pick_up_resource(\n  plate,\n  direction=\"front\",\n  backend_params=iSWAP.PickUpParams(\n    minimum_traverse_height=280.0,\n    z_position_at_end=280.0,\n    grip_strength=4,\n    plate_width_tolerance=2.0,\n    collision_control_level=0,\n    fold_up_at_end=False,\n  ),\n)\nprint(f\"Picked up '{plate.name}'\")"
   },
   {
    "cell_type": "code",
@@ -218,37 +187,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "cmd C0PRid0031xs04604xd0yj3062yd0zj1923zd0th2800te2800gr1go1308ga0gc0\n",
-      "Plate 'my_plate' is now in: carrier-2\n",
-      "Plate absolute location: Coordinate(396.500, 263.500, 183.120)\n"
-     ]
-    }
-   ],
-   "source": [
-    "await arm.drop_resource(carrier[2], direction=GripDirection.FRONT)\n",
-    "print(f\"Plate '{plate.name}' is now in: {plate.parent.name}\")\n",
-    "print(f\"Plate absolute location: {plate.get_absolute_location()}\")"
-   ]
+   "outputs": [],
+   "source": "await arm.drop_resource(carrier[2], direction=\"front\")\nprint(f\"Plate '{plate.name}' is now in: {plate.parent.name}\")\nprint(f\"Plate absolute location: {plate.get_absolute_location()}\")"
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "await arm.pick_up_resource(\n",
-    "  plate,\n",
-    "  direction=GripDirection.LEFT,\n",
-    ")\n",
-    "await arm.drop_resource(carrier[2], direction=GripDirection.RIGHT)"
-   ]
+   "source": "await arm.pick_up_resource(\n  plate,\n  direction=\"left\",\n)\nawait arm.drop_resource(carrier[2], direction=\"right\")"
   },
   {
    "cell_type": "markdown",

--- a/pylabrobot/hamilton/liquid_handlers/star/tests/iswap_tests.py
+++ b/pylabrobot/hamilton/liquid_handlers/star/tests/iswap_tests.py
@@ -16,9 +16,10 @@ class TestiSWAPCommands(unittest.IsolatedAsyncioTestCase):
 
   async def test_pick_up_at_location(self):
     """C0PPid0001xs03479xd0yj1142yd0zj1874zd0gr1th2800te2800gw4go1308gb1245gt20ga0gc0"""
+    # direction=270° = -Y = "front" pickup; firmware gr=1 (front).
     await self.iswap.pick_up_at_location(
       location=Coordinate(347.9, 114.2, 187.4),
-      direction=0.0,
+      direction=270.0,
       resource_width=127.76,
     )
 
@@ -44,9 +45,10 @@ class TestiSWAPCommands(unittest.IsolatedAsyncioTestCase):
 
   async def test_pick_up_grip_direction_left(self):
     """C0PPid0003xs10427xd0yj3286yd0zj2063zd0gr4th2800te2800gw4go1308gb1245gt20ga0gc0"""
+    # direction=180° = -X = "left" pickup; firmware gr=4 (left).
     await self.iswap.pick_up_at_location(
       location=Coordinate(1042.7, 328.6, 206.3),
-      direction=270.0,
+      direction=180.0,
       resource_width=127.76,
     )
 
@@ -72,9 +74,10 @@ class TestiSWAPCommands(unittest.IsolatedAsyncioTestCase):
 
   async def test_drop_at_location(self):
     """C0PRid0002xs03479xd0yj3062yd0zj1874zd0th2800te2800gr1go1308ga0gc0"""
+    # direction=270° = -Y = "front" drop; firmware gr=1 (front).
     await self.iswap.drop_at_location(
       location=Coordinate(347.9, 306.2, 187.4),
-      direction=0.0,
+      direction=270.0,
       resource_width=127.76,
     )
 
@@ -97,9 +100,10 @@ class TestiSWAPCommands(unittest.IsolatedAsyncioTestCase):
 
   async def test_drop_grip_direction_left(self):
     """C0PRid0002xs10427xd0yj3286yd0zj2063zd0th2800te2800gr4go1308ga0gc0"""
+    # direction=180° = -X = "left" drop; firmware gr=4 (left).
     await self.iswap.drop_at_location(
       location=Coordinate(1042.7, 328.6, 206.3),
-      direction=270.0,
+      direction=180.0,
       resource_width=127.76,
     )
 

--- a/pylabrobot/legacy/liquid_handling/liquid_handler.py
+++ b/pylabrobot/legacy/liquid_handling/liquid_handler.py
@@ -22,7 +22,7 @@ from typing import (
 
 from pylabrobot.capabilities.arms.backend import OrientableGripperArmBackend
 from pylabrobot.capabilities.arms.orientable_arm import OrientableArm
-from pylabrobot.capabilities.arms.standard import GripDirection as _NewGripDirection
+from pylabrobot.capabilities.arms.standard import GripperDirection as _NewGripperDirection
 from pylabrobot.capabilities.arms.standard import CartesianPose
 from pylabrobot.capabilities.liquid_handling.head96 import Head96
 from pylabrobot.capabilities.liquid_handling.head96_backend import (
@@ -305,7 +305,12 @@ class _Head96Adapter(_NewHead96Backend):
     await self._legacy.dispense96(dispense=legacy_disp, **kw)
 
 
-_LEGACY_TO_NEW_GRIP = {d: _NewGripDirection[d.name] for d in GripDirection}
+_LEGACY_TO_NEW_GRIP: Dict[GripDirection, _NewGripperDirection] = {
+  GripDirection.FRONT: "front",
+  GripDirection.BACK: "back",
+  GripDirection.LEFT: "left",
+  GripDirection.RIGHT: "right",
+}
 
 
 class _ArmAdapter(OrientableGripperArmBackend):


### PR DESCRIPTION
## Summary

- Rename `GripDirection` enum → `GripperDirection = Literal[\"front\",\"back\",\"left\",\"right\"]` (and `GripOrientation` → `GripperOrientation`). String-literal type plays nicely with JSON, kwargs, and IDE autocomplete; enum was overkill.
- Rotate the cross-backend rotation convention so **`direction=0°` is `+X` (CCW about +Z, right-hand rule)**, instead of `-Y`. New cardinal mapping: `right=0°, back=90°, left=180°, front=270°`.
- iSWAP backend updated for both: `_direction_degrees_to_grip_direction` mapping rotates one step (firmware contract unchanged), `iSWAPBackend.rotate(grip_direction=…)` now takes a string. Tests updated to feed the new degree values; physical poses unchanged (e.g. \"front\" pickup that used to be `direction=0` is now `direction=270`, still emitting firmware `gr=1`).
- `OrientableArm._resource_width_for_direction` flips: `direction%180==0` is now along ±X (right/left), so jaws grip in Y.
- Legacy `_LEGACY_TO_NEW_GRIP` becomes a static enum→string dict.
- `architecture.md` and the user guide spell out the convention with a table.

This PR is the v1 half of the work. KX2 FK/IK in `kx2-backend` will need the same yaw rotation as a follow-up after this lands and merges in.

## Test plan

- [x] `pytest pylabrobot/capabilities/arms/ pylabrobot/arms/ pylabrobot/hamilton/ pylabrobot/legacy/liquid_handling/` — 582 passed, 0 regressions
- [x] Wider sweep `pytest pylabrobot/` — 1699 passed; the 13 unrelated xarm6 / scila failures pre-exist on `v1b1` and are unaffected
- [ ] Smoke-test on a real STAR(let) iSWAP (the firmware-command test pins `gr=1..4` so this should be safe, but worth a sanity move)
- [ ] Sphinx doc build

🤖 Generated with [Claude Code](https://claude.com/claude-code)