### PR TITLE
Populate STAR CoRe 96 head (`H0`) error trace table

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -1007,6 +1007,9 @@ def trace_information_to_string(module_identifier: str, trace_information: int) 
       96: "Limit curve already stored",
     }
   elif module_identifier == "R0":  # iswap
+    # These messages are iSWAP-specific. The internal plate gripper (IPG) also
+    # reports as module R0 but numbers its drives differently, so for an IPG the
+    # codes from 55 up map to different drives than the ones listed here.
     table = {
       20: "No communication to EEPROM",
       30: "Unknown command",

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -958,7 +958,14 @@ def trace_information_to_string(module_identifier: str, trace_information: int) 
     }
   elif module_identifier == "H0":  # Core 96 head
     table = {
+      0: "No error",
       20: "No communication to EEPROM",
+      # 21 is the current-firmware transfer-check error; older firmware reports 20
+      21: "No communication to digital potentiometer",
+      25: "Flash EPROM data incorrect",
+      26: "Flash EPROM cannot be programmed",
+      27: "Flash EPROM cannot be erased",
+      28: "Flash EPROM checksum error",
       30: "Unknown command",
       31: "Unknown parameter",
       32: "Parameter out of range",
@@ -988,6 +995,16 @@ def trace_information_to_string(module_identifier: str, trace_information: int) 
       75: "No tip picked up",
       76: "Tip already picked up",
       81: "Clot detected",
+      82: "TADM measurement out of lower limit curve",
+      83: "TADM measurement out of upper limit curve",
+      84: "Not enough memory for TADM measurement",
+      90: "Limit curve not resettable",
+      91: "Limit curve not programmable",
+      92: "Limit curve not found",
+      93: "Limit curve data incorrect",
+      94: "Not enough memory for limit curve",
+      95: "Invalid limit curve index",
+      96: "Limit curve already stored",
     }
   elif module_identifier == "R0":  # iswap
     table = {


### PR DESCRIPTION
The CoRe 96 head (`H0`) trace-information table in `trace_information_to_string` stopped at code 81, so a range of real firmware errors surfaced to the user as the opaque `Unknown trace information code <n>`: the firmware-download / Flash-EPROM errors (`25-28`), the TADM-measurement errors (`82-84`), and the limit-curve errors (`90-96`).

This PR adds the missing codes from the 96-head command set so these failures report what actually went wrong. The shared TADM and limit-curve entries reuse the exact wording already present in the pipetting-channel (`PX`) table, so the two tables stay consistent.

The existing code `20` ("No communication to EEPROM") is kept - it is the transfer-check error reported by older 96-head firmware - and `21` ("No communication to digital potentiometer") is added as its current-firmware equivalent, with a comment noting the distinction.

The change is additive and localized to the `H0` branch. Dispatch is keyed by module identifier, so these codes do not collide with the identically-numbered codes in the C0 (master), I0 (autoload), or R0 (iSWAP) tables.

Also adds a one-line comment on the adjacent R0 (iSWAP) table noting those codes are iSWAP-specific and do not apply to the internal plate gripper, which shares the R0 module identifier but numbers its drives differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)