### PR TITLE
Fix NEST/AGenBio trough reservoir well geometry

### DIFF
--- a/pylabrobot/resources/agenbio/plates.py
+++ b/pylabrobot/resources/agenbio/plates.py
@@ -136,10 +136,10 @@ def AGenBio_1_wellplate_Fl(name: str, lid: Optional[Lid] = None) -> Plate:
 
 
 def AGenBio_1_troughplate_190000uL_Fl(name: str, lid: Optional[Lid] = None) -> Plate:
-  """
-  AGenBio Catalog No. RES-190-F
-  - Material: Polypropylene
-  - Max. volume: 190 mL
+  """AGenBio single-well reagent reservoir, 190 mL, flat-bottom (ANSI/SLAS footprint).
+
+  cat. no.: RES-190-F
+  Material: polypropylene
   """
   INNER_WELL_WIDTH = 107.2  # measured
   INNER_WELL_HEIGHT = 70.9  # measured
@@ -147,7 +147,8 @@ def AGenBio_1_troughplate_190000uL_Fl(name: str, lid: Optional[Lid] = None) -> P
   well_kwargs = {
     "size_x": INNER_WELL_WIDTH,  # measured
     "size_y": INNER_WELL_HEIGHT,  # measured
-    "size_z": 24.76,  # measured to bottom of well
+    "size_z": 44.2 - 5.88,  # well cavity reaches the plate top (plate size_z 44.2 - dz 5.88)
+    "max_volume": 190_000,  # spec rating; size_z reaches the rim so the box volume would overstate capacity
     "bottom_type": WellBottomType.FLAT,
     "cross_section_type": CrossSectionType.RECTANGLE,
     "compute_height_from_volume": lambda liquid_volume: compute_height_from_volume_rectangle(
@@ -185,10 +186,10 @@ def AGenBio_1_troughplate_190000uL_Fl(name: str, lid: Optional[Lid] = None) -> P
 
 
 def AGenBio_1_troughplate_100000uL_Fl(name: str, lid: Optional[Lid] = None) -> Plate:
-  """
-  AGenBio Catalog No. RES-100-F
-  - Material: Polypropylene
-  - Max. volume: 100 mL
+  """AGenBio single-well reagent reservoir, 100 mL, flat-bottom (ANSI/SLAS footprint).
+
+  cat. no.: RES-100-F
+  Material: polypropylene
   """
   INNER_WELL_WIDTH = 107.2  # measured
   INNER_WELL_HEIGHT = 70.9  # measured
@@ -196,11 +197,17 @@ def AGenBio_1_troughplate_100000uL_Fl(name: str, lid: Optional[Lid] = None) -> P
   well_kwargs = {
     "size_x": INNER_WELL_WIDTH,  # measured
     "size_y": INNER_WELL_HEIGHT,  # measured
-    "size_z": 13,  # measured to bottom of well
+    "size_z": 31.4 - 5.88,  # well cavity reaches the plate top (plate size_z 31.4 - dz 5.88)
+    "max_volume": 100_000,  # spec rating; size_z reaches the rim so the box volume would overstate capacity
     "bottom_type": WellBottomType.FLAT,
     "cross_section_type": CrossSectionType.RECTANGLE,
     "compute_height_from_volume": lambda liquid_volume: compute_height_from_volume_rectangle(
       liquid_volume,
+      INNER_WELL_HEIGHT,
+      INNER_WELL_WIDTH,
+    ),
+    "compute_volume_from_height": lambda liquid_height: compute_volume_from_height_rectangle(
+      liquid_height,
       INNER_WELL_HEIGHT,
       INNER_WELL_WIDTH,
     ),

--- a/pylabrobot/resources/nest/plates.py
+++ b/pylabrobot/resources/nest/plates.py
@@ -54,16 +54,22 @@ def nest_1_troughplate_195000uL_Vb(name: str) -> Plate:
 
 
 def nest_1_troughplate_185000uL_Vb(name: str) -> Plate:
-  """part no 360104. 384 tiny holes, but one container."""
+  """NEST single-trough reagent reservoir plate, 185 mL, V-bottom (ANSI/SLAS footprint).
+
+  cat. no.: 360104
+
+  384 tiny holes feed one shared container.
+  """
   real_well_d = (85.48 - 8.99 * 2) / 15  # 4.5. in the drawing it says 2.4 which is wrong
 
-  well_size_y = 127.76 - (12.13 - real_well_d / 2) * 2  # from datasheet
-  well_size_x = 85.48 - (8.99 - real_well_d / 2) * 2  # from datasheet
+  well_size_x = 127.76 - (12.13 - real_well_d / 2) * 2  # from datasheet
+  well_size_y = 85.48 - (8.99 - real_well_d / 2) * 2  # from datasheet
   well_kwargs = {
     "size_x": well_size_x,
     "size_y": well_size_y,
     "size_z": 26.85,  # from datasheet
     "bottom_type": WellBottomType.V,
+    "cross_section_type": CrossSectionType.RECTANGLE,
     # an approximation: the trapezoid at the bottom is not fully defined in the datasheet
     "compute_height_from_volume": lambda liquid_volume: compute_height_from_volume_rectangle(
       liquid_volume=liquid_volume, well_length=well_size_x, well_width=well_size_y
@@ -96,7 +102,12 @@ def nest_1_troughplate_185000uL_Vb(name: str) -> Plate:
 
 
 def nest_8_troughplate_22000uL_Vb(name: str) -> Plate:
-  """part no 360101. not validated"""
+  """NEST 8-trough reagent reservoir plate, 22 mL, V-bottom (ANSI/SLAS footprint).
+
+  cat. no.: 360101
+
+  Not validated.
+  """
   well_size_x = 107.5  # from datasheet
   well_size_y = 8.2  # from datasheet
   well_kwargs = {
@@ -104,6 +115,7 @@ def nest_8_troughplate_22000uL_Vb(name: str) -> Plate:
     "size_y": well_size_y,
     "size_z": 26.85,  # from datasheet
     "bottom_type": WellBottomType.V,
+    "cross_section_type": CrossSectionType.RECTANGLE,
     # an approximation: the trapezoid at the bottom is not fully defined in the datasheet
     "compute_height_from_volume": lambda liquid_volume: compute_height_from_volume_rectangle(
       liquid_volume=liquid_volume, well_length=well_size_x, well_width=well_size_y
@@ -136,7 +148,10 @@ def nest_8_troughplate_22000uL_Vb(name: str) -> Plate:
 
 
 def nest_12_troughplate_15000uL_Vb(name: str) -> Plate:
-  """part no 360102."""
+  """NEST 12-trough reagent reservoir plate, 15 mL, V-bottom (ANSI/SLAS footprint).
+
+  cat. no.: 360102
+  """
   well_size_x = 8.2  # from datasheet
   well_size_y = 71.2  # from datasheet
   well_kwargs = {
@@ -144,6 +159,7 @@ def nest_12_troughplate_15000uL_Vb(name: str) -> Plate:
     "size_y": well_size_y,
     "size_z": 26.85,  # from datasheet
     "bottom_type": WellBottomType.V,
+    "cross_section_type": CrossSectionType.RECTANGLE,
     # an approximation: the trapezoid at the bottom is not fully defined in the datasheet
     "compute_height_from_volume": lambda liquid_volume: compute_height_from_volume_rectangle(
       liquid_volume=liquid_volume, well_length=well_size_x, well_width=well_size_y


### PR DESCRIPTION
## Summary

Corrects resource-definition geometry bugs in the NEST and AGenBio single-/multi-trough reservoirs, surfaced while reviewing the 3D geometry preview in #1042. Scoped to one focused PR; no public API change.

- **`nest_1_troughplate_185000uL_Vb`** — `well_size_x`/`well_size_y` were transposed relative to the plate body (127.76 × 85.48), so the single well was effectively rotated 90° and overhung the trough (preview bbox 127.76 × 113.92). Swapped to match the body and the working `nest_8`/`nest_12` convention (well is now 108 × 72, inside the body).
- **`nest_1` / `nest_8` / `nest_12_troughplate_*`** — added `cross_section_type=CrossSectionType.RECTANGLE`; these rectangular troughs were defaulting to `CIRCLE`, so they were modelled/rendered as round.
- **`AGenBio_1_troughplate_190000uL_Fl` / `_100000uL_Fl`** — extended well `size_z` so the cavity reaches the plate rim (well top now flush with plate top); pinned `max_volume` to the catalogued spec (190 mL / 100 mL) so the now-taller box doesn't overstate capacity; added the missing `compute_volume_from_height` to the 100000 def (mirrors the 190000 sibling).
- Added concise one-line docstrings + `cat. no.:` provenance to all five defs.

## Test plan

- [x] `make format` / `make format-check` — clean
- [x] `make lint` (ruff) — All checks passed
- [x] `make typecheck` (mypy --check-untyped-defs) — no issues, 488 files
- [x] `pytest pylabrobot/resources` — 197 passed, 27 subtests
- [x] `make docs-check` (-W) — build succeeded
- [x] Instantiation: each well now fits within the plate footprint; AGenBio well tops are flush with the plate rim; volume round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)