### PR TITLE
`LiquidHandler`: gate aspirate96 tip volume tracking on `does_volume_tracking()`

### DIFF
--- a/pylabrobot/liquid_handling/liquid_handler.py
+++ b/pylabrobot/liquid_handling/liquid_handler.py
@@ -1754,9 +1754,10 @@ class LiquidHandler(Resource, Machine):
         if tip is None:
           continue
 
-        if not container.tracker.is_disabled and does_volume_tracking():
-          container.tracker.remove_liquid(volume=volume)
-        tip.tracker.add_liquid(volume=volume)
+        if does_volume_tracking():
+          if not container.tracker.is_disabled:
+            container.tracker.remove_liquid(volume=volume)
+          tip.tracker.add_liquid(volume=volume)
 
       aspiration = MultiHeadAspirationContainer(
         container=container,
@@ -1782,9 +1783,10 @@ class LiquidHandler(Resource, Machine):
         if tip is None:
           continue
 
-        if not well.tracker.is_disabled and does_volume_tracking():
-          well.tracker.remove_liquid(volume=volume)
-        tip.tracker.add_liquid(volume=volume)
+        if does_volume_tracking():
+          if not well.tracker.is_disabled:
+            well.tracker.remove_liquid(volume=volume)
+          tip.tracker.add_liquid(volume=volume)
 
       aspiration = MultiHeadAspirationPlate(
         wells=cast(List[Well], containers),

--- a/pylabrobot/liquid_handling/liquid_handler_tests.py
+++ b/pylabrobot/liquid_handling/liquid_handler_tests.py
@@ -46,6 +46,7 @@ from pylabrobot.resources.hamilton import (
 from pylabrobot.resources.revvity.plates import Revvity_384_wellplate_28ul_Ub
 from pylabrobot.resources.utils import create_ordered_items_2d
 from pylabrobot.resources.volume_tracker import (
+  no_volume_tracking,
   set_volume_tracking,
 )
 from pylabrobot.resources.well import Well
@@ -532,6 +533,15 @@ class TestLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
     self.backend.drop_tips96.assert_called_once()
     call_kwargs = self.backend.drop_tips96.call_args.kwargs
     self.assertEqual(call_kwargs["drop"].offset, Coordinate(1, 3, 3))
+
+  async def test_aspirate96_tip_tracker_respects_volume_tracking_off(self):
+    """With volume tracking off, aspirate96 leaves the 96-head tip trackers untouched, matching
+    single-channel aspirate (the global flag governs the tip side, not just the source)."""
+    await self.lh.pick_up_tips96(self.tip_rack)
+    tip = self.lh.head96[0].get_tip()
+    with no_volume_tracking():
+      await self.lh.aspirate96(self.plate, volume=10)
+    self.assertEqual(tip.tracker.get_used_volume(), 0)
 
   async def test_default_offset_head96_initializer(self):
     backend = _create_mock_backend(num_channels=8)


### PR DESCRIPTION
aspirate96 gated the source `remove_liquid` on `does_volume_tracking()` but added to the 96-head tip trackers unconditionally, so with volume tracking globally off the wells were left untouched while the tips were still loaded - tip state drifting away from a source that never changed.

Single-channel `aspirate` is the canonical pattern: the whole tracker block, tip included, sits under one `does_volume_tracking()` guard, and `is_disabled` is checked only on the container (tips are never disabled). This restructures both aspirate96 branches - single-container and 96-well - to the same shape, so the global flag governs the tip side as well as the source. When tracking is on, behavior is unchanged.

Test: with tracking off, aspirate96 leaves the 96-head tip trackers untouched.

The matching cleanup of the tip commit/rollback loops in aspirate96 and dispense96 - currently ungated but a no-op once the queue is gated - is left to a follow-up consistency PR.

## Problem deep-dive

Disabling volume tracking is meant to turn off all liquid bookkeeping, but aspirate96 kept writing to the tip trackers anyway. The numbers below are from a run against `hamilton_96_tiprack_300uL_filter`, whose tips track to a 360 uL ceiling:

```python
set_volume_tracking(False)              # I don't want any liquid bookkeeping
await lh.pick_up_tips96(tip_rack)
await lh.aspirate96(plate, volume=200)
```

After that single call, before this change:

- the source well tracker is untouched, used = 0 (correct - tracking is off)
- every 96-head tip tracker reads used = 200 uL

The source says nothing was removed, the tips claim to hold 200, and the books do not balance - even though tracking was explicitly off. Single-channel `aspirate` in the same scenario leaves the tips at 0.

The sharp, throwable consequence shows up on the next aspirate:

```python
set_volume_tracking(False)
await lh.pick_up_tips96(tip_rack)        # tips track to 360 uL
await lh.aspirate96(plate, volume=200)   # tips silently bumped to 200, 160 uL free
await lh.aspirate96(plate, volume=200)   # before: TooLittleVolumeError: Not enough space in container: 200.0uL > 160.0uL.
                                         # after:  proceeds - tracking is off, as asked
```

`VolumeTracker.add_liquid` runs its capacity check unconditionally, so the phantom 200 uL leaves only 160 uL free and the next 200 uL overflows the tip, raising `TooLittleVolumeError` - the precise class of error the user disabled tracking to avoid. After this change the tip tracker is never written while tracking is off, so neither the divergence nor the spurious error occurs.

It only ever affected the tracking-off path; with tracking on the tip add fired in both versions, so normal workflows were unaffected, which is why it went unnoticed.
