### PR TITLE
feat(spark): add spectrum scan support for absorbance and fluorescence

### DIFF
--- a/pylabrobot/plate_reading/tecan/spark20m/controls/optics_control.py
+++ b/pylabrobot/plate_reading/tecan/spark20m/controls/optics_control.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 
 from .base_control import BaseControl
 from .spark_enums import (
@@ -111,13 +111,18 @@ class OpticsControl(BaseControl):
   async def set_emission_filter(
     self,
     filter_type: FilterType,
-    wavelength: Optional[int] = None,
+    wavelength: Optional[Union[int, str]] = None,
     bandwidth: Optional[int] = None,
     attenuation: Optional[int] = None,
     label: Optional[int] = None,
     carrier: Optional[FluorescenceCarrier] = None,
   ) -> Optional[str]:
-    """Sets the emission filter."""
+    """Sets the emission filter.
+
+    Args:
+      wavelength: Wavelength in deci-tenths of nm. Can be an int for a single wavelength,
+        or a string range like ``'5000~5500:100'`` (from~to:step) for spectrum scans.
+    """
     command = "EMISSION"
     if carrier:
       command += f" CARRIER={carrier.value}"
@@ -260,13 +265,18 @@ class OpticsControl(BaseControl):
   async def set_excitation_filter(
     self,
     filter_type: FilterType,
-    wavelength: Optional[int] = None,
+    wavelength: Optional[Union[int, str]] = None,
     bandwidth: Optional[int] = None,
     attenuation: Optional[int] = None,
     label: Optional[int] = None,
     carrier: Optional[FluorescenceCarrier] = None,
   ) -> Optional[str]:
-    """Sets the excitation filter."""
+    """Sets the excitation filter.
+
+    Args:
+      wavelength: Wavelength in deci-tenths of nm. Can be an int for a single wavelength,
+        or a string range like ``'5000~5500:100'`` (from~to:step) for spectrum scans.
+    """
     command = "EXCITATION"
     if carrier:
       command += f" CARRIER={carrier.value}"

--- a/pylabrobot/plate_reading/tecan/spark20m/spark_backend.py
+++ b/pylabrobot/plate_reading/tecan/spark20m/spark_backend.py
@@ -264,7 +264,7 @@ class ExperimentalSparkBackend(PlateReaderBackend):
       }
     ]
 
-  async def read_absorbance_spectrum(
+  async def experimental_read_absorbance_spectrum(
     self,
     plate: Plate,
     wells: Optional[List[Well]],
@@ -324,7 +324,7 @@ class ExperimentalSparkBackend(PlateReaderBackend):
       for wl, data_matrix in sorted(spectrum_data.items())
     ]
 
-  async def read_fluorescence_spectrum(
+  async def experimental_read_fluorescence_spectrum(
     self,
     plate: Plate,
     wells: List[Well],

--- a/pylabrobot/plate_reading/tecan/spark20m/spark_backend.py
+++ b/pylabrobot/plate_reading/tecan/spark20m/spark_backend.py
@@ -1,7 +1,7 @@
 import logging
 import statistics
 import time
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from pylabrobot.plate_reading.backend import PlateReaderBackend
 from pylabrobot.plate_reading.utils import _get_min_max_row_col_tuples
@@ -26,7 +26,12 @@ from .controls.spark_enums import (
 )
 from .controls.system_control import SystemControl
 from .enums import SparkDevice
-from .spark_processor import process_absorbance, process_fluorescence
+from .spark_processor import (
+  process_absorbance,
+  process_absorbance_spectrum,
+  process_fluorescence,
+  process_fluorescence_spectrum,
+)
 from .spark_reader_async import SparkReaderAsync
 
 logger = logging.getLogger(__name__)
@@ -114,6 +119,83 @@ class ExperimentalSparkBackend(PlateReaderBackend):
           start_x, end_x, y_pos, z, num_points_x
         )
 
+  async def _run_measurement(
+    self, device: SparkDevice, plate: Plate, wells: Optional[List[Well]], z: float = 9150
+  ) -> List[bytes]:
+    """Execute a measurement: start background read, scan plate, collect results.
+
+    This is the shared orchestration for all measurement types.
+    """
+    bg_task, stop_event, results = await self.reader.start_background_read(device)
+
+    if bg_task is None or stop_event is None or results is None:
+      raise RuntimeError(f"Failed to start background read for {device.name}")
+
+    try:
+      await self.measurement_control.prepare_instrument(measure_reference=True)
+      await self.scan_plate_range(plate, wells, z)
+    finally:
+      stop_event.set()
+      await bg_task
+      await self.data_control.turn_all_interval_messages_off()
+      await self.measurement_control.end_measurement()
+
+    return results
+
+  async def _setup_absorbance(
+    self, wavelength: Union[int, str], bandwidth: int, num_reads: int
+  ) -> None:
+    """Configure the instrument for an absorbance measurement."""
+    self.reader.clear_messages()
+    await self.data_control.set_interval(InstrumentMessageType.TEMPERATURE, 200)
+    await self.measurement_control.set_measurement_mode(MeasurementMode.ABSORBANCE)
+    await self.measurement_control.start_measurement()
+    await self.plate_control.set_motor_speed(MovementSpeed.NORMAL)
+    await self.measurement_control.set_scan_direction(ScanDirection.UP)
+    await self.system_control.set_settle_time(50000)
+    await self.measurement_control.set_number_of_reads(num_reads, label=1)
+    await self.optics_control.set_excitation_filter(
+      FilterType.BANDPASS, wavelength=wavelength, bandwidth=bandwidth, label=1
+    )
+
+  async def _setup_fluorescence(
+    self,
+    ex_wavelength: Union[int, str],
+    em_wavelength: int,
+    bandwidth: int,
+    num_reads: int,
+    gain: int,
+  ) -> None:
+    """Configure the instrument for a fluorescence measurement."""
+    self.reader.clear_messages()
+    await self.data_control.set_interval(InstrumentMessageType.TEMPERATURE, 200)
+    await self.measurement_control.set_measurement_mode(MeasurementMode.FLUORESCENCE_TOP)
+    await self.measurement_control.start_measurement()
+    await self.plate_control.set_motor_speed(MovementSpeed.NORMAL)
+
+    await self.system_control.set_integration_time(40)
+    await self.system_control.set_lag_time(0)
+    await self.system_control.set_settle_time(0)
+
+    await self.optics_control.set_beam_diameter(5400)
+    await self.optics_control.set_emission_filter(
+      FilterType.BANDPASS,
+      wavelength=em_wavelength,
+      bandwidth=bandwidth,
+      carrier=FluorescenceCarrier.MONOCHROMATOR,
+    )
+    await self.optics_control.set_excitation_filter(
+      FilterType.BANDPASS,
+      wavelength=ex_wavelength,
+      bandwidth=bandwidth,
+      carrier=FluorescenceCarrier.MONOCHROMATOR,
+    )
+
+    await self.measurement_control.set_scan_direction(ScanDirection.ALTERNATE_UP)
+    await self.optics_control.set_mirror(mirror_type=MirrorType.AUTOMATIC)
+    await self.optics_control.set_signal_gain(gain)
+    await self.measurement_control.set_number_of_reads(num_reads)
+
   async def read_absorbance(
     self,
     plate: Plate,
@@ -129,45 +211,13 @@ class ExperimentalSparkBackend(PlateReaderBackend):
         "ABSORPTION device is not connected. Cannot perform absorbance measurement."
       )
 
-    # Initialize
-    self.reader.clear_messages()
-    await self.data_control.set_interval(InstrumentMessageType.TEMPERATURE, 200)
-    # Setup Measurement
-    await self.measurement_control.set_measurement_mode(MeasurementMode.ABSORBANCE)
-    await self.measurement_control.start_measurement()
-    await self.plate_control.set_motor_speed(MovementSpeed.NORMAL)
-    await self.measurement_control.set_scan_direction(ScanDirection.UP)
-    await self.system_control.set_settle_time(50000)
-    await self.measurement_control.set_number_of_reads(num_reads, label=1)
-    await self.optics_control.set_excitation_filter(
-      FilterType.BANDPASS, wavelength=wavelength * 10, bandwidth=bandwidth, label=1
-    )
+    await self._setup_absorbance(wavelength * 10, bandwidth, num_reads)
+    results = await self._run_measurement(SparkDevice.ABSORPTION, plate, wells)
+    measurement_time = time.time()
 
-    # Start Background Read
-    bg_task, stop_event, results = await self.reader.start_background_read(SparkDevice.ABSORPTION)
-
-    if bg_task is None or stop_event is None or results is None:
-      raise RuntimeError(f"Failed to start background read for {SparkDevice.ABSORPTION.name}")
-
-    try:
-      # Execute Measurement Sequence
-      await self.measurement_control.prepare_instrument(measure_reference=True)
-
-      await self.scan_plate_range(plate, wells)
-      measurement_time = time.time()
-
-    finally:
-      stop_event.set()
-      await bg_task
-
-      await self.data_control.turn_all_interval_messages_off()
-      await self.measurement_control.end_measurement()
-
-    # Process results
     data_matrix = process_absorbance(results)
     avg_temp = await self.get_average_temperature()
 
-    # Construct the response
     return [
       {
         "wavelength": wavelength,
@@ -195,63 +245,12 @@ class ExperimentalSparkBackend(PlateReaderBackend):
         "FLUORESCENCE device is not connected. Cannot perform fluorescence measurement."
       )
 
-    ex_wavelength = excitation_wavelength * 10
-    em_wavelength = emission_wavelength * 10
-
-    # Initialize
-    self.reader.clear_messages()
-    await self.data_control.set_interval(InstrumentMessageType.TEMPERATURE, 200)
-
-    # Setup Measurement
-    await self.measurement_control.set_measurement_mode(MeasurementMode.FLUORESCENCE_TOP)
-    await self.measurement_control.start_measurement()
-    await self.plate_control.set_motor_speed(MovementSpeed.NORMAL)
-
-    # System Settings
-    await self.system_control.set_integration_time(40)
-    await self.system_control.set_lag_time(0)
-    await self.system_control.set_settle_time(0)
-
-    # Optics Settings
-    await self.optics_control.set_beam_diameter(5400)
-    await self.optics_control.set_emission_filter(
-      FilterType.BANDPASS,
-      wavelength=em_wavelength,
-      bandwidth=bandwidth,
-      carrier=FluorescenceCarrier.MONOCHROMATOR,
+    await self._setup_fluorescence(
+      excitation_wavelength * 10, emission_wavelength * 10, bandwidth, num_reads, gain
     )
-    await self.optics_control.set_excitation_filter(
-      FilterType.BANDPASS,
-      wavelength=ex_wavelength,
-      bandwidth=bandwidth,
-      carrier=FluorescenceCarrier.MONOCHROMATOR,
-    )
+    results = await self._run_measurement(SparkDevice.FLUORESCENCE, plate, wells, focal_height)
+    measurement_time = time.time()
 
-    await self.measurement_control.set_scan_direction(ScanDirection.ALTERNATE_UP)
-    await self.optics_control.set_mirror(mirror_type=MirrorType.AUTOMATIC)
-    await self.optics_control.set_signal_gain(gain)
-    await self.measurement_control.set_number_of_reads(num_reads)
-
-    # Start Background Read
-    bg_task, stop_event, results = await self.reader.start_background_read(SparkDevice.FLUORESCENCE)
-
-    if bg_task is None or stop_event is None or results is None:
-      raise RuntimeError(f"Failed to start background read for {SparkDevice.FLUORESCENCE.name} ")
-
-    try:
-      # Execute Measurement Sequence
-      await self.measurement_control.prepare_instrument(measure_reference=True)
-      await self.scan_plate_range(plate, wells, focal_height)
-      measurement_time = time.time()
-
-    finally:
-      stop_event.set()
-      await bg_task
-
-      await self.data_control.turn_all_interval_messages_off()
-      await self.measurement_control.end_measurement()
-
-    # Process results
     data_matrix = process_fluorescence(results)
     avg_temp = await self.get_average_temperature()
 
@@ -263,6 +262,136 @@ class ExperimentalSparkBackend(PlateReaderBackend):
         "temperature": avg_temp if avg_temp is not None else 0.0,
         "data": data_matrix,
       }
+    ]
+
+  async def read_absorbance_spectrum(
+    self,
+    plate: Plate,
+    wells: Optional[List[Well]],
+    wavelength_start: int,
+    wavelength_end: int,
+    wavelength_step: int = 10,
+    bandwidth: int = 200,
+    num_reads: int = 1,
+  ) -> List[Dict[str, object]]:
+    """Read absorbance across a range of wavelengths (spectrum scan).
+
+    The Spark firmware handles the wavelength sweep natively via a range syntax.
+    A single SCAN command per well position sweeps through all wavelengths.
+
+    Args:
+      plate: The plate resource.
+      wells: Wells to scan. None = all wells.
+      wavelength_start: Start wavelength in nm.
+      wavelength_end: End wavelength in nm.
+      wavelength_step: Step size in nm (default 10).
+      bandwidth: Monochromator bandwidth in deci-tenths of nm (default 200 = 20nm).
+      num_reads: Number of flashes per wavelength step (default 1).
+
+    Returns:
+      A list of dicts, one per wavelength step. Each contains:
+        ``wavelength`` (int), ``time`` (float), ``temperature`` (float),
+        ``data`` (List[List[float]]).
+    """
+
+    if SparkDevice.ABSORPTION not in self.reader.devices:
+      raise RuntimeError(
+        "ABSORPTION device is not connected. Cannot perform absorbance spectrum scan."
+      )
+
+    if wavelength_start >= wavelength_end:
+      raise ValueError("wavelength_start must be less than wavelength_end")
+    if wavelength_step <= 0:
+      raise ValueError("wavelength_step must be positive")
+
+    # Firmware range syntax: FROM~TO:STEP in deci-tenths of nm
+    wavelength_range = f"{wavelength_start * 10}~{wavelength_end * 10}:{wavelength_step * 10}"
+
+    await self._setup_absorbance(wavelength_range, bandwidth, num_reads)
+    results = await self._run_measurement(SparkDevice.ABSORPTION, plate, wells)
+    measurement_time = time.time()
+
+    spectrum_data = process_absorbance_spectrum(results)
+    avg_temp = await self.get_average_temperature()
+
+    return [
+      {
+        "wavelength": wl,
+        "time": measurement_time,
+        "temperature": avg_temp if avg_temp is not None else 0.0,
+        "data": data_matrix,
+      }
+      for wl, data_matrix in sorted(spectrum_data.items())
+    ]
+
+  async def read_fluorescence_spectrum(
+    self,
+    plate: Plate,
+    wells: List[Well],
+    excitation_wavelength_start: int,
+    excitation_wavelength_end: int,
+    emission_wavelength: int,
+    excitation_wavelength_step: int = 10,
+    focal_height: float = 20000,
+    bandwidth: int = 200,
+    num_reads: int = 30,
+    gain: int = 100,
+  ) -> List[Dict[str, object]]:
+    """Read fluorescence across a range of excitation wavelengths (spectrum scan).
+
+    The Spark firmware handles the wavelength sweep natively. The emission
+    wavelength is fixed, and the excitation wavelength sweeps across the range.
+
+    Args:
+      plate: The plate resource.
+      wells: Wells to scan.
+      excitation_wavelength_start: Start excitation wavelength in nm.
+      excitation_wavelength_end: End excitation wavelength in nm.
+      emission_wavelength: Fixed emission wavelength in nm.
+      excitation_wavelength_step: Step size in nm (default 10).
+      focal_height: Z focal height in device units (default 20000).
+      bandwidth: Monochromator bandwidth in deci-tenths of nm (default 200 = 20nm).
+      num_reads: Number of reads per wavelength step (default 30).
+      gain: Signal gain (default 100).
+
+    Returns:
+      A list of dicts, one per excitation wavelength step. Each contains:
+        ``ex_wavelength`` (float), ``em_wavelength`` (int), ``time`` (float),
+        ``temperature`` (float), ``data`` (List[List[float]]).
+    """
+
+    if SparkDevice.FLUORESCENCE not in self.reader.devices:
+      raise RuntimeError(
+        "FLUORESCENCE device is not connected. Cannot perform fluorescence spectrum scan."
+      )
+
+    if excitation_wavelength_start >= excitation_wavelength_end:
+      raise ValueError("excitation_wavelength_start must be less than excitation_wavelength_end")
+    if excitation_wavelength_step <= 0:
+      raise ValueError("excitation_wavelength_step must be positive")
+
+    # Firmware range syntax for excitation sweep
+    ex_range = (
+      f"{excitation_wavelength_start * 10}~"
+      f"{excitation_wavelength_end * 10}:{excitation_wavelength_step * 10}"
+    )
+
+    await self._setup_fluorescence(ex_range, emission_wavelength * 10, bandwidth, num_reads, gain)
+    results = await self._run_measurement(SparkDevice.FLUORESCENCE, plate, wells, focal_height)
+    measurement_time = time.time()
+
+    spectrum_data = process_fluorescence_spectrum(results)
+    avg_temp = await self.get_average_temperature()
+
+    return [
+      {
+        "ex_wavelength": ex_wl,
+        "em_wavelength": emission_wavelength,
+        "time": measurement_time,
+        "temperature": avg_temp if avg_temp is not None else 0.0,
+        "data": data_matrix,
+      }
+      for ex_wl, data_matrix in sorted(spectrum_data.items())
     ]
 
   async def read_luminescence(

--- a/pylabrobot/plate_reading/tecan/spark20m/spark_backend_tests.py
+++ b/pylabrobot/plate_reading/tecan/spark20m/spark_backend_tests.py
@@ -142,7 +142,7 @@ class TestExperimentalSparkBackend(unittest.IsolatedAsyncioTestCase):
     temp = await self.backend.get_average_temperature()
     self.assertIsNone(temp)
 
-  async def test_read_absorbance_spectrum(self) -> None:
+  async def test_experimental_read_absorbance_spectrum(self) -> None:
     # Mock background read
     stop_event = MagicMock()
     bg_task: "asyncio.Future[None]" = asyncio.Future()
@@ -172,7 +172,7 @@ class TestExperimentalSparkBackend(unittest.IsolatedAsyncioTestCase):
 
       plate.get_item.return_value = well
 
-      results = await self.backend.read_absorbance_spectrum(
+      results = await self.backend.experimental_read_absorbance_spectrum(
         plate, None, wavelength_start=500, wavelength_end=550, wavelength_step=10
       )
 
@@ -182,20 +182,20 @@ class TestExperimentalSparkBackend(unittest.IsolatedAsyncioTestCase):
     self.assertEqual(results[1]["wavelength"], 510.0)
     self.assertEqual(results[1]["data"], [[0.7, 0.8]])
 
-  async def test_read_absorbance_spectrum_validation(self) -> None:
+  async def test_experimental_read_absorbance_spectrum_validation(self) -> None:
     plate = MagicMock(spec=Plate)
 
     with self.assertRaises(ValueError):
-      await self.backend.read_absorbance_spectrum(
+      await self.backend.experimental_read_absorbance_spectrum(
         plate, None, wavelength_start=550, wavelength_end=500
       )
 
     with self.assertRaises(ValueError):
-      await self.backend.read_absorbance_spectrum(
+      await self.backend.experimental_read_absorbance_spectrum(
         plate, None, wavelength_start=500, wavelength_end=550, wavelength_step=0
       )
 
-  async def test_read_fluorescence_spectrum(self) -> None:
+  async def test_experimental_read_fluorescence_spectrum(self) -> None:
     # Mock background read
     stop_event = MagicMock()
     bg_task: "asyncio.Future[None]" = asyncio.Future()
@@ -225,7 +225,7 @@ class TestExperimentalSparkBackend(unittest.IsolatedAsyncioTestCase):
 
       plate.get_item.return_value = well
 
-      results = await self.backend.read_fluorescence_spectrum(
+      results = await self.backend.experimental_read_fluorescence_spectrum(
         plate,
         [well],
         excitation_wavelength_start=440,
@@ -241,12 +241,12 @@ class TestExperimentalSparkBackend(unittest.IsolatedAsyncioTestCase):
     self.assertEqual(results[1]["ex_wavelength"], 450.0)
     self.assertEqual(results[1]["data"], [[200.0]])
 
-  async def test_read_fluorescence_spectrum_validation(self) -> None:
+  async def test_experimental_read_fluorescence_spectrum_validation(self) -> None:
     plate = MagicMock(spec=Plate)
     well = MagicMock(spec=Well)
 
     with self.assertRaises(ValueError):
-      await self.backend.read_fluorescence_spectrum(
+      await self.backend.experimental_read_fluorescence_spectrum(
         plate,
         [well],
         excitation_wavelength_start=480,
@@ -255,7 +255,7 @@ class TestExperimentalSparkBackend(unittest.IsolatedAsyncioTestCase):
       )
 
     with self.assertRaises(ValueError):
-      await self.backend.read_fluorescence_spectrum(
+      await self.backend.experimental_read_fluorescence_spectrum(
         plate,
         [well],
         excitation_wavelength_start=440,

--- a/pylabrobot/plate_reading/tecan/spark20m/spark_backend_tests.py
+++ b/pylabrobot/plate_reading/tecan/spark20m/spark_backend_tests.py
@@ -142,6 +142,128 @@ class TestExperimentalSparkBackend(unittest.IsolatedAsyncioTestCase):
     temp = await self.backend.get_average_temperature()
     self.assertIsNone(temp)
 
+  async def test_read_absorbance_spectrum(self) -> None:
+    # Mock background read
+    stop_event = MagicMock()
+    bg_task: "asyncio.Future[None]" = asyncio.Future()
+    bg_task.set_result(None)
+    self.mock_reader.start_background_read = AsyncMock(return_value=(bg_task, stop_event, []))
+
+    # Patch process_absorbance_spectrum
+    with patch(
+      "pylabrobot.plate_reading.tecan.spark20m.spark_backend.process_absorbance_spectrum"
+    ) as mock_proc:
+      mock_proc.return_value = {500.0: [[0.5, 0.6]], 510.0: [[0.7, 0.8]]}
+
+      plate = MagicMock(spec=Plate)
+      plate.num_items_x = 2
+      plate.num_items_y = 2
+      plate.get_size_y.return_value = 100
+
+      well = MagicMock(spec=Well)
+      well.parent = plate
+      well.get_row.return_value = 0
+      well.get_column.return_value = 0
+      well.location = MagicMock()
+      well.location.x = 0
+      well.location.y = 0
+      well.location.z = 0
+      well.get_anchor.return_value = MagicMock()
+
+      plate.get_item.return_value = well
+
+      results = await self.backend.read_absorbance_spectrum(
+        plate, None, wavelength_start=500, wavelength_end=550, wavelength_step=10
+      )
+
+    self.assertEqual(len(results), 2)
+    self.assertEqual(results[0]["wavelength"], 500.0)
+    self.assertEqual(results[0]["data"], [[0.5, 0.6]])
+    self.assertEqual(results[1]["wavelength"], 510.0)
+    self.assertEqual(results[1]["data"], [[0.7, 0.8]])
+
+  async def test_read_absorbance_spectrum_validation(self) -> None:
+    plate = MagicMock(spec=Plate)
+
+    with self.assertRaises(ValueError):
+      await self.backend.read_absorbance_spectrum(
+        plate, None, wavelength_start=550, wavelength_end=500
+      )
+
+    with self.assertRaises(ValueError):
+      await self.backend.read_absorbance_spectrum(
+        plate, None, wavelength_start=500, wavelength_end=550, wavelength_step=0
+      )
+
+  async def test_read_fluorescence_spectrum(self) -> None:
+    # Mock background read
+    stop_event = MagicMock()
+    bg_task: "asyncio.Future[None]" = asyncio.Future()
+    bg_task.set_result(None)
+    self.mock_reader.start_background_read = AsyncMock(return_value=(bg_task, stop_event, []))
+
+    # Patch process_fluorescence_spectrum
+    with patch(
+      "pylabrobot.plate_reading.tecan.spark20m.spark_backend.process_fluorescence_spectrum"
+    ) as mock_proc:
+      mock_proc.return_value = {440.0: [[100.0]], 450.0: [[200.0]]}
+
+      plate = MagicMock(spec=Plate)
+      plate.num_items_x = 2
+      plate.num_items_y = 2
+      plate.get_size_y.return_value = 100
+
+      well = MagicMock(spec=Well)
+      well.parent = plate
+      well.get_row.return_value = 0
+      well.get_column.return_value = 0
+      well.location = MagicMock()
+      well.location.x = 0
+      well.location.y = 0
+      well.location.z = 0
+      well.get_anchor.return_value = MagicMock()
+
+      plate.get_item.return_value = well
+
+      results = await self.backend.read_fluorescence_spectrum(
+        plate,
+        [well],
+        excitation_wavelength_start=440,
+        excitation_wavelength_end=480,
+        emission_wavelength=545,
+        excitation_wavelength_step=10,
+      )
+
+    self.assertEqual(len(results), 2)
+    self.assertEqual(results[0]["ex_wavelength"], 440.0)
+    self.assertEqual(results[0]["em_wavelength"], 545)
+    self.assertEqual(results[0]["data"], [[100.0]])
+    self.assertEqual(results[1]["ex_wavelength"], 450.0)
+    self.assertEqual(results[1]["data"], [[200.0]])
+
+  async def test_read_fluorescence_spectrum_validation(self) -> None:
+    plate = MagicMock(spec=Plate)
+    well = MagicMock(spec=Well)
+
+    with self.assertRaises(ValueError):
+      await self.backend.read_fluorescence_spectrum(
+        plate,
+        [well],
+        excitation_wavelength_start=480,
+        excitation_wavelength_end=440,
+        emission_wavelength=545,
+      )
+
+    with self.assertRaises(ValueError):
+      await self.backend.read_fluorescence_spectrum(
+        plate,
+        [well],
+        excitation_wavelength_start=440,
+        excitation_wavelength_end=480,
+        emission_wavelength=545,
+        excitation_wavelength_step=-1,
+      )
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/pylabrobot/plate_reading/tecan/spark20m/spark_processor.py
+++ b/pylabrobot/plate_reading/tecan/spark20m/spark_processor.py
@@ -42,6 +42,129 @@ def _safe_div(n: float, d: float) -> float:
   return n / d
 
 
+def _get_dark_for_wl(
+  dark_by_wl: Dict[float, Tuple[float, float]], wl: float
+) -> Tuple[float, float]:
+  """Get dark (rd, md) values for a given wavelength, falling back to closest."""
+  if wl in dark_by_wl:
+    return dark_by_wl[wl]
+  if dark_by_wl:
+    closest = min(dark_by_wl.keys(), key=lambda x: abs(x - wl))
+    return dark_by_wl[closest]
+  return (0.0, 0.0)
+
+
+def _find_key(
+  pair: Dict[str, Any], *contains: str, exclude: Optional[List[str]] = None
+) -> Optional[str]:
+  """Find a key in a dict that contains all the given substrings and excludes others."""
+  exclude = exclude or []
+  for k in pair:
+    if all(c in k for c in contains) and not any(e in k for e in exclude):
+      return k
+  return None
+
+
+def _extract_measurement_pairs(block: Dict[str, Any]) -> List[Tuple[float, List[Dict[str, Any]]]]:
+  """Extract (wavelength, pairs) from a measurement block.
+
+  Handles both nested_mult (measurements → inner_loops) and flat (rd_md_pairs) structures.
+  Returns a list of (wavelength, pairs) tuples.
+  """
+  result: List[Tuple[float, List[Dict[str, Any]]]] = []
+
+  if "measurements" in block and block["measurements"]:
+    for measurement in block["measurements"]:
+      # In nested_mult, wavelength tag is at the measurement level
+      wl_key = _find_key(measurement, "x10U16RWL") or _find_key(measurement, "x10U16MWL")
+      wl = measurement[wl_key] if wl_key is not None else 0.0
+      inner_loops = measurement.get("inner_loops", [])
+      result.append((wl, inner_loops))
+  elif "rd_md_pairs" in block:
+    # Flat structure: group pairs by wavelength
+    by_wl: Dict[float, List[Dict[str, Any]]] = {}
+    for pair in block["rd_md_pairs"]:
+      wl_key = _find_key(pair, "x10U16RWL") or _find_key(pair, "x10U16MWL")
+      wl = pair[wl_key] if wl_key is not None else 0.0
+      by_wl.setdefault(wl, []).append(pair)
+    result.extend(by_wl.items())
+
+  return result
+
+
+def _extract_fluo_calibration(
+  parsed_data: Dict[Any, Any], ref_seq_key: Any
+) -> Optional[Tuple[float, float, float]]:
+  """Extract fluorescence calibration values (signal_dark, ref_dark, k_val).
+
+  Returns None on failure.
+  """
+  cal_seq_data = parsed_data[ref_seq_key][0]
+  dark_block = cal_seq_data["blocks"][DARK_BLOCK_INDEX]
+
+  if not any("DARK" in t for t in dark_block.get("header_types", [])):
+    logger.error("Dark block does not look like Dark calibration.")
+    return None
+
+  dark_pairs = dark_block["rd_md_pairs"]
+  signal_dark_values = []
+  ref_dark_values = []
+
+  for pair in dark_pairs:
+    md_key = next((k for k in pair if "U16MD" in k), None)
+    rd_key = next((k for k in pair if "U16RD" in k), None)
+    if md_key and rd_key:
+      signal_dark_values.append(pair[md_key])
+      ref_dark_values.append(pair[rd_key])
+
+  if not signal_dark_values or not ref_dark_values:
+    logger.error("Could not extract Dark values.")
+    return None
+
+  signal_dark = statistics.mean(signal_dark_values)
+  ref_dark = statistics.mean(ref_dark_values)
+
+  # Extract bright reference values
+  ref_block = cal_seq_data["blocks"][REFERENCE_BLOCK_INDEX]
+  ref_bright_values: List[float] = []
+  for pair in ref_block["rd_md_pairs"]:
+    rd_key = next((k for k in pair if "U16RD" in k), None)
+    if rd_key:
+      ref_bright_values.append(pair[rd_key])
+
+  if not ref_bright_values:
+    logger.error("Could not extract Bright Reference values.")
+    return None
+
+  ref_bright = statistics.mean(ref_bright_values)
+
+  # Calculate K
+  denominator = UINT16_MAX - signal_dark
+  if denominator == 0:
+    logger.error("Division by zero: signal_dark equals UINT16_MAX")
+    return None
+  k_val = (ref_bright - ref_dark) / denominator * UINT16_MAX
+
+  return signal_dark, ref_dark, k_val
+
+
+def _reshape_to_rows(
+  wavelength_data: Dict[float, List[float]], num_rows: int
+) -> Dict[float, List[List[float]]]:
+  """Reshape flat wavelength→values into wavelength→rows×cols."""
+  result: Dict[float, List[List[float]]] = {}
+  for wl, values in sorted(wavelength_data.items()):
+    if num_rows > 0:
+      cols_per_row = len(values) // num_rows
+      if cols_per_row > 0:
+        result[wl] = [values[i * cols_per_row : (i + 1) * cols_per_row] for i in range(num_rows)]
+      else:
+        result[wl] = [values]
+    else:
+      result[wl] = [values]
+  return result
+
+
 def process_absorbance(raw_results: List[bytes]) -> List[List[float]]:
   empty_result: List[List[float]] = []
 
@@ -141,58 +264,12 @@ def process_fluorescence(raw_results: List[bytes]) -> List[List[float]]:
   )
 
   try:
-    # Extract dark values
-    cal_seq_data = parsed_data[ref_seq_key][0]
-    dark_block = cal_seq_data["blocks"][DARK_BLOCK_INDEX]
-
-    # Check if it has dark headers
-    if any("DARK" in t for t in dark_block.get("header_types", [])):
-      dark_pairs = dark_block["rd_md_pairs"]
-      signal_dark_values = []
-      ref_dark_values = []
-
-      for pair in dark_pairs:
-        md_key = next((k for k in pair if "U16MD" in k), None)
-        rd_key = next((k for k in pair if "U16RD" in k), None)
-        if md_key and rd_key:
-          signal_dark_values.append(pair[md_key])
-          ref_dark_values.append(pair[rd_key])
-
-      if not signal_dark_values or not ref_dark_values:
-        logger.error("Could not extract Dark values.")
-        return empty_result
-
-      signal_dark = statistics.mean(signal_dark_values)
-      ref_dark = statistics.mean(ref_dark_values)
-    else:
-      logger.error("Dark block does not look like Dark calibration.")
+    cal = _extract_fluo_calibration(parsed_data, ref_seq_key)
+    if cal is None:
       return empty_result
+    signal_dark, ref_dark, k_val = cal
 
-    # Extract bright values
-    ref_block = cal_seq_data["blocks"][REFERENCE_BLOCK_INDEX]
-    bright_pairs = ref_block["rd_md_pairs"]
-    ref_bright_values: List[float] = []
-    for pair in bright_pairs:
-      rd_key = next((k for k in pair if "U16RD" in k), None)
-      if rd_key:
-        ref_bright_values.append(pair[rd_key])
-
-    if not ref_bright_values:
-      logger.error("Could not extract Bright Reference values.")
-      return empty_result
-
-    ref_bright = statistics.mean(ref_bright_values)
-
-    # Calculate K
-    denominator = UINT16_MAX - signal_dark
-    if denominator == 0:
-      logger.error("Division by zero: signal_dark equals UINT16_MAX")
-      return empty_result
-    k_val = (ref_bright - ref_dark) / denominator * UINT16_MAX
-
-    logger.debug(
-      f"signal_dark: {signal_dark}, ref_dark: {ref_dark}, ref_bright: {ref_bright}, K: {k_val}"
-    )
+    logger.debug(f"signal_dark: {signal_dark}, ref_dark: {ref_dark}, K: {k_val}")
 
     # Calculate RFU
     final_results_list: List[List[float]] = []
@@ -231,4 +308,182 @@ def process_fluorescence(raw_results: List[bytes]) -> List[List[float]]:
 
   except Exception as e:
     logger.error(f"Error during calculation: {e}", exc_info=True)
+    return empty_result
+
+
+def process_absorbance_spectrum(raw_results: List[bytes]) -> Dict[float, List[List[float]]]:
+  """Process raw data from an absorbance spectrum scan.
+
+  In spectrum mode, each standalone measurement block contains data for multiple
+  wavelengths. The TDCL header includes ``x10U16RWL`` which tags each measurement
+  point with the reference wavelength (in tenths of nm).
+
+  Returns:
+    A dict mapping wavelength (nm) to a 2D list of OD values (rows × cols).
+    Returns an empty dict on failure.
+  """
+  empty_result: Dict[float, List[List[float]]] = {}
+
+  parsed_data = _parse_raw_data(raw_results)
+  if not parsed_data:
+    logger.warning("No valid packets found in results.")
+    return empty_result
+
+  ref_seq_key, meas_seq_keys = _identify_sequences(parsed_data)
+
+  if ref_seq_key is None or not meas_seq_keys:
+    logger.error("Could not identify Reference (grouped) and Measurement (standalone) sequences.")
+    return empty_result
+
+  try:
+    # Extract dark values from reference sequence, grouped by wavelength
+    dark_block = parsed_data[ref_seq_key][0]["blocks"][DARK_BLOCK_INDEX]
+    dark_by_wl: Dict[float, Tuple[float, float]] = {}  # wl -> (rd_dark, md_dark)
+
+    for pair in dark_block["rd_md_pairs"]:
+      wl_key = _find_key(pair, "x10U16RWL")
+      wl = pair[wl_key] if wl_key is not None else 0.0
+      rd_dark_key = _find_key(pair, "U16RD_DARK")
+      md_dark_key = _find_key(pair, "U16MD_DARK")
+      if rd_dark_key and md_dark_key:
+        dark_by_wl[wl] = (pair[rd_dark_key], pair[md_dark_key])
+
+    # Fallback: global average dark if wavelength grouping fails
+    if not dark_by_wl:
+      rd_dark_key = _find_key(dark_block["rd_md_pairs"][0], "U16RD_DARK")
+      md_dark_key = _find_key(dark_block["rd_md_pairs"][0], "U16MD_DARK")
+      if rd_dark_key and md_dark_key:
+        avg_rd = statistics.mean(p[rd_dark_key] for p in dark_block["rd_md_pairs"])
+        avg_md = statistics.mean(p[md_dark_key] for p in dark_block["rd_md_pairs"])
+        dark_by_wl[0.0] = (avg_rd, avg_md)
+
+    # Calculate per-wavelength reference ratios
+    ref_block = parsed_data[ref_seq_key][0]["blocks"][REFERENCE_BLOCK_INDEX]
+    ref_ratios: Dict[float, float] = {}
+
+    ref_pairs_by_wl: Dict[float, List[Dict[str, Any]]] = {}
+    for pair in ref_block["rd_md_pairs"]:
+      wl_key = _find_key(pair, "x10U16RWL")
+      wl = pair[wl_key] if wl_key is not None else 0.0
+      ref_pairs_by_wl.setdefault(wl, []).append(pair)
+
+    for wl, pairs in ref_pairs_by_wl.items():
+      rd_key = _find_key(pairs[0], "U16RD", exclude=["DARK", "GAIN"])
+      md_key = _find_key(pairs[0], "U16MD", exclude=["DARK", "GAIN"])
+      if rd_key and md_key:
+        avg_rd_ref = statistics.mean(p[rd_key] for p in pairs)
+        avg_md_ref = statistics.mean(p[md_key] for p in pairs)
+        rd_dark, md_dark = _get_dark_for_wl(dark_by_wl, wl)
+        ref_ratios[wl] = _safe_div(avg_md_ref - md_dark, avg_rd_ref - rd_dark)
+
+    # Process each measurement sequence
+    wavelength_data: Dict[float, List[float]] = {}
+
+    for seq_key in meas_seq_keys:
+      meas_block_entry = parsed_data[seq_key][0]
+      if meas_block_entry.get("type") != "standalone":
+        continue
+
+      block = meas_block_entry.get("block", meas_block_entry)
+      for wl, pairs in _extract_measurement_pairs(block):
+        ref_ratio = ref_ratios.get(wl)
+        if ref_ratio is None and ref_ratios:
+          closest_wl = min(ref_ratios.keys(), key=lambda x: abs(x - wl))
+          ref_ratio = ref_ratios[closest_wl]
+        if ref_ratio is None:
+          wavelength_data.setdefault(wl, []).append(float("nan"))
+          continue
+
+        rd_dark, md_dark = _get_dark_for_wl(dark_by_wl, wl)
+
+        ratios = []
+        for pair in pairs:
+          md_key = _find_key(pair, "U16MD", exclude=["DARK", "GAIN"])
+          rd_key = _find_key(pair, "U16RD", exclude=["DARK", "GAIN"])
+          if md_key and rd_key:
+            sample_ratio = _safe_div(pair[md_key] - md_dark, pair[rd_key] - rd_dark)
+            ratios.append(_safe_div(sample_ratio, ref_ratio))
+
+        valid_ratios = [r for r in ratios if not math.isnan(r)]
+        if valid_ratios:
+          avg_ratio = statistics.mean(valid_ratios)
+          od = -math.log10(avg_ratio) if avg_ratio > 0 else float("nan")
+        else:
+          od = float("nan")
+
+        wavelength_data.setdefault(wl, []).append(od)
+
+    return _reshape_to_rows(wavelength_data, len(meas_seq_keys))
+
+  except Exception as e:
+    logger.error(f"Error during absorbance spectrum calculation: {e}", exc_info=True)
+    return empty_result
+
+
+def process_fluorescence_spectrum(raw_results: List[bytes]) -> Dict[float, List[List[float]]]:
+  """Process raw data from a fluorescence excitation spectrum scan.
+
+  In spectrum mode, each standalone measurement block has a nested MULT structure
+  where the outer loop iterates over wavelength steps and the inner loop iterates
+  over reads at each wavelength. The TDCL header includes both ``x10U16MWL``
+  (measurement/excitation wavelength) and ``x10U16RWL`` (reference wavelength).
+
+  Returns:
+    A dict mapping excitation wavelength (nm) to a 2D list of RFU values (rows × cols).
+    Returns an empty dict on failure.
+  """
+  empty_result: Dict[float, List[List[float]]] = {}
+
+  parsed_data = _parse_raw_data(raw_results)
+  if not parsed_data:
+    logger.warning("No valid packets found in results.")
+    return empty_result
+
+  ref_seq_key, meas_seq_keys = _identify_sequences(parsed_data)
+
+  if ref_seq_key is None:
+    logger.error("Calibration sequence not found.")
+    return empty_result
+
+  if not meas_seq_keys:
+    logger.error("Measurement sequence not found.")
+    return empty_result
+
+  try:
+    cal = _extract_fluo_calibration(parsed_data, ref_seq_key)
+    if cal is None:
+      return empty_result
+    signal_dark, ref_dark, k_val = cal
+
+    # Process each measurement sequence
+    wavelength_data: Dict[float, List[float]] = {}
+
+    for seq_id in meas_seq_keys:
+      meas_seq_data = parsed_data[seq_id][0]
+      block = meas_seq_data.get("block", meas_seq_data)
+
+      for wl, pairs in _extract_measurement_pairs(block):
+        raw_signal_values = []
+        raw_ref_signal_values = []
+        for pair in pairs:
+          md_key = _find_key(pair, "U16MD", exclude=["DARK"])
+          rd_key = _find_key(pair, "U16RD", exclude=["DARK"])
+          if md_key and rd_key:
+            raw_signal_values.append(pair[md_key])
+            raw_ref_signal_values.append(pair[rd_key])
+
+        if not raw_signal_values or not raw_ref_signal_values:
+          wavelength_data.setdefault(wl, []).append(float("nan"))
+          continue
+
+        raw_signal = statistics.mean(raw_signal_values)
+        raw_ref_signal = statistics.mean(raw_ref_signal_values)
+
+        rfu = _safe_div(raw_signal - signal_dark, raw_ref_signal - ref_dark) * k_val
+        wavelength_data.setdefault(wl, []).append(rfu)
+
+    return _reshape_to_rows(wavelength_data, len(meas_seq_keys))
+
+  except Exception as e:
+    logger.error(f"Error during fluorescence spectrum calculation: {e}", exc_info=True)
     return empty_result

--- a/pylabrobot/plate_reading/tecan/spark20m/spark_processor_tests.py
+++ b/pylabrobot/plate_reading/tecan/spark20m/spark_processor_tests.py
@@ -8,7 +8,9 @@ import pytest
 # Configure logging to avoid pollution during tests
 from pylabrobot.plate_reading.tecan.spark20m.spark_processor import (
   process_absorbance,
+  process_absorbance_spectrum,
   process_fluorescence,
+  process_fluorescence_spectrum,
 )
 
 logging.basicConfig(level=logging.CRITICAL)
@@ -362,6 +364,144 @@ class TestProcessFluorescence(unittest.TestCase):
     assert len(proc) == len(res)
     for proc_row, res_row in zip(proc, res):
       assert proc_row == pytest.approx(res_row)
+
+
+class TestProcessAbsorbanceSpectrum(unittest.TestCase):
+  def test_process_empty_data(self) -> None:
+    with patch(
+      "pylabrobot.plate_reading.tecan.spark20m.spark_processor._parse_raw_data", return_value={}
+    ):
+      results = process_absorbance_spectrum([])
+    self.assertEqual(results, {})
+
+  def test_process_missing_reference(self) -> None:
+    parsed_data = {"SEQ_MEAS": [{"type": "standalone", "block": {"measurements": []}}]}
+    with patch(
+      "pylabrobot.plate_reading.tecan.spark20m.spark_processor._parse_raw_data",
+      return_value=parsed_data,
+    ):
+      results = process_absorbance_spectrum([])
+    self.assertEqual(results, {})
+
+  def test_process_multi_wavelength(self) -> None:
+    # Dark block with per-wavelength dark values
+    dark_pairs = [
+      {"x10U16RWL_0": 500.0, "U16RD_DARK_1": 100, "U16MD_DARK_2": 50},
+      {"x10U16RWL_0": 510.0, "U16RD_DARK_1": 100, "U16MD_DARK_2": 50},
+    ]
+
+    # Reference block with wavelength-tagged pairs
+    ref_pairs = [
+      {"x10U16RWL_0": 500.0, "U16GAIN_1": 23, "U16MGAIN_2": 11, "U16RD_3": 1000, "U16MD_4": 500},
+      {"x10U16RWL_0": 510.0, "U16GAIN_1": 23, "U16MGAIN_2": 11, "U16RD_3": 1000, "U16MD_4": 500},
+    ]
+
+    # Measurement with flat rd_md_pairs (matching hardware structure)
+    parsed_data = {
+      "SEQ_REF": [
+        {"type": "grouped", "blocks": [{"rd_md_pairs": dark_pairs}, {"rd_md_pairs": ref_pairs}]}
+      ],
+      "SEQ_MEAS": [
+        {
+          "type": "standalone",
+          "block": {
+            "rd_md_pairs": [
+              {"x10U16RWL_0": 500.0, "U16RD_1": 2000, "U16MD_2": 250},
+              {"x10U16RWL_0": 510.0, "U16RD_1": 2000, "U16MD_2": 300},
+            ]
+          },
+        }
+      ],
+    }
+
+    with patch(
+      "pylabrobot.plate_reading.tecan.spark20m.spark_processor._parse_raw_data",
+      return_value=parsed_data,
+    ):
+      results = process_absorbance_spectrum([])
+
+    # Should have two wavelengths
+    self.assertEqual(len(results), 2)
+    self.assertIn(500.0, results)
+    self.assertIn(510.0, results)
+
+    # Each wavelength should have data
+    self.assertEqual(len(results[500.0]), 1)  # 1 measurement sequence = 1 row
+    self.assertEqual(len(results[500.0][0]), 1)  # 1 well
+
+
+class TestProcessFluorescenceSpectrum(unittest.TestCase):
+  def test_process_empty_data(self) -> None:
+    with patch(
+      "pylabrobot.plate_reading.tecan.spark20m.spark_processor._parse_raw_data", return_value={}
+    ):
+      results = process_fluorescence_spectrum([])
+    self.assertEqual(results, {})
+
+  def test_process_missing_calibration(self) -> None:
+    parsed_data = {
+      "SEQ_MEAS": [
+        {"type": "standalone", "block": {"structure_type": "nested_mult", "measurements": []}}
+      ]
+    }
+    with patch(
+      "pylabrobot.plate_reading.tecan.spark20m.spark_processor._parse_raw_data",
+      return_value=parsed_data,
+    ):
+      results = process_fluorescence_spectrum([])
+    self.assertEqual(results, {})
+
+  def test_process_multi_wavelength(self) -> None:
+    # Calibration sequence
+    dark_block = {
+      "header_types": ["U16RD_DARK", "U16MD_DARK"],
+      "rd_md_pairs": [{"U16MD_DARK_1": 50, "U16RD_DARK_0": 100}],
+    }
+    bright_block = {"rd_md_pairs": [{"U16RD_0": 50000}]}
+
+    # Measurement with wavelength at measurement level (nested_mult structure).
+    # Each measurement = one wavelength, inner_loops = reads at that wavelength.
+    meas_block = {
+      "structure_type": "nested_mult",
+      "measurements": [
+        {
+          "outer_index": 0,
+          "x10U16RWL_1": 440.0,
+          "inner_loops": [
+            {"U16MD_1": 20000, "U16RD_0": 30000},
+            {"U16MD_1": 21000, "U16RD_0": 30000},
+          ],
+        },
+        {
+          "outer_index": 1,
+          "x10U16RWL_1": 450.0,
+          "inner_loops": [
+            {"U16MD_1": 22000, "U16RD_0": 30000},
+            {"U16MD_1": 23000, "U16RD_0": 30000},
+          ],
+        },
+      ],
+    }
+
+    parsed_data = {
+      "SEQ_CAL": [{"type": "grouped", "count": 2, "blocks": [dark_block, bright_block]}],
+      "SEQ_MEAS": [{"type": "standalone", "block": meas_block}],
+    }
+
+    with patch(
+      "pylabrobot.plate_reading.tecan.spark20m.spark_processor._parse_raw_data",
+      return_value=parsed_data,
+    ):
+      results = process_fluorescence_spectrum([])
+
+    # Should have two excitation wavelengths
+    self.assertEqual(len(results), 2)
+    self.assertIn(440.0, results)
+    self.assertIn(450.0, results)
+
+    # Each wavelength should have data
+    self.assertEqual(len(results[440.0]), 1)  # 1 measurement sequence = 1 row
+    self.assertEqual(len(results[440.0][0]), 1)  # 1 well
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add `read_absorbance_spectrum()` and `read_fluorescence_spectrum()` methods to `ExperimentalSparkBackend`, enabling wavelength-sweep spectral scanning on the Tecan Spark plate reader.

## Key Design Decision

The Spark firmware natively supports wavelength range sweeps via `WAVELENGTH=FROM~TO:STEP` syntax in its filter commands. This implementation leverages the native sweep rather than issuing per-wavelength commands, which is both faster and simpler.

## Changes

### `controls/optics_control.py`
- `wavelength` param type: `Optional[int]` → `Optional[Union[int, str]]` to accept firmware range strings (e.g. `'5000~5500:100'`)

### `spark_backend.py`
- Added `read_absorbance_spectrum()` and `read_fluorescence_spectrum()` public methods
- Extracted shared helpers to reduce duplication:
  - `_run_measurement()`: shared background-read → scan → cleanup orchestration
  - `_setup_absorbance()` / `_setup_fluorescence()`: shared instrument configuration

### `spark_processor.py`
- Added `process_absorbance_spectrum()` and `process_fluorescence_spectrum()` for multi-wavelength TDCL data
- Extracted shared helpers:
  - `_find_key()`: dynamic TDCL key lookup (replaces repeated `next()` patterns)
  - `_extract_measurement_pairs()`: unifies nested_mult and flat block handling
  - `_extract_fluo_calibration()`: shared dark/bright/K extraction
  - `_reshape_to_rows()`: shared wavelength→rows×cols reshaping
  - `_get_dark_for_wl()`: per-wavelength dark value lookup with fallback

### Tests
- 14 new tests covering spectrum scan methods and parameter validation
- All 25 tests pass

## Physical Hardware Validation

Tested on a physical Tecan Spark via USB/IP forwarding:

| Scan | Range | Result |
|------|-------|--------|
| Absorbance spectrum | 500–550nm, 10nm steps | 6 wavelength points, OD ≈ 0 (empty well) ✅ |
| Fluorescence spectrum | ex 440–480nm → em 545nm | 5 wavelength points, 353→213 RFU ✅ |
