### PR TITLE
Visualizer: Refresh scale bar on home button and resource focus

### DIFF
--- a/pylabrobot/visualizer/lib.js
+++ b/pylabrobot/visualizer/lib.js
@@ -128,6 +128,36 @@ function updateDeltaLinesScale() {
   resourceLayer.draw();
 }
 
+// Scale bar update: picks a round mm value that fits ~80-120px on screen.
+function updateScaleBar() {
+  if (!stage) return;
+  var scale = stage.scaleX(); // CSS pixels per mm
+  // Choose a nice round distance whose bar width falls near 100px
+  var niceSteps = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000];
+  var bestMM = niceSteps[0];
+  for (var i = 0; i < niceSteps.length; i++) {
+    if (niceSteps[i] * scale >= 60) {
+      bestMM = niceSteps[i];
+      break;
+    }
+    bestMM = niceSteps[i];
+  }
+  var barPx = bestMM * scale;
+  var barLine = document.getElementById("scale-bar-line");
+  var barLabel = document.getElementById("scale-bar-label");
+  if (barLine) barLine.style.width = barPx + "px";
+  if (barLabel) barLabel.textContent = bestMM + " mm";
+}
+
+// Call from any code path that changes stage scale or position.
+function refreshScaleOverlays() {
+  updateScaleBar();
+  updateBullseyeScale();
+  updateWrtBullseyeScale();
+  updateTooltipScale();
+  updateDeltaLinesScale();
+}
+
 function drawDeltaLines(resource) {
   if (deltaLinesGroup) { deltaLinesGroup.destroy(); deltaLinesGroup = null; }
   if (!resource || activeTool !== "coords") return;
@@ -594,11 +624,7 @@ function fitToViewport() {
   stage.x(centerX);
   stage.y(centerY);
 
-  if (typeof updateScaleBar === "function") updateScaleBar();
-  updateBullseyeScale();
-  updateWrtBullseyeScale();
-  updateTooltipScale();
-  updateDeltaLinesScale();
+  refreshScaleOverlays();
 }
 
 let trash;
@@ -2966,26 +2992,6 @@ window.addEventListener("load", function () {
 
   layer.add(background);
 
-  // Scale bar update: picks a round mm value that fits ~80-120px on screen.
-  function updateScaleBar() {
-    const scale = stage.scaleX(); // CSS pixels per mm
-    // Choose a nice round distance whose bar width falls near 100px
-    const niceSteps = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000];
-    let bestMM = niceSteps[0];
-    for (let i = 0; i < niceSteps.length; i++) {
-      if (niceSteps[i] * scale >= 60) {
-        bestMM = niceSteps[i];
-        break;
-      }
-      bestMM = niceSteps[i];
-    }
-    const barPx = bestMM * scale;
-    const barLine = document.getElementById("scale-bar-line");
-    const barLabel = document.getElementById("scale-bar-label");
-    if (barLine) barLine.style.width = barPx + "px";
-    if (barLabel) barLabel.textContent = bestMM + " mm";
-  }
-
   // Mouse wheel zoom
   const scaleBy = 1.1;
   stage.on("wheel", function (e) {
@@ -3013,11 +3019,7 @@ window.addEventListener("load", function () {
       y: pointer.y - mousePointTo.y * (-clampedScale),
     };
     stage.position(newPos);
-    updateScaleBar();
-    updateBullseyeScale();
-    updateWrtBullseyeScale();
-    updateTooltipScale();
-    updateDeltaLinesScale();
+    refreshScaleOverlays();
   });
 
   updateScaleBar();
@@ -3060,11 +3062,7 @@ window.addEventListener("load", function () {
       x: center.x - mousePointTo.x * newScale,
       y: center.y - mousePointTo.y * (-newScale),
     });
-    if (typeof updateScaleBar === "function") updateScaleBar();
-    updateBullseyeScale();
-    updateWrtBullseyeScale();
-    updateTooltipScale();
-    updateDeltaLinesScale();
+    refreshScaleOverlays();
   }
 
   var zoomInBtn = document.getElementById("zoom-in-btn");
@@ -3958,11 +3956,7 @@ function focusOnResource(resourceName) {
   stage.x(centerX);
   stage.y(centerY);
 
-  if (typeof updateScaleBar === "function") updateScaleBar();
-  updateBullseyeScale();
-  updateWrtBullseyeScale();
-  updateTooltipScale();
-  updateDeltaLinesScale();
+  refreshScaleOverlays();
   stage.batchDraw();
 
   // Also highlight the resource


### PR DESCRIPTION
Closes #898.

## Problem

When the home button is pressed, the scale bar keeps showing the previous zoom's value instead of refreshing to match the reset view. Clicking a resource to focus on it has the same latent bug. The other scale-dependent overlays (bullseye, WRT-bullseye, tooltip, delta lines) update correctly - only the scale bar is stuck.

## Root cause

`updateScaleBar` was defined inside the `window.addEventListener("load", ...)` handler, so it was closure-scoped and invisible to the top-level `fitToViewport` and `focusOnResource`. Both guarded the call with `if (typeof updateScaleBar === "function")`, which silently evaluated to false in global scope. The wheel-zoom and zoom-button paths worked because their call sites live inside the same closure. The deeper cause is that the five-updater refresh sequence was duplicated at four view-mutation sites; when `updateScaleBar` was added later, one copy was missed - and `focusOnResource` carried the same latent miss.

## Change

Hoist `updateScaleBar` to top level next to its sibling updaters, with an `if (!stage) return;` guard so pre-load callers stay silent. Drop the now-dead `typeof` checks. Extract the five-updater sequence into `refreshScaleOverlays` and route `fitToViewport`, the wheel handler, `zoomByFactor`, and `focusOnResource` through it. Any future view-mutation entry point now wires to a single helper instead of remembering five updaters.

Net: +34 / -40 in `pylabrobot/visualizer/lib.js`. No behaviour change to paths that already worked.