### PR TITLE
`STARBackend`: direct X-drive `head96_move_x` via EEPROM X-offset (per-axis motion control)

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -5577,9 +5577,6 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     generic master-EEPROM read RA - mirroring the iSWAP rotation-drive x-offset (`kg`).
     Required for deriving the head's X-arm carriage X from a target A1 X. Cached on the
     backend as `head96_information.x_offset` during setup.
-
-    NOTE: `kf` is the working hypothesis (sibling of the iSWAP `kg`, matching the AF/AG
-    setter pair); verify against the master EEPROM before relying on it.
     """
     if not self.extended_conf.left_x_drive.core_96_head_installed:
       raise RuntimeError("96-head is not installed")
@@ -7923,23 +7920,6 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     return await self.send_command(module="H0", command="MO")
 
   @_requires_head96
-  async def head96_move_x_OLD(self, x: float):
-    """Deprecated EM-based X move, kept only for A/B verification against head96_move_x.
-
-    Moves all axes together via the EM/coordinate command, after a position round-trip, so
-    it exposes no per-axis motion control. Slated for deletion once the direct-drive
-    head96_move_x is validated on hardware.
-
-    Args:
-      x: Target X coordinate in mm. Valid range: [-271.0, 974.0]
-    """
-    current_pos = await self.head96_request_position()
-    return await self.head96_move_to_coordinate(
-      Coordinate(x, current_pos.y, current_pos.z),
-      minimum_height_at_beginning_of_a_command=current_pos.z - 10,
-    )
-
-  @_requires_head96
   async def head96_move_x(
     self,
     x: float,
@@ -7952,8 +7932,8 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     ``x``: A1 sits left of (below) the carriage center, so deck-A1 = carriage - offset and the
     carriage target is therefore ``x + offset`` (inverse of the iSWAP rotation-drive derivation,
     ``iswap_rotation_drive_request_x``).
-    Unlike the EM-based ``head96_move_x_OLD`` (all axes together, no motion control), this is
-    the single-axis X-arm drive command and exposes acceleration and current control, like
+    Unlike the legacy EM coordinate move (all axes together, no per-axis motion control), this
+    is the single-axis X-arm drive command and exposes acceleration and current control, like
     ``head96_move_y`` / ``head96_move_z``.
 
     Args:
@@ -10107,17 +10087,6 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
 
     return await self.send_command(
       module="C0", command="GZ", gz=str(round(abs(step_size) * 10)).zfill(3), zd=direction
-    )
-
-  async def move_iswap_x_OLD(self, x_position: float):
-    """Deprecated pre-smooth-motion iSWAP X move (pre #1053), kept only for A/B verification
-    against move_iswap_x. Queries the position then steps X relative by the delta (with
-    splitting). Slated for deletion once the refactored move_iswap_x is validated on hardware.
-    """
-    loc = await self.request_iswap_position()
-    await self.move_iswap_x_relative(
-      step_size=x_position - loc.x,
-      allow_splitting=True,
     )
 
   async def move_iswap_x(

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -1394,6 +1394,9 @@ class Head96Information:
   HeadType = Literal["Low volume head", "High volume head", "96 head II", "96 head TADM", "unknown"]
 
   fw_version: datetime.date
+  x_offset: float
+  """Deck X distance from the X-arm carriage center to head channel A1 (mm), read from
+  master EEPROM at setup. Mirrors iSWAPInformation.rotation_drive_x_offset."""
   supports_clot_monitoring_clld: bool
   stop_disc_type: StopDiscType
   instrument_type: InstrumentType
@@ -2060,6 +2063,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
 
         self._head96_information = Head96Information(
           fw_version=fw_version,
+          x_offset=await self._head96_request_x_offset(),
           supports_clot_monitoring_clld=bool(int(configuration_96head[0])),
           stop_disc_type="core_i" if configuration_96head[1] == "0" else "core_ii",
           instrument_type="legacy" if configuration_96head[2] == "0" else "FM-STAR",
@@ -5566,6 +5570,22 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
 
     return await self.send_command(module="C0", command="AF", x_offset=x_offset)
 
+  async def _head96_request_x_offset(self) -> float:
+    """Read the X-offset i.e. X-arm carriage center <-> CoRe 96 head channel A1, in mm.
+
+    Stored in the master EEPROM as parameter `kf` (set via the AF command), read with the
+    generic master-EEPROM read RA - mirroring the iSWAP rotation-drive x-offset (`kg`).
+    Required for deriving the head's X-arm carriage X from a target A1 X. Cached on the
+    backend as `head96_information.x_offset` during setup.
+
+    NOTE: `kf` is the working hypothesis (sibling of the iSWAP `kg`, matching the AF/AG
+    setter pair); verify against the master EEPROM before relying on it.
+    """
+    if not self.extended_conf.left_x_drive.core_96_head_installed:
+      raise RuntimeError("96-head is not installed")
+    resp = await self.send_command(module="C0", command="RA", ra="kf", fmt="kf###")
+    return cast(int, resp["kf"]) / 10.0
+
   async def set_x_offset_x_axis_core_nano_pipettor_head(self, x_offset: int):
     """Set X-offset X-axis <-> CoRe 96 head
 
@@ -7901,26 +7921,56 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     return await self.send_command(module="H0", command="MO")
 
   @_requires_head96
-  async def head96_move_x(self, x: float):
-    """Move the 96-head to a specified X-axis coordinate.
+  async def head96_move_x_OLD(self, x: float):
+    """Deprecated EM-based X move, kept only for A/B verification against head96_move_x.
 
-    Note: Unlike head96_move_y and head96_move_z, the X-axis movement does not have
-    dedicated speed/acceleration parameters - it uses the EM command which moves
-    all axes together.
+    Moves all axes together via the EM/coordinate command, after a position round-trip, so
+    it exposes no per-axis motion control. Slated for deletion once the direct-drive
+    head96_move_x is validated on hardware.
 
     Args:
       x: Target X coordinate in mm. Valid range: [-271.0, 974.0]
-
-    Returns:
-      Response from the hardware command.
-
-    Raises:
-      RuntimeError: If 96-head is not installed.
     """
     current_pos = await self.head96_request_position()
     return await self.head96_move_to_coordinate(
       Coordinate(x, current_pos.y, current_pos.z),
       minimum_height_at_beginning_of_a_command=current_pos.z - 10,
+    )
+
+  @_requires_head96
+  async def head96_move_x(
+    self,
+    x: float,
+    acceleration_level: int = 3,
+    current_protection_limiter: int = 7,
+  ):
+    """Move the 96-head to a target channel-A1 X coordinate via the direct X-arm drive.
+
+    Drives the X-arm carriage to ``x - head96_information.x_offset`` so channel A1 lands at
+    ``x``, mirroring how the iSWAP derives its rotation-drive X from the carriage center.
+    Unlike the EM-based ``head96_move_x_OLD`` (all axes together, no motion control), this is
+    the single-axis X-arm drive command and exposes acceleration and current control, like
+    ``head96_move_y`` / ``head96_move_z``.
+
+    Args:
+      x: Target A1 X coordinate in mm. Valid range [x_min, 974.0]; x_min is 0.0 with a left
+        side panel installed, else -271.0.
+      acceleration_level: X-arm acceleration index (1-5). Default 3.
+      current_protection_limiter: X-arm motor current limit (0-7). Default 7.
+
+    Raises:
+      RuntimeError: If the 96-head is not installed.
+      ValueError: If the target A1 X is outside the legal 96-head X range.
+    """
+    x_min = self.HEAD96_X_MIN_WITH_LEFT_SIDE_PANEL if self.left_side_panel_installed else -271.0
+    if not (x_min <= x <= 974.0):
+      raise ValueError(f"96-head A1 x={x} out of range [{x_min}, 974.0]")
+    assert self._head96_information is not None, "96-head information not loaded; run setup()"
+    carriage_x = x - self._head96_information.x_offset
+    return await self.experimental_x_arm_move(
+      carriage_x,
+      acceleration_level=acceleration_level,
+      current_protection_limiter=current_protection_limiter,
     )
 
   @_requires_head96
@@ -10053,6 +10103,17 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
 
     return await self.send_command(
       module="C0", command="GZ", gz=str(round(abs(step_size) * 10)).zfill(3), zd=direction
+    )
+
+  async def move_iswap_x_OLD(self, x_position: float):
+    """Deprecated pre-smooth-motion iSWAP X move (pre #1053), kept only for A/B verification
+    against move_iswap_x. Queries the position then steps X relative by the delta (with
+    splitting). Slated for deletion once the refactored move_iswap_x is validated on hardware.
+    """
+    loc = await self.request_iswap_position()
+    await self.move_iswap_x_relative(
+      step_size=x_position - loc.x,
+      allow_splitting=True,
     )
 
   async def move_iswap_x(

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -5583,7 +5583,9 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     """
     if not self.extended_conf.left_x_drive.core_96_head_installed:
       raise RuntimeError("96-head is not installed")
-    resp = await self.send_command(module="C0", command="RA", ra="kf", fmt="kf###")
+    # 4-digit field: the head96 offset is ~10x the iSWAP's (~368 mm vs ~34 mm), so it exceeds
+    # 3 digits in 0.1 mm units - "kf###" silently truncates 3684 -> 368.
+    resp = await self.send_command(module="C0", command="RA", ra="kf", fmt="kf####")
     return cast(int, resp["kf"]) / 10.0
 
   async def set_x_offset_x_axis_core_nano_pipettor_head(self, x_offset: int):
@@ -7946,8 +7948,10 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
   ):
     """Move the 96-head to a target channel-A1 X coordinate via the direct X-arm drive.
 
-    Drives the X-arm carriage to ``x - head96_information.x_offset`` so channel A1 lands at
-    ``x``, mirroring how the iSWAP derives its rotation-drive X from the carriage center.
+    Drives the X-arm carriage to ``x + head96_information.x_offset`` so channel A1 lands at
+    ``x``: A1 sits left of (below) the carriage center, so deck-A1 = carriage - offset and the
+    carriage target is therefore ``x + offset`` (inverse of the iSWAP rotation-drive derivation,
+    ``iswap_rotation_drive_request_x``).
     Unlike the EM-based ``head96_move_x_OLD`` (all axes together, no motion control), this is
     the single-axis X-arm drive command and exposes acceleration and current control, like
     ``head96_move_y`` / ``head96_move_z``.
@@ -7966,7 +7970,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     if not (x_min <= x <= 974.0):
       raise ValueError(f"96-head A1 x={x} out of range [{x_min}, 974.0]")
     assert self._head96_information is not None, "96-head information not loaded; run setup()"
-    carriage_x = x - self._head96_information.x_offset
+    carriage_x = x + self._head96_information.x_offset
     return await self.experimental_x_arm_move(
       carriage_x,
       acceleration_level=acceleration_level,

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_chatterbox.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_chatterbox.py
@@ -160,6 +160,7 @@ class STARChatterboxBackend(STARBackend):
     if self.extended_conf.left_x_drive.core_96_head_installed and not skip_core96_head:
       self._head96_information = Head96Information(
         fw_version=datetime.date(2023, 1, 1),
+        x_offset=0.0,  # canned; real value read from EEPROM (kf) on hardware
         supports_clot_monitoring_clld=False,
         stop_disc_type="core_ii",
         instrument_type="FM-STAR",

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_chatterbox.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_chatterbox.py
@@ -160,7 +160,7 @@ class STARChatterboxBackend(STARBackend):
     if self.extended_conf.left_x_drive.core_96_head_installed and not skip_core96_head:
       self._head96_information = Head96Information(
         fw_version=datetime.date(2023, 1, 1),
-        x_offset=0.0,  # canned; real value read from EEPROM (kf) on hardware
+        x_offset=368.4,  # representative value; hardware reads the true offset from EEPROM (kf)
         supports_clot_monitoring_clld=False,
         stop_disc_type="core_ii",
         instrument_type="FM-STAR",

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_chatterbox.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_chatterbox.py
@@ -160,7 +160,7 @@ class STARChatterboxBackend(STARBackend):
     if self.extended_conf.left_x_drive.core_96_head_installed and not skip_core96_head:
       self._head96_information = Head96Information(
         fw_version=datetime.date(2023, 1, 1),
-        x_offset=368.4,  # representative value; hardware reads the true offset from EEPROM (kf)
+        x_offset=365.0,  # factory default; hardware reads the per-machine value from EEPROM (kf)
         supports_clot_monitoring_clld=False,
         stop_disc_type="core_ii",
         instrument_type="FM-STAR",


### PR DESCRIPTION
## What
Rework `head96_move_x` from the `EM` "move all axes together" command into a real single-axis X-arm drive, so the CoRe 96 head's X move gets the same per-axis acceleration and current control that `head96_move_y` and `head96_move_z` already have. The implementation mirrors the existing iSWAP rotation-drive X handling exactly: a master-EEPROM offset getter (`_head96_request_x_offset` alongside `_iswap_rotation_drive_request_x_offset`), the offset cached on the setup info record (`Head96Information.x_offset` alongside `iSWAPInformation.rotation_drive_x_offset`), and a move that converts a target deck position to a carriage target via that offset (the inverse of `iswap_rotation_drive_request_x`).

## Why
`head96_move_x` was the only head96 axis without dedicated motion control: it did a position round-trip then issued `EM`, which moves all axes together and exposes no speed/acceleration. A direct X-arm drive needs the X distance between the X-arm carriage center and channel A1, which the firmware stores in master EEPROM.

## Pattern
This is the second adopter of a low-to-high command-layering standard for STAR moves, after `move_iswap_x`: a low-level primitive that exposes motion control (`X0:XP` via `experimental_x_arm_move`), a cached EEPROM calibration offset on the `*Information` record, and a deck-frame public method that transforms via the offset and threads the motion params through. It replaces the anti-pattern of going straight to a monolithic `EM` macro that bundles all axes and exposes nothing. Candidates to migrate next: iSWAP Y/Z, head96 Y/Z, CoRe 384 head, nano pipettor.

## What this enables
Per-move acceleration, impossible with `EM`'s single fixed ramp:

```python
await star.head96_move_x(500.0, acceleration_level=5)   # empty head: fast repositioning
await star.head96_move_x(500.0, acceleration_level=1)   # 96 tips full of liquid: gentle, no sloshing
```

- Gentle ramp (level 1) for liquid-laden transits avoids sloshing/droplet loss across all 96 tips; level 5 for empty repositioning.
- Lower acceleration tames the cantilever wobble when the head is extended forward (the X-drive sits at the back).
- Max acceleration on empty traverses recovers cycle time.

## Changes
- Add `_head96_request_x_offset()`: reads the carriage-center-to-A1 X offset from master EEPROM (parameter `kf`, set via `C0:AF`, read via `C0:RA`), in mm.
- Cache it as `Head96Information.x_offset`, populated in `set_up_core96_head` (mirrors `iSWAPInformation.rotation_drive_x_offset`).
- Rework `head96_move_x` to drive the X arm to `x + x_offset` via `X0:XP` (channel A1 sits left of the carriage center, so the carriage target is `A1 + offset`), guarded by the 96-head A1 X range, exposing `acceleration_level` / `current_protection_limiter`.
- Chatterbox returns the factory-default offset (365.0 mm).

## Behavior change
`head96_move_x` now issues a single-axis X move instead of the `EM` all-axes coordinate move. Like `head96_move_y` / `head96_move_z` it moves only its own axis and assumes a safe Z (no `EM` lower-then-move). The signature stays backward compatible: `x` remains positional, the new parameters default.

## Compatibility
All firmware commands used (`C0:RA`, `C0:AF`/`kf`, `X0:XP`) are long-standing STAR commands, stable across firmware versions; the change was validated on a head96 running 2021 firmware. `current_protection_limiter` is capped at 7, which is valid on every firmware track.

## Validation
Hardware A/B on a STAR against the previous `EM` move: for target A1 X = 500, the direct drive lands A1 at 499.90 mm vs 500.00 (`EM`), a 0.1 mm delta (one firmware increment), and is Y-invariant (identical front and back of the deck) where `EM` drifted ~0.2 mm with Y. The EEPROM read returned 368.2 mm on that machine. lint, mypy, and the STAR test suite pass.
