### PR TITLE
fix(logging): don't let setup_logger crash on a non-regular log path (e.g. /dev/null)

### DIFF
--- a/pylabrobot/__init__.py
+++ b/pylabrobot/__init__.py
@@ -70,11 +70,16 @@ def setup_logger(log_dir: Optional[Union[Path, str]], level: int):
   # remove existing file handlers (but keep stream handlers like those from verbose())
   for handler in logger.handlers[:]:
     if isinstance(handler, logging.FileHandler):
+      handler.close()
       logger.removeHandler(handler)
-      # delete empty log file if it has been created
+      # delete the log file if it was created empty, but only regular files - a handler pointing at
+      # a device node like /dev/null reports size 0 yet cannot (and must not) be unlinked.
       log_file_path = Path(handler.baseFilename)
-      if log_file_path.exists() and log_file_path.stat().st_size == 0:
-        log_file_path.unlink()
+      if log_file_path.is_file() and log_file_path.stat().st_size == 0:
+        try:
+          log_file_path.unlink()
+        except OSError:
+          pass
 
   # Add a file handler, if log_dir is not None
   if log_path is not None:


### PR DESCRIPTION
## Problem

`setup_logger` deletes any empty log file left behind by a previous `FileHandler`:

```python
log_file_path = Path(handler.baseFilename)
if log_file_path.exists() and log_file_path.stat().st_size == 0:
    log_file_path.unlink()
```

`exists() + size == 0` is **also true for a device node like `/dev/null`** — it reports size 0 but cannot be unlinked. When a handler points there, `unlink()` raises `PermissionError: [Errno 13] Permission denied: '/dev/null'`.

This fires inside the autouse `setup_test_config` fixture (`configure(TEST_CONFIG)`), so it surfaces as an **`ERROR at setup`** on whichever test happens to run first after a `/dev/null` handler is left on the `pylabrobot` logger. It's **order-dependent and nondeterministic** — e.g. in one CI run py3.9 passed while py3.10–3.14 failed at `precise_flex .../test_approach_c`, a test entirely unrelated to logging.

## Fix

- Only unlink **regular files** (`Path.is_file()`), so device nodes are skipped.
- Wrap the `unlink()` in `try/except OSError` as a backstop.
- `close()` the handler before removing it (release the fd).

## Verification

- Direct repro (a `FileHandler('/dev/null')` present, then `configure(...)`): raised `PermissionError` before, succeeds after.
- Empty *regular* log-file cleanup still works (verified across distinct log dirs).
- `pylabrobot/config/` and the full `precise_flex` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)