### PR TITLE
STARBackend: tolerate short-form VW pip-channel replies

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -1693,16 +1693,48 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
         f"(channel {channel} firmware date: {pip_fw.isoformat()})."
       )
     resp: str = await self.send_command(STARBackend.channel_id(channel), "VW")
+    return self._parse_pip_channel_information(resp)
+
+  @staticmethod
+  def _parse_pip_channel_information(resp: str) -> PipChannelInformation:
+    """Parse a VW (pip channel hardware-configuration) firmware response.
+
+    The number of fields in a VW reply varies by firmware. The full form is
+    4 fields (channel_type, head_type, stop_disc_type, pressure_adc), but some
+    firmwares -- including post-2016 ones that pass the year gate in
+    `_pip_channel_request_configuration` -- return a 2-field short form such as
+    ``vw0 0``. Missing trailing fields fall back to their baseline ("code 0")
+    value rather than raising, since the cached information is descriptive
+    metadata and is not consulted by pipetting logic. This is distinct from the
+    firmware-year gate in `_pip_channel_request_configuration`, which decides
+    whether VW is queried at all.
+
+    Behavior for fields that ARE present is identical to the historical parser;
+    only absent fields are newly defaulted. A reply with zero fields is treated
+    as a malformed/communication failure and raises, so it is distinguishable
+    from a known short layout.
+
+    Args:
+      resp: Raw VW firmware response (e.g. ``"P1VWid0001vw0 0"``).
+
+    Returns:
+      Parsed `PipChannelInformation`.
+
+    Raises:
+      ValueError: If the response contains no hardware-configuration fields.
+    """
     hw_tokens = resp.split("vw")[-1].strip().split()
+    if not hw_tokens:
+      raise ValueError(f"Unparsable VW (pip channel configuration) response: {resp!r}")
+
+    def tok(i: int) -> Optional[str]:
+      return hw_tokens[i] if i < len(hw_tokens) else None
+
     return PipChannelInformation(
-      channel_type="ML_STAR_RPC" if hw_tokens[0] == "1" else "ML_STAR",
-      head_type="ML_STAR_PLE"
-      if hw_tokens[1] == "1"
-      else "ML_STAR_RPC"
-      if hw_tokens[1] == "2"
-      else "ML_STAR",
-      stop_disc_type="core_i" if hw_tokens[2] == "0" else "core_ii",
-      pressure_adc="Analog_Devices_AD5263" if hw_tokens[3] == "1" else "Renesas_X9268",
+      channel_type="ML_STAR_RPC" if tok(0) == "1" else "ML_STAR",
+      head_type="ML_STAR_PLE" if tok(1) == "1" else "ML_STAR_RPC" if tok(1) == "2" else "ML_STAR",
+      stop_disc_type="core_i" if tok(2) in ("0", None) else "core_ii",
+      pressure_adc="Analog_Devices_AD5263" if tok(3) == "1" else "Renesas_X9268",
     )
 
   def get_id_from_fw_response(self, resp: str) -> Optional[int]:

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
@@ -37,6 +37,7 @@ from .STAR_backend import (
   CommandSyntaxError,
   HamiltonNoTipError,
   HardwareError,
+  PipChannelInformation,
   STARBackend,
   STARFirmwareError,
   UnknownHamiltonError,
@@ -150,6 +151,88 @@ def _any_write_and_read_command_call(cmd):
     read_timeout=unittest.mock.ANY,
     wait=unittest.mock.ANY,
   )
+
+
+class TestPipChannelInformationParsing(unittest.TestCase):
+  """VW (pip channel hardware-configuration) response parsing.
+
+  Regression coverage for the IndexError on short-form VW replies
+  (e.g. ``vw0 0``) returned by some post-2016 firmwares.
+  """
+
+  def test_short_form_two_fields_does_not_raise(self):
+    """Short 2-field reply (the captured `vw0 0`) should parse to baseline defaults, not raise."""
+    result = STARBackend._parse_pip_channel_information("P1VWid0001vw0 0")
+    self.assertEqual(
+      result,
+      PipChannelInformation(
+        channel_type="ML_STAR",
+        head_type="ML_STAR",
+        stop_disc_type="core_i",
+        pressure_adc="Renesas_X9268",
+      ),
+    )
+
+  def test_full_form_four_fields(self):
+    """Full 4-field reply should parse each non-baseline code to its mapped value."""
+    result = STARBackend._parse_pip_channel_information("P1VWid0001vw1 1 1 1")
+    self.assertEqual(
+      result,
+      PipChannelInformation(
+        channel_type="ML_STAR_RPC",
+        head_type="ML_STAR_PLE",
+        stop_disc_type="core_ii",
+        pressure_adc="Analog_Devices_AD5263",
+      ),
+    )
+
+  def test_head_type_code_two_maps_to_rpc(self):
+    """head_type code `2` should map to ML_STAR_RPC (the otherwise-uncovered branch)."""
+    result = STARBackend._parse_pip_channel_information("P1VWid0001vw0 2 0 0")
+    self.assertEqual(result.head_type, "ML_STAR_RPC")
+
+  def test_three_fields_defaults_only_the_missing_trailing_field(self):
+    """Present tokens should be honored; only the absent trailing field should default.
+
+    stop_disc_type is present (-> core_ii); pressure_adc is absent (-> default Renesas).
+    """
+    result = STARBackend._parse_pip_channel_information("P1VWid0001vw1 1 1")
+    self.assertEqual(
+      result,
+      PipChannelInformation(
+        channel_type="ML_STAR_RPC",
+        head_type="ML_STAR_PLE",
+        stop_disc_type="core_ii",
+        pressure_adc="Renesas_X9268",
+      ),
+    )
+
+  def test_empty_field_list_raises_value_error(self):
+    """Zero fields should raise ValueError -- a malformed reply, distinct from a known short form."""
+    with self.assertRaises(ValueError):
+      STARBackend._parse_pip_channel_information("P1VWid0001vw")
+
+  def test_full_form_parity_across_all_combinations(self):
+    """Every 4-field reply should parse identically to the historical logic.
+
+    Only absent fields are newly defaulted; present fields are unchanged. `legacy`
+    below is the genuine pre-fix implementation, so this is a real parity oracle.
+    """
+    import itertools
+
+    def legacy(resp: str) -> PipChannelInformation:
+      hw = resp.split("vw")[-1].strip().split()
+      return PipChannelInformation(
+        channel_type="ML_STAR_RPC" if hw[0] == "1" else "ML_STAR",
+        head_type="ML_STAR_PLE" if hw[1] == "1" else "ML_STAR_RPC" if hw[1] == "2" else "ML_STAR",
+        stop_disc_type="core_i" if hw[2] == "0" else "core_ii",
+        pressure_adc="Analog_Devices_AD5263" if hw[3] == "1" else "Renesas_X9268",
+      )
+
+    for a, b, c, d in itertools.product(["0", "1", "2"], repeat=4):
+      resp = f"P1VWid0001vw{a} {b} {c} {d}"
+      with self.subTest(resp=resp):
+        self.assertEqual(STARBackend._parse_pip_channel_information(resp), legacy(resp))
 
 
 class TestiSWAPForwardKinematics(unittest.TestCase):


### PR DESCRIPTION
`STARBackend.setup()` can raise `IndexError: list index out of range` while parsing the per-channel `VW` (pip-channel hardware-configuration) reply: the parser assumes a fixed 4-field response and indexes the tokens directly, but some firmwares return a 2-field short form (`vw0 0`). The existing firmware-year gate does not catch this: it only skips `VW` on firmware from 2016 or older (which lacks `VW` entirely), whereas the affected machine is newer than 2016, passes the gate, and answers `VW` with the short layout. The gate guards a different failure; field-count tolerance is the missing piece. This makes parsing length-tolerant while leaving full 4-field replies unchanged.

## Root cause
The `VW` reply length varies by firmware. The four fields (channel type, head type, stop-disc type, pressure-sensor ADC) were added incrementally: `VW` originally returned only the first two, and the stop-disc-type field was not needed until CO-RE II appeared (around 2020) to distinguish it from CO-RE I; the firmware added that third field roughly four years after `VW` was introduced. Firmware from that window legitimately answers with two fields, so a short reply is expected rather than malformed. The parser hard-coded the 4-field assumption with direct indexing.

## The fix
Two changes, both in `STAR_backend.py`:

Extract parsing into a pure `_parse_pip_channel_information` staticmethod; `_pip_channel_request_configuration` keeps the year gate and `send_command`, then delegates. This makes parsing unit-testable with no event loop or mocking.

Read tokens through a bounds-safe helper. Missing trailing fields fall back to their baseline ("code 0") value; a zero-field reply raises `ValueError` instead of an opaque `IndexError`.

## Compatibility
Present fields parse identically to before. `stop_disc_type` uses `tok(2) in ("0", None)` so any present token matches the old `== "0"` result; only the absent case is new. A parity test confirms the new parser matches the historical logic across every combination of the documented field codes.

Defaulting an absent field is safe because `PipChannelInformation` is descriptive metadata cached at setup and never consulted by pipetting logic, so it cannot affect aspiration, dispense, or motion. The baseline values are also the older hardware variants those fields were introduced to distinguish, so a firmware too old to report a field is the baseline case by construction.

## Tests
A new `TestPipChannelInformationParsing` class covers: the captured short form `vw0 0` parsing to defaults instead of raising; a full 4-field reply; the RPC head-type code (otherwise-uncovered branch); a 3-field reply (only the absent trailing field defaulted); a zero-field reply raising `ValueError`; and parity with the historical parser across every combination of the documented field codes.

## Risk
Low: one extracted method plus a length guard, no public API change, full-form parsing provably unchanged. Validated on hardware returning the full 4-field form (parser output identical to prior behavior) and by the short-form and empty-case unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

