### PR TITLE
Gate all pip-channel queries behind `STARBackend.setup(skip_pip=True)`

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -1904,7 +1904,11 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     self._num_channels = len(tip_presences)
 
     async def set_up_pip():
-      if (not initialized or any(tip_presences)) and not skip_pip:
+      if skip_pip:
+        # Skip pip-channel I/O; the __init__ defaults stand in.
+        # TODO: does not yet gate request_tip_presence or instrument-init moves.
+        return
+      if not initialized or any(tip_presences):
         await self.initialize_pip()
       self._channels_minimum_y_spacing = await self.channels_request_y_minimum_spacing()
 


### PR DESCRIPTION
`STARBackend.setup()` accepts `skip_pip=True` to bypass pipetting-channel work, but it only gated `initialize_pip()`. The two queries that follow in `set_up_pip` ran unconditionally:

- `channels_request_y_minimum_spacing()`
- the per-channel VW (hardware-configuration) loop, `_pip_channel_request_configuration` for every channel

So a caller passing `skip_pip=True` still issued pip-channel firmware commands during setup, which is the opposite of what the flag promises.

This moves both queries behind an early return on `skip_pip`. When skipped, the defaults already set in `__init__` take over: `_channels_minimum_y_spacing = [9.0] * 8` and `_pip_channel_information = None`. Behavior for `skip_pip=False` is unchanged.

A TODO notes the remaining non-goal: `skip_pip` still does not gate `request_tip_presence()` (which runs earlier to count channels) or the instrument-initialization channel moves. Making `skip_pip` bypass every channel-touching command in setup is a larger semantic change left for a follow-up.

## Verification

Instrumented `setup()` with the pip-channel methods mocked to count calls:

- `skip_pip=False`: 11 pip-channel calls (1 initialize + 1 y-spacing + 1 channel-version + 8 VW).
- `skip_pip=True`: 0 pip-channel calls.

`pytest pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py` - 88 passed, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)