### PR TITLE
Expose `STARBackend.channels_request_stop_disk_z_positions()` (bulk read)

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -7332,7 +7332,13 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     resp = await self.send_command(module="C0", command="RY", fmt="ry#### (n)")
     return [v / 10 for v in resp["ry"]]
 
-  # TODO:(command:RZ): Request Z-Positions of all pipetting channels
+  async def channels_request_stop_disk_z_positions(self) -> List[float]:
+    """Request the stop-disk Z-position of every channel, excluding any mounted tip.
+
+    Returns:
+      Stop-disk Z (mm) per channel, ordered by channel index (0 = backmost).
+    """
+    return [await self.request_probe_z_position(i) for i in range(self.num_channels)]
 
   async def request_z_pos_channel_n(self, pipetting_channel_index: int) -> float:
     warnings.warn(

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -13104,6 +13104,8 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
 
     return resp_tip_mm
 
+  # TODO(v1): rename to request_stop_disk_z_position for consistency with
+  # move_channel_stop_disk_z and channels_request_stop_disk_z_positions.
   async def request_probe_z_position(self, channel_idx: int) -> float:
     """Request the z-position of the channel probe (EXCLUDING the tip)"""
     resp = await self.send_command(


### PR DESCRIPTION
Reads every channel's stop-disk Z (the bare stop disk, excluding any mounted tip) across all channels. The stop-disk read is a per-channel-module command with no master-level equivalent, so this fans out one `request_probe_z_position` call per channel rather than a single master read.

Mirrors the existing single-channel stop-disk / tip-bottom split (`request_probe_z_position` vs `request_tip_bottom_z_position`) at the all-channel level, and follows the `channels_request_*` naming.

**Why not just wrap the firmware's `C0 RZ`?** The firmware has a one-shot all-channel reader (`C0 RZ`) that returns each channel's bottom-most Z - tip end if a tip is fitted, bare stop disk if not. It is tempting because it is a single round-trip. We deliberately do not expose it, because that tip-vs-no-tip branch is computed invisibly inside the firmware: a caller reading `channels_request_stop_disk_z_positions()` cannot tell from the call site whether a given number is a tip end or a bare stop disk, and the rule that produced it lives in firmware we do not control. That implicitness is a maintenance hazard - the meaning of the returned number silently depends on machine state, and any future change to the firmware's tip handling changes the result with no signal in our code. Reading the stop-disk Z explicitly and letting the caller branch on `request_tip_presence` keeps the tip logic legible and owned in Python, at the cost of N round-trips instead of one. For the iSWAP collision use case correctness and clarity matter more than the extra round-trips.

Motivated by the upcoming iSWAP `move_y` channel-collision check, which needs each channel's Z to decide whether it sits in the arm's swept band.

Also adds a `TODO(v1)` to rename `request_probe_z_position` to `request_stop_disk_z_position`, aligning it with `move_channel_stop_disk_z` and the new bulk reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
