### PR TITLE
Expose `STARBackend.channels_request_y_positions()` (bulk read)

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -7292,8 +7292,6 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
 
   # -------------- 3.5.7 PIP query --------------
 
-  # TODO:(command:RY): Request Y-Positions of all pipetting channels
-
   async def request_x_pos_channel_n(self, pipetting_channel_index: int = 0) -> float:
     """Request X-Position of Pipetting channel n (in mm)"""
 
@@ -7324,6 +7322,18 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     )
     # Extract y-coordinate and convert to mm
     return float(y_pos_query["rb"] / 10)
+
+  async def channels_request_y_positions(self) -> List[float]:
+    """Request the Y-positions of all pipetting channels in one command.
+
+    One firmware round-trip for the whole column, versus a `request_y_pos_channel_n`
+    call per channel.
+
+    Returns:
+      Y-position (mm) per channel, ordered by channel index (0 = backmost).
+    """
+    resp = await self.send_command(module="C0", command="RY", fmt="ry#### (n)")
+    return [v / 10 for v in cast(List[int], resp["ry"])]
 
   # TODO:(command:RZ): Request Z-Positions of all pipetting channels
 

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -7326,9 +7326,6 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
   async def channels_request_y_positions(self) -> List[float]:
     """Request the Y-positions of all pipetting channels in one command.
 
-    One firmware round-trip for the whole column, versus a `request_y_pos_channel_n`
-    call per channel.
-
     Returns:
       Y-position (mm) per channel, ordered by channel index (0 = backmost).
     """

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -7330,7 +7330,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       Y-position (mm) per channel, ordered by channel index (0 = backmost).
     """
     resp = await self.send_command(module="C0", command="RY", fmt="ry#### (n)")
-    return [v / 10 for v in cast(List[int], resp["ry"])]
+    return [v / 10 for v in resp["ry"]]
 
   # TODO:(command:RZ): Request Z-Positions of all pipetting channels
 


### PR DESCRIPTION
Reads every pipetting channel's Y position in one `C0 RY` firmware command, instead of a per-channel `request_y_pos_channel_n` (`C0 RB`) round-trip.

Returns `List[float]` in mm, one entry per channel, ordered by channel index (channel 0 = backmost).

Mirrors the existing all-channel readers (`request_tip_presence`, `request_pip_height_last_lld`) and the `channels_request_*` naming. Motivated by the upcoming iSWAP `move_y` channel-collision check, which needs every channel's Y in a single read rather than N round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
