### PR TITLE
Populate STAR autoload (`I0`) error trace table

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -882,7 +882,34 @@ def trace_information_to_string(module_identifier: str, trace_information: int) 
       53: "Robotic channel task busy",
     }
   elif module_identifier == "I0":  # autoload
-    table = {36: "Hamilton will not run while the hood is open"}
+    table = {
+      0: "No error",
+      20: "No communication to EEPROM",
+      30: "Unknown command",
+      31: "Unknown parameter",
+      32: "Parameter out of range",
+      35: "Voltages outside permitted range",
+      # generic firmware meaning of 36 is "Stop during execution of command"
+      36: "Hamilton will not run while the hood is open",
+      40: "No parallel processes permitted",
+      50: "Scanner X-drive: init position not found",
+      51: "Scanner X-drive: stepper motor not initialized",
+      52: "Scanner X-drive: movement error (step loss)",
+      55: "Scanner rotation drive: drive blocked",
+      60: "Carrier Y-drive: init position not found",
+      61: "Carrier Y-drive: stepper motor not initialized",
+      62: "Carrier Y-drive: movement error (step loss)",
+      65: "Carrier Z-drive: init position not found",
+      66: "Carrier Z-drive: stepper motor not initialized",
+      67: "Carrier Z-drive: movement error (step loss)",
+      70: "Barcode scanner: communication error",
+      75: "Loading indicator (LED): communication error",
+      80: "Identification barcode not readable",
+      81: "No carrier present",
+      82: "No carrier loaded",
+      83: "Loading tray is occupied",
+      84: "Data for free definable carrier not correct",
+    }
   elif module_identifier in [
     "PX",
     "P1",


### PR DESCRIPTION
The autoload (`I0`) trace-information table in `trace_information_to_string` mapped only a single code (36), so every other autoload firmware error surfaced to the user as the opaque `Unknown trace information code <n>`.

This surfaced from a real failure during `initialize_autoload()`, where the machine returned `I002/50`: a `HardwareError` with trace code 50. Code 50 is the autoload scanner X-drive failing to find its initialization position, but pylabrobot had no string for it, so the only diagnostic was `Unknown trace information code 50`.

This PR fills in the full autoload trace table - per-sub-drive init / not-initialized / movement-error codes, plus the barcode-scanner, loading-indicator (LED), and carrier-handling codes - so these failures report what actually went wrong.

The existing code 36 description ("Hamilton will not run while the hood is open") is kept unchanged, since it reflects the real-world cause it was originally reported for, with a comment noting the generic firmware meaning ("Stop during execution of command").

The change is additive and localized to the `I0` branch. Dispatch is keyed by module identifier, so these codes do not collide with the identically-numbered C0 (master) or R0 (iSWAP) codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)