### PR TITLE
`Mix`: add optional `surface_following_distance`

### DIFF
--- a/pylabrobot/liquid_handling/standard.py
+++ b/pylabrobot/liquid_handling/standard.py
@@ -74,9 +74,20 @@ class SingleChannelDispense:
 
 @dataclass(frozen=True)
 class Mix:
+  """Repeated aspirate/dispense cycles to mix the liquid during a transfer.
+
+  Args:
+    volume: The volume drawn then expelled each cycle.
+    repetitions: The number of aspirate/dispense cycles.
+    flow_rate: The flow rate of the mix.
+    surface_following_distance: The distance (mm) the tip follows the liquid surface each cycle on
+      backends that support it (e.g. Hamilton STAR); others ignore it.
+  """
+
   volume: float
   repetitions: int
   flow_rate: float
+  surface_following_distance: Optional[float] = None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Adds an optional `surface_following_distance` (mm) to `Mix`. On liquid handlers whose firmware drives Z in parallel with the piston during a mix (e.g. the Hamilton STAR), following the surface as the level changes is an essential part of a good in-place mix. Backends without that capability ignore the field; the default `None` means no surface following.

This is the same shape as other capability-dependent parameters in PyLabRobot - for example a plate reader exposing a reading mode (orbital shaking, a given wavelength range) that some models support and others don't. The protocol states the intent once; backends that can honour it do, and those that can't ignore it, rather than the protocol branching per device.

Backward compatible: optional with a default, so existing `Mix(volume, repetitions, flow_rate)` construction and serialization are unchanged. No backend behaviour changes in this PR - it just adds the parameter to the shared vocabulary so supporting backends can consume it.
