### PR TITLE
Fix `STARBackend.iswap_close_gripper` defaults so it works without args

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -10911,8 +10911,8 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
   async def iswap_close_gripper(
     self,
     grip_strength: int = 5,
-    plate_width: float = 0,
-    plate_width_tolerance: float = 0,
+    plate_width: float = 86.0,
+    plate_width_tolerance: float = 2.0,
   ):
     """Close gripper
 
@@ -10920,13 +10920,14 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
 
     Args:
       grip_strength: Grip strength. 0 = low . 9 = high. Default 5.
-      plate_width: Plate width [mm] (gb should be > min. Pos. + stop ramp + gt -> gb > 760 + 5 + g )
-      plate_width_tolerance: Plate width tolerance [mm]. Must be between 0 and 9.9. Default 2.0.
+      plate_width: Plate width [mm] (gb should be > min. Pos. + stop ramp + gt -> gb > 760 + 5 + g ).
+        Default 86.0 (SBS short side, matching `iswap_get_plate`'s 860 in 0.1 mm units).
+      plate_width_tolerance: Plate width tolerance [mm]. Must be between 0.5 and 9.9. Default 2.0.
     """
 
     assert 0 <= grip_strength <= 9, "grip_strength must be between 0 and 9"
-    assert 0 <= plate_width <= 999.9, "plate_width must be between 0 and 999.9"
-    assert 0 <= plate_width_tolerance <= 9.9, "plate_width_tolerance must be between 0 and 9.9"
+    assert 76.0 < plate_width <= 999.9, "plate_width must be between 76.0 and 999.9"
+    assert 0.5 <= plate_width_tolerance <= 9.9, "plate_width_tolerance must be between 0.5 and 9.9"
 
     return await self.send_command(
       module="C0",


### PR DESCRIPTION
## Summary

The firmware's `C0 GC` command rejects both `gb=0000` (`plate_width=0`) and `gt=00` (`plate_width_tolerance=0`) as out-of-range, so calling `await backend.iswap_close_gripper()` with no args has been guaranteed to raise `Parameter out of range` (R0/err 32). Pick defaults that actually work.

| | Before | After |
|---|---|---|
| `plate_width` default | `0` | `86.0` (SBS short side -- matches `iswap_get_plate`'s `860` in 0.1 mm units used elsewhere in this file) |
| `plate_width_tolerance` default | `0` | `2.0` (firmware spec default of 20 in 0.1 mm units) |
| `plate_width` assertion | `>= 0` | `> 76.0` (firmware requires `gb > 760`) |
| `plate_width_tolerance` assertion | `>= 0` | `>= 0.5` (firmware rejects lower) |

Same change [already landed on v1b1](https://github.com/PyLabRobot/pylabrobot/commit/8639d644e) (commit `8639d644e`) for the new `iSWAPBackend.close_gripper`; this PR ports it to the legacy `STARBackend.iswap_close_gripper` so users on `main` get the fix.

## Test plan

- [ ] Static: existing CI (lint, type-check) passes.
- [ ] On a real STAR with an iSWAP installed:
  - [ ] `await backend.iswap_close_gripper()` (no args) closes on a 96-well plate without raising.
  - [ ] `iswap_close_gripper(plate_width=50.0)` fails fast in Python with the new 76.0 assertion (not the firmware).
  - [ ] `iswap_close_gripper(plate_width_tolerance=0.1)` fails fast in Python with the new 0.5 assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)