### PR TITLE
Reroute `STARBackend.iswap_rotation_drive_request_z` to R0 RZ

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -10023,11 +10023,14 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     """Request iSWAP rotation-drive-bottom Z (deck coordinates), in mm.
 
     Returns the Z of the rotation drive's lowest physical point, which sits
-    13 mm above the gripper finger plane that C0 QG reports.
+    `iswap_rotation_drive_z_offset_above_finger_mm` above the gripper finger
+    plane that R0 RZ reports.
     """
     if not self.extended_conf.left_x_drive.iswap_installed:
       raise RuntimeError("iSWAP is not installed")
-    finger_plane_z = (await self.request_iswap_position()).z
+    resp = await self.send_command(module="R0", command="RZ", fmt="rz##### (n)")
+    iswap_z_pos_increments = resp["rz"][1]  # 0 = FW counter, 1 = HW counter
+    finger_plane_z = STARBackend.iswap_z_drive_increment_to_mm(iswap_z_pos_increments)
     return finger_plane_z + STARBackend.iswap_rotation_drive_z_offset_above_finger_mm
 
   async def iswap_rotation_drive_request_position(self) -> Coordinate:

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -10031,7 +10031,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     resp = await self.send_command(module="R0", command="RZ", fmt="rz##### (n)")
     iswap_z_pos_increments = resp["rz"][1]  # 0 = FW counter, 1 = HW counter
     finger_plane_z = STARBackend.iswap_z_drive_increment_to_mm(iswap_z_pos_increments)
-    return finger_plane_z + STARBackend.iswap_rotation_drive_z_offset_above_finger_mm
+    return round(finger_plane_z + STARBackend.iswap_rotation_drive_z_offset_above_finger_mm, 1)
 
   async def iswap_rotation_drive_request_position(self) -> Coordinate:
     """Position of the iSWAP rotation drive (joint 1) in deck coordinates, mm."""


### PR DESCRIPTION
`iswap_rotation_drive_request_z` now queries R0 RZ directly on the iSWAP
slave instead of going through `request_iswap_position` (C0 QG). This
matches how the sibling `iswap_rotation_drive_request_x` and
`iswap_rotation_drive_request_y` already source their values
(carriage-position arithmetic and R0 RY direct respectively).

C0 QG returns gripper xyz, but its X and Y components misreport in
certain states (e.g. PARKED, where it returns rotation-drive xy instead
of the kinematically-extended gripper xy). The Z component itself is
unaffected and the existing wrapper has always been correct. Even so,
building a public per-axis request method on top of an aggregator
command that's regularly wrong for 2 of its 3 outputs is fragile
foundation - the iSWAP request layer is better served by clean
per-axis direct-source queries with no shared failure modes.

R0 RZ returns the iSWAP's Z encoder counter (finger-plane reference).
The wrapper converts to mm via `iswap_z_drive_increment_to_mm`, adds
the 13 mm offset (`iswap_rotation_drive_z_offset_above_finger_mm`) to
land in rotation-drive-bottom-Z deck coords, and rounds to 0.1 mm to
match the physical device accuracy (already the convention of the
sibling Y reader).

Same return contract as before (deck-coord mm). Mirrors the existing
`iswap_rotation_drive_request_y`. Validated on STAR hardware: R0 RZ HW
counter * 0.01072765 mm/incr matches `request_iswap_position().z`
within ~0.03 mm in the quiescent state spot-checked (QG's 0.1 mm
reporting precision).

Part 17 of the "Tame the iSWAP" epic:
https://discuss.pylabrobot.org/t/intro-to-epic-tame-the-iswap/517

🤖 Generated with [Claude Code](https://claude.com/claude-code)
