### PR TITLE
Refactor `STARBackend.move_iswap_y` for smooth motion

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -9918,8 +9918,24 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
         `speed`, `acceleration_level`, or `current_protection_limiter` is
         outside its valid range.
     """
-    current_gripper_y = (await self.iswap_request_pose()).location.y
-    current_rotation_drive_y = await self.iswap_rotation_drive_request_y()
+    # Read the full joint state once so the current rotation-drive Y and the
+    # FK-derived current gripper Y come from the same snapshot - avoids the
+    # redundant R0 RY read and any race window between the two values.
+    joints = {
+      STARBackend.iSWAPAxis(k): v for k, v in (await self.iswap_request_joint_state()).items()
+    }
+    current_rotation_drive_y = joints[STARBackend.iSWAPAxis.Y]
+    current_gripper_y = STARBackend._iswap_fk(
+      joints=joints,
+      link_1_length=self.iswap_information.link_1_length,
+      link_2_length=self.iswap_information.link_2_length,
+      wrist_straight_angle=STARBackend._iswap_wrist_drive_increments_to_angle(
+        self.iswap_information.wrist_drive_predefined_increments[
+          STARBackend.WristDriveOrientation.STRAIGHT
+        ]
+      ),
+    ).location.y
+
     await self.iswap_rotation_drive_move_y(
       y=current_rotation_drive_y + (y_position - current_gripper_y),
       speed=speed,

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -9918,24 +9918,8 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
         `speed`, `acceleration_level`, or `current_protection_limiter` is
         outside its valid range.
     """
-    # Read the full joint state once so the current rotation-drive Y and the
-    # FK-derived current gripper Y come from the same snapshot - avoids the
-    # redundant R0 RY read and any race window between the two values.
-    joints = {
-      STARBackend.iSWAPAxis(k): v for k, v in (await self.iswap_request_joint_state()).items()
-    }
-    current_rotation_drive_y = joints[STARBackend.iSWAPAxis.Y]
-    current_gripper_y = STARBackend._iswap_fk(
-      joints=joints,
-      link_1_length=self.iswap_information.link_1_length,
-      link_2_length=self.iswap_information.link_2_length,
-      wrist_straight_angle=STARBackend._iswap_wrist_drive_increments_to_angle(
-        self.iswap_information.wrist_drive_predefined_increments[
-          STARBackend.WristDriveOrientation.STRAIGHT
-        ]
-      ),
-    ).location.y
-
+    current_gripper_y = (await self.iswap_request_pose()).location.y
+    current_rotation_drive_y = await self.iswap_rotation_drive_request_y()
     target_rotation_drive_y = current_rotation_drive_y + (y_position - current_gripper_y)
     try:
       await self.iswap_rotation_drive_move_y(

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -9875,7 +9875,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       module="C0", command="GZ", gz=str(round(abs(step_size) * 10)).zfill(3), zd=direction
     )
 
-  async def move_iswap_x(self, x_position: float):
+  async def move_iswap_x(self, x_position: float):  # TODO: by convention should be just 'x' in v1
     """Move iSWAP X to absolute position"""
     loc = await self.request_iswap_position()
     await self.move_iswap_x_relative(
@@ -9883,15 +9883,49 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       allow_splitting=True,
     )
 
-  async def move_iswap_y(self, y_position: float):
-    """Move iSWAP Y to absolute position"""
-    loc = await self.request_iswap_position()
-    await self.move_iswap_y_relative(
-      step_size=y_position - loc.y,
-      allow_splitting=True,
+  async def move_iswap_y(
+    self,
+    y_position: float,  # TODO: by convention should be just 'y' in v1
+    speed: float = 220.0,
+    acceleration_level: int = 2,
+    current_protection_limiter: int = 7,
+    make_space: bool = False,
+  ):
+    """Move the iSWAP gripper center to absolute Y position (deck coordinates).
+
+    The rotation drive Y carriage and the gripper translate rigidly together
+    in Y, so the gripper-Y delta equals the rotation-drive-Y delta. Read the
+    current gripper Y from FK, translate the rotation drive by the delta,
+    and the gripper lands at `y_position` via a single smooth `R0 YA` move.
+
+    Args:
+      y_position [mm]: target gripper Y in deck coordinates.
+      speed [mm/sec]: max linear velocity.
+      acceleration_level: acceleration index, 1 or 2.
+      current_protection_limiter: motor current limit, 0..7.
+      make_space: if True, reposition pipetting channels when channel 0 is
+        in the way and can be cleared. If False, raise so the caller decides.
+
+    Raises:
+      RuntimeError: if iSWAP is not installed, or if `setup()` has not
+        populated `iswap_information`.
+      ValueError: if `y_position` is outside the Y hardware range; if the
+        target requires channel 0 to be moved and `make_space=False`; if
+        the move is unreachable even with channel repositioning; or if
+        `speed`, `acceleration_level`, or `current_protection_limiter` is
+        outside its valid range.
+    """
+    current_gripper_y = (await self.iswap_request_pose()).location.y
+    current_rotation_drive_y = await self.iswap_rotation_drive_request_y()
+    await self.iswap_rotation_drive_move_y(
+      y=current_rotation_drive_y + (y_position - current_gripper_y),
+      speed=speed,
+      acceleration_level=acceleration_level,
+      current_protection_limiter=current_protection_limiter,
+      make_space=make_space,
     )
 
-  async def move_iswap_z(self, z_position: float):
+  async def move_iswap_z(self, z_position: float):  # TODO: by convention should be just 'z' in v1
     """Move iSWAP Z to absolute position"""
     loc = await self.request_iswap_position()
     await self.move_iswap_z_relative(

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -9936,13 +9936,20 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       ),
     ).location.y
 
-    await self.iswap_rotation_drive_move_y(
-      y=current_rotation_drive_y + (y_position - current_gripper_y),
-      speed=speed,
-      acceleration_level=acceleration_level,
-      current_protection_limiter=current_protection_limiter,
-      make_space=make_space,
-    )
+    target_rotation_drive_y = current_rotation_drive_y + (y_position - current_gripper_y)
+    try:
+      await self.iswap_rotation_drive_move_y(
+        y=target_rotation_drive_y,
+        speed=speed,
+        acceleration_level=acceleration_level,
+        current_protection_limiter=current_protection_limiter,
+        make_space=make_space,
+      )
+    except ValueError as e:
+      raise ValueError(
+        f"move_iswap_y(y_position={y_position}) resolved to rotation drive "
+        f"target y={target_rotation_drive_y:.2f}: {e}"
+      ) from e
 
   async def move_iswap_z(self, z_position: float):  # TODO: by convention should be just 'z' in v1
     """Move iSWAP Z to absolute position"""

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -9899,8 +9899,11 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     and the gripper lands at `y_position` via a single smooth `R0 YA` move.
 
     Args:
-      y_position [mm]: target gripper Y in deck coordinates.
-      speed [mm/sec]: max linear velocity.
+      y_position [mm]: target gripper Y in deck coordinates. The achievable
+        range depends on channel configuration and current arm pose; in
+        unobstructed conditions the absolute envelope is approximately
+        -270..+648 mm at factory link lengths.
+      speed [mm/sec]: max linear velocity, 2.4..370.
       acceleration_level: acceleration index, 1 or 2.
       current_protection_limiter: motor current limit, 0..7.
       make_space: if True, reposition pipetting channels when channel 0 is

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_chatterbox.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_chatterbox.py
@@ -318,7 +318,14 @@ class STARChatterboxBackend(STARBackend):
   async def move_iswap_x(self, x_position: float):
     print("moving iswap x to", x_position)
 
-  async def move_iswap_y(self, y_position: float):
+  async def move_iswap_y(
+    self,
+    y_position: float,
+    speed: float = 220.0,
+    acceleration_level: int = 2,
+    current_protection_limiter: int = 7,
+    make_space: bool = False,
+  ):
     print("moving iswap y to", y_position)
 
   async def move_iswap_z(self, z_position: float):


### PR DESCRIPTION
Replaces the C0 QG read + C0 GY relative-step-with-splitting pattern with a single R0 YA absolute move via `iswap_rotation_drive_move_y`. The rotation drive Y carriage and the gripper translate rigidly together in Y, so the algorithm reads the current gripper Y from `iswap_request_pose` (FK-based, correct in all states), reads the current rotation drive Y direct from R0 RY, and issues one `iswap_rotation_drive_move_y` for `current_rotation_drive_y + (target_gripper_y - current_gripper_y)`.

Four behavioural improvements:

- **Corrects a parked-state landing bug.** From PARKED state, the previous code read the gripper Y from `request_iswap_position` (C0 QG), which actually returns the rotation drive XY (not the gripper XY). The old algorithm therefore landed the **rotation drive** at `y_position` instead of the gripper - up to ~276 mm wrong depending on arm orientation. The new path uses FK-based `iswap_request_pose`, correct in all states.
- Smooth motion. The previous path split moves > 99.9 mm into multiple GY commands, each with its own decel-and-stop in between. The new path issues one R0 YA with a single continuous motion profile.
- Caller-controllable motion parameters. `speed` (mm/sec), `acceleration_level`, `current_protection_limiter`, and `make_space` are now optional kwargs with the same defaults as `iswap_rotation_drive_move_y`. The previous path used Hamilton's firmware-internal GY defaults with no PyLabRobot-side override. Additive and non-breaking - existing positional call sites remain valid.
- Inherits the safety machinery of `iswap_rotation_drive_move_y` (Y hardware range, channel-0 collision detection with optional `make_space=True` auto-clearing, speed/accel/current-limit range checks).

Part 18 of the "Tame the iSWAP" epic:
https://discuss.pylabrobot.org/t/intro-to-epic-tame-the-iswap/517

🤖 Generated with [Claude Code](https://claude.com/claude-code)
