### PR TITLE
Create generic `ContainerRack`

### DIFF
--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -89,7 +89,8 @@ PLR's `Resource` subclasses in the inheritance tree are:
   <tr><td>├── <a href="itemized-resource/itemized-resource.html">ItemizedResource</a></td></tr>
   <tr><td>│   ├── <a href="itemized-resource/plate/plate.html">Plate</a></td></tr>
   <tr><td>│   ├── TipRack</td></tr>
-  <tr><td>│   └── TubeRack</td></tr>
+  <tr><td>│   └── ContainerRack</td></tr>
+  <tr><td>│       └── TubeRack</td></tr>
 
   <!-- ResourceHolder subtree -->
   <tr><td>├── <a href="resource-holder/resource-holder.html">ResourceHolder</a></td></tr>

--- a/pylabrobot/resources/__init__.py
+++ b/pylabrobot/resources/__init__.py
@@ -18,6 +18,7 @@ from .carrier import (
 from .celltreat import *
 from .cellvis import *
 from .container import Container
+from .container_rack import ContainerRack
 from .coordinate import Coordinate
 from .corning import *
 from .deck import Deck

--- a/pylabrobot/resources/alpaqua/__init__.py
+++ b/pylabrobot/resources/alpaqua/__init__.py
@@ -1,1 +1,2 @@
 from .magnetic_racks import *
+from .tube_racks import *

--- a/pylabrobot/resources/alpaqua/tube_racks.py
+++ b/pylabrobot/resources/alpaqua/tube_racks.py
@@ -1,0 +1,32 @@
+from pylabrobot.resources.container_rack import ContainerRack
+from pylabrobot.resources.resource_holder import ResourceHolder
+from pylabrobot.resources.utils import create_ordered_items_2d
+
+
+def alpaqua_12_tuberack_5mL_eppis(name: str) -> ContainerRack:
+  """Alpaqua Engineering LLC cat. no.: A000080
+  SLAS-compliant tube rack for use on liquid handlers to
+  accommodate 5 mL Eppendorf Tubes with snap cap lids
+
+  - URL: https://www.alpaqua.com/product/12-position-eppendorf-rack/
+  """
+
+  return ContainerRack(
+    name=name,
+    size_x=127.76,
+    size_y=85.48,
+    size_z=51.5,
+    ordered_items=create_ordered_items_2d(
+      klass=ResourceHolder,
+      num_items_x=4,
+      num_items_y=3,
+      dx=2.4,
+      dy=10.2,
+      dz=4.8,
+      item_dx=31.0,  # Column spacing
+      item_dy=20.0,  # Row spacing
+      size_x=16.7,  # Holder width
+      size_y=16.7,  # Holder depth
+      size_z=0.0,  # Holder height
+    ),
+  )

--- a/pylabrobot/resources/container_rack.py
+++ b/pylabrobot/resources/container_rack.py
@@ -1,0 +1,215 @@
+"""A movable rack of holders parameterized by container content type."""
+
+from typing import ClassVar, Dict, Generic, List, Optional, Sequence, TypeVar, Union, cast
+
+from pylabrobot.resources.itemized_resource import ItemizedResource
+from pylabrobot.resources.resource import Resource
+from pylabrobot.resources.resource_holder import ResourceHolder
+
+T = TypeVar("T", bound=Resource)
+
+
+class ContainerRack(ItemizedResource[ResourceHolder], Generic[T]):
+  """A movable rack of holders parameterized by content type ``T``.
+
+  Slots are :class:`ResourceHolder` cells in a 2D grid; each slot may be empty
+  or hold a resource of type ``T``. Dimensions and item layout are caller-defined,
+  so the rack is not restricted to any particular footprint (the SLAS-1
+  127.76 x 85.48 mm footprint is one common case — see e.g.
+  :func:`pylabrobot.resources.alpaqua.tube_racks.alpaqua_12_tuberack_5mL_eppis`).
+
+  Subclasses pick a concrete content type by parameterizing ``T`` and overriding
+  ``_content_type`` (used for runtime ``isinstance`` enforcement, since Python
+  erases generic parameters at runtime). The base class uses :class:`Resource`,
+  i.e. accepts anything.
+
+  Identifiers in ``ordered_items`` may be any string — Excel notation
+  (``"A1"``, ``"B2"``), descriptive names (``"primary"``, ``"left_well"``),
+  or anything else. Slice syntax (``rack["A1:A3"]``) and row/column helpers
+  inherited from :class:`ItemizedResource` only work for Excel-style keys;
+  single-key access (``rack["primary"]``) works for any identifier. This
+  matters for irregularly shaped racks that don't fit a Cartesian grid.
+
+  Examples:
+      >>> # Heterogeneous rack with Excel-style identifiers:
+      >>> rack: ContainerRack[Resource] = ContainerRack(
+      ...     name="mixed", size_x=127.76, size_y=85.48, size_z=45.0,
+      ...     ordered_items=holders,
+      ... )
+      >>> rack["A1"] = my_tube
+      >>> rack["A1:A3"] = [tube1, tube2, tube3]
+      >>>
+      >>> # Irregular rack with custom identifiers:
+      >>> rack["primary_well"] = my_tube
+      >>> rack["overflow"] = backup_tube
+      >>>
+      >>> # Typed rack (only Tubes), via subclass:
+      >>> tr: TubeRack = TubeRack(...)
+      >>> tube: Tube = tr.get_container("A1")  # statically typed Tube
+  """
+
+  _content_type: ClassVar[type] = Resource
+
+  def __init__(
+    self,
+    name: str,
+    size_x: float,
+    size_y: float,
+    size_z: float,
+    ordered_items: Optional[Dict[str, ResourceHolder]] = None,
+    model: Optional[str] = None,
+    category: str = "container_rack",
+  ):
+    if ordered_items is None or len(ordered_items) == 0:
+      raise ValueError("ordered_items must be provided and non-empty")
+
+    super().__init__(
+      name=name,
+      size_x=size_x,
+      size_y=size_y,
+      size_z=size_z,
+      ordered_items=ordered_items,
+      category=category,
+      model=model,
+    )
+
+  def __repr__(self) -> str:
+    return (
+      f"{self.__class__.__name__}(name={self.name!r}, "
+      f"size_x={self._size_x}, size_y={self._size_y}, size_z={self._size_z}, "
+      f"location={self.location})"
+    )
+
+  # =========================================================================
+  # CONTAINER ACCESS
+  # =========================================================================
+
+  def get_container(self, identifier: Union[str, int]) -> T:
+    """Get the container at a position. Raises if the slot is empty."""
+    holder = self.get_item(identifier)
+    if holder.resource is None:
+      raise ValueError(
+        f"No container at position {identifier} in rack '{self.name}'. "
+        f"Use has_container() to check first."
+      )
+    return cast(T, holder.resource)
+
+  def get_containers(self, identifiers: Union[str, Sequence[int], Sequence[str]]) -> List[T]:
+    """Get containers at multiple positions. Raises if any position is empty."""
+    holders = self.get_items(identifiers)
+    containers: List[T] = []
+    for i, holder in enumerate(holders):
+      if holder.resource is None:
+        try:
+          ident = self.get_child_identifier(holder)
+        except (ValueError, AttributeError):
+          ident = f"index {i}"
+        raise ValueError(f"No container at position {ident} in rack '{self.name}'. ")
+      containers.append(cast(T, holder.resource))
+    return containers
+
+  def has_container(self, identifier: Union[str, int]) -> bool:
+    """Return True if a position is occupied."""
+    holder = self.get_item(identifier)
+    return holder.resource is not None
+
+  def row_containers(self, row: Union[int, str]) -> List[T]:
+    """Get all containers in a row. Raises if any position in the row is empty."""
+    return self._collect_containers(self.row(row))
+
+  def column_containers(self, col: int) -> List[T]:
+    """Get all containers in a column. Raises if any position in the column is empty."""
+    return self._collect_containers(self.column(col))
+
+  def get_all_containers(self) -> List[T]:
+    """Get all containers in order. Raises if any position is empty."""
+    return self._collect_containers(self.get_all_items())
+
+  def _collect_containers(self, holders: Sequence[ResourceHolder]) -> List[T]:
+    containers: List[T] = []
+    for holder in holders:
+      if holder.resource is None:
+        ident = self.get_child_identifier(holder)
+        raise ValueError(f"No container at position {ident} in rack '{self.name}'. ")
+      containers.append(cast(T, holder.resource))
+    return containers
+
+  def get_occupied_containers(self) -> List[T]:
+    """Get all non-empty containers (only occupied positions)."""
+    return [
+      cast(T, holder.resource) for holder in self.get_all_items() if holder.resource is not None
+    ]
+
+  # =========================================================================
+  # ASSIGNMENT
+  # =========================================================================
+
+  def __setitem__(
+    self,
+    identifier: Union[str, int, slice],
+    value: Union[T, List[T], Sequence[T]],
+  ) -> None:
+    """Assign container(s) to position(s). Replaces existing contents."""
+    if isinstance(identifier, slice) or (isinstance(identifier, str) and ":" in identifier):
+      holders = self[identifier]
+
+      if not isinstance(value, (list, tuple)):
+        raise ValueError(
+          f"When assigning to a range, value must be a list or tuple, not {type(value).__name__}"
+        )
+
+      if len(holders) != len(value):
+        raise ValueError(
+          f"Number of containers ({len(value)}) must match number of positions ({len(holders)})"
+        )
+
+      for container in value:
+        self._check_content_type(container)
+      for holder, container in zip(holders, value):
+        self._assign_to_holder(holder, container)
+
+    else:
+      if isinstance(value, (list, tuple)):
+        raise ValueError(
+          f"Cannot assign list to single position '{identifier}'. "
+          f"Use a range like 'A1:A3' for batch assignment."
+        )
+
+      assert isinstance(value, Resource)
+      self._check_content_type(value)
+      holder = self.get_item(identifier)
+      self._assign_to_holder(holder, value)
+
+  @classmethod
+  def _check_content_type(cls, resource: Resource) -> None:
+    if not isinstance(resource, cls._content_type):
+      raise ValueError(
+        f"Only {cls._content_type.__name__} resources can be added to a {cls.__name__}, "
+        f"got {type(resource).__name__}."
+      )
+
+  @staticmethod
+  def _assign_to_holder(holder: ResourceHolder, resource: Resource) -> None:
+    # Resource.assign_child_resource only appends; without first unassigning the
+    # existing occupant, reassigning a holder leaves the previous resource as
+    # children[0] and the new one as children[1] (holder.resource still returns
+    # the old one). Clear first so reassign actually replaces.
+    if holder.resource is resource:
+      return
+    if holder.resource is not None:
+      holder.unassign_child_resource(holder.resource)
+    holder.assign_child_resource(resource, reassign=True)
+
+  # =========================================================================
+  # STATE MANAGEMENT
+  # =========================================================================
+
+  def empty(self) -> None:
+    """Remove all containers from the rack."""
+    for holder in self.get_all_items():
+      if holder.resource is not None:
+        holder.unassign_child_resource(holder.resource)
+
+  @staticmethod
+  def _occupied_func(item: ResourceHolder) -> str:
+    return "O" if item.resource is not None else "-"

--- a/pylabrobot/resources/itemized_resource.py
+++ b/pylabrobot/resources/itemized_resource.py
@@ -108,10 +108,6 @@ class ItemizedResource(Resource, Generic[T], metaclass=ABCMeta):
         raise ValueError("Must specify either `ordered_items` or `ordering`.")
       self._ordering = ordering
 
-    # validate that ordering is in the transposed Excel style notation
-    for identifier in self._ordering:
-      _ = split_identifier(identifier)
-
   def __getitem__(
     self,
     identifier: Union[str, int, Sequence[int], Sequence[str], slice, range],

--- a/pylabrobot/resources/tube_rack.py
+++ b/pylabrobot/resources/tube_rack.py
@@ -1,14 +1,21 @@
-from typing import Dict, Optional, Union, cast
+from typing import ClassVar, Dict, Optional, Union
 
+from .container_rack import ContainerRack
 from .coordinate import Coordinate
-from .itemized_resource import ItemizedResource
 from .resource import Resource
 from .resource_holder import ResourceHolder
 from .tube import Tube
 
 
-class TubeRack(ItemizedResource[ResourceHolder]):
-  """Tube rack resource."""
+class TubeRack(ContainerRack[Tube]):
+  """A rack of tubes.
+
+  Specialization of :class:`ContainerRack` that restricts slot contents to
+  :class:`Tube` resources (statically via ``ContainerRack[Tube]`` and at
+  runtime via ``_content_type``).
+  """
+
+  _content_type: ClassVar[type] = Tube
 
   def __init__(
     self,
@@ -18,23 +25,15 @@ class TubeRack(ItemizedResource[ResourceHolder]):
     size_z: float,
     ordered_items: Optional[Dict[str, ResourceHolder]] = None,
     model: Optional[str] = None,
+    category: str = "tube_rack",
   ):
-    """Initialize a TubeRack resource.
-
-    Args:
-      name: Name of the tube rack.
-      size_x: Size of the tube rack in the x direction.
-      size_y: Size of the tube rack in the y direction.
-      size_z: Size of the tube rack in the z direction.
-      items: List of lists of wells.
-      model: Model of the tube rack.
-    """
     super().__init__(
       name=name,
       size_x=size_x,
       size_y=size_y,
       size_z=size_z,
       ordered_items=ordered_items,
+      category=category,
       model=model,
     )
 
@@ -47,25 +46,8 @@ class TubeRack(ItemizedResource[ResourceHolder]):
     assert location is not None, "Location must be specified for resource."
     return super().assign_child_resource(resource, location=location, reassign=reassign)
 
-  def __repr__(self) -> str:
-    return (
-      f"{self.__class__.__name__}(name={self.name!r}, size_x={self._size_x}, "
-      f"size_y={self._size_y}, size_z={self._size_z}, location={self.location})"
-    )
-
-  def __setitem__(self, key: Union[int, str], value: Tube) -> None:
-    if not isinstance(value, Tube):
-      raise ValueError("Only Tubes resources can be added to a TubeRack.")
-    self.get_item(key).resource = value
-
   def get_tube(self, key: Union[int, str]) -> Optional[Tube]:
-    """Get the tube at the given position.
-
-    Args:
-      key: Position of the tube to get. Can be an integer index or a string name.
-
-    Returns:
-      The tube at the given position, or None if there is no tube at that position.
-    """
-    holder = self.get_item(key)
-    return cast(Optional[Tube], holder.resource) if holder.resource is not None else None
+    """Get the tube at the given position, or None if the position is empty."""
+    if not self.has_container(key):
+      return None
+    return self.get_container(key)


### PR DESCRIPTION
## Summary

Introduces generic `ContainerRack[T]`. `TubeRack` is refactored as `ContainerRack[Tube]` — type-safe accessors, richer ergonomics, 25% less code (71 → 53 lines).

## Capabilities not currently in PLR

- **Irregular racks are representable for the first time.** Today PLR cannot model a rack whose slots don't fit a Cartesian Excel grid — every `ItemizedResource` rejects non-Excel identifiers at construction. This blocks any 3D-printed or custom-fabricated rack with arbitrary slot positions, descriptive slot names (`"primary"`, `"overflow"`, `"left_reservoir"`), or non-grid geometry. `ContainerRack` lifts the restriction: free dimensions, per-slot positions, any string identifier, any content type.
- **Heterogeneous racks.** Mix `Tube`, `Trough`, `PetriDish`, vials, adapters in one rack. `TubeRack` rejects non-`Tube`; no current class accepts mixed contents.
- **Type-parameterized rack content.** Define a typed rack in 2 lines (`class TroughRack(ContainerRack[Trough]): _content_type = Trough`). Previously required ~35–40 lines of `__init__`/`__repr__`/`__setitem__` boilerplate.
- **Static type narrowing.** `tr.get_container("A1")` returns `Tube` (not `Resource`) under mypy. Same for `get_containers`, `get_all_containers`, `row_containers`. Typed iteration without `cast()`.
- **Slice-range assignment on tube racks.** `tr["A1:A8"] = batch_of_tubes`. Old `TubeRack` accepted only single positions.
- **Explicit empty/occupied API on tube racks.** `has_container`, `get_container` (raises), `get_occupied_containers`, `empty()`. Old `TubeRack` only had `get_tube → Optional[Tube]`.
- **Microplate-footprint tube racks.** 127.76 × 85.48 mm racks that hold tubes instead of wells, occupying a plate-carrier slot. Example: Alpaqua A000080 (12-position 5 mL Eppendorf).

## What's new

- **`ContainerRack[T]`** (`pylabrobot/resources/container_rack.py`): generic base; runtime `isinstance` via `_content_type`; explicit empty/occupied API; slice/row/column/integer indexing; fixes a latent reassignment bug (previously silently appended to `holder.children`).
- **`TubeRack(ContainerRack[Tube])`** — `Tube` enforced statically and at runtime.
- **Identifier flexibility**: removes the construction-time Excel check from `ItemizedResource`. Slice/`row`/`column` still raise at call-time on non-Excel keys.
- **`alpaqua_12_tuberack_5mL_eppis`** (Alpaqua A000080) as the first concrete instance.

## Breaking changes

- `ordered_items` is now required and non-empty.
- `TubeRack.category` default: `None` → `"tube_rack"`. Affects `Resource.__eq__` and JSON snapshots across versions.
- Slot reassignment now replaces the existing tube (bug fix; was silent append).
- `ItemizedResource` no longer validates Excel notation at construction. Slice/`row`/`column` still raise at call-time when invoked on non-Excel keys.

## Future direction

`PetriDishRack(ContainerRack[PetriDish])` and `TroughRack(ContainerRack[Trough])` as minimal subclasses.
