### PR TITLE
Add MicroSpin centrifuge docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,16 +83,30 @@ data = await pr.read_luminescence()
 
 For Cytation5, use the `Cytation5` backend.
 
-### Centrifuges ([docs](https://docs.pylabrobot.org/0.2.1/user_guide/01_material-handling/centrifuge/_centrifuge.html))
+### Centrifuges ([docs](https://docs.pylabrobot.org/user_guide/01_material-handling/centrifuge/_centrifuge.html))
 
-Centrifugation at 800g for 60 seconds:
+Centrifugation at 800g for 60 seconds with an Agilent VSpin:
 
 ```python
-from pylabrobot.centrifuge import Centrifuge, VSpin
-cf = Centrifuge(backend=VSpin(bucket_1_position=0), name="centrifuge", size_x=1, size_y=1, size_z=1)
+from pylabrobot.centrifuge import Centrifuge, VSpinBackend
+
+vspin_backend = VSpinBackend(device_id="YOUR_FTDI_ID_HERE")
+cf = Centrifuge(name="centrifuge", backend=vspin_backend, size_x=1, size_y=1, size_z=1)
 await cf.setup()
 
-await cf.start_spin_cycle(g = 800, duration = 60)
+await cf.spin(g=800, duration=60)
+```
+
+For a HighRes Biosolutions MicroSpin, use the MicroSpin factory:
+
+```python
+from pylabrobot.centrifuge import MicroSpin
+
+cf = MicroSpin(name="microspin", host="192.168.127.60")
+await cf.setup()
+await cf.backend.home()
+
+await cf.spin(g=800, duration=60)
 ```
 
 ### Pumps ([docs](https://docs.pylabrobot.org/0.2.1/user_guide/00_liquid-handling/pumps/_pumps.html))

--- a/docs/api/pylabrobot.centrifuge.rst
+++ b/docs/api/pylabrobot.centrifuge.rst
@@ -14,6 +14,18 @@ This package contains APIs for working with centrifuges.
     centrifuge.Loader
 
 
+Factory functions
+-----------------
+
+.. autosummary::
+  :toctree: _autosummary
+  :nosignatures:
+  :recursive:
+
+    access2.Access2
+    highres.microspin.MicroSpin
+
+
 Backends
 --------
 
@@ -40,4 +52,16 @@ Errors
     standard.LoaderNoPlateError
     standard.NotAtBucketError
     highres.microspin_backend.MicroSpinError
+    highres.microspin_backend.MicroSpinAbortedError
     highres.microspin_backend.MicroSpinProtocolError
+
+
+Testing utilities
+-----------------
+
+.. autosummary::
+  :toctree: _autosummary
+  :nosignatures:
+  :recursive:
+
+    highres.mock_server.MicroSpinMockServer

--- a/docs/user_guide/01_material-handling/centrifuge/_centrifuge.md
+++ b/docs/user_guide/01_material-handling/centrifuge/_centrifuge.md
@@ -14,7 +14,11 @@ The {class}`~pylabrobot.centrifuge.centrifuge.Centrifuge` class has a number of 
 - {meth}`~pylabrobot.centrifuge.centrifuge.Centrifuge.go_to_bucket2`: Rotate/present Bucket 2.
 - {meth}`~pylabrobot.centrifuge.centrifuge.Centrifuge.spin`: Start a centrifuge spin cycle.
 
-Some standalone door and lock primitives are hardware-dependent. For example, the HighRes MicroSpin firmware handles those operations automatically as part of bucket presentation and spinning; see the MicroSpin guide below for details.
+Some standalone door/lock and low-level rotation primitives are hardware-dependent. For example,
+the Agilent VSpin backend exposes {meth}`~pylabrobot.centrifuge.vspin_backend.VSpinBackend.go_to_position`
+for arbitrary bucket positioning during calibration (8000 ticks = 360 degrees), while the HighRes
+MicroSpin only exposes bucket presentation through `go_to_bucket1()` / `go_to_bucket2()` and manages
+door/lock operations automatically. See the hardware-specific guides below for details.
 
 PLR supports the following centrifuges:
 

--- a/docs/user_guide/01_material-handling/centrifuge/_centrifuge.md
+++ b/docs/user_guide/01_material-handling/centrifuge/_centrifuge.md
@@ -10,10 +10,11 @@ The {class}`~pylabrobot.centrifuge.centrifuge.Centrifuge` class has a number of 
 - {meth}`~pylabrobot.centrifuge.centrifuge.Centrifuge.unlock_door`: Unlock the centrifuge door.
 - {meth}`~pylabrobot.centrifuge.centrifuge.Centrifuge.lock_bucket`: Lock centrifuge buckets.
 - {meth}`~pylabrobot.centrifuge.centrifuge.Centrifuge.unlock_bucket`: Unlock centrifuge buckets.
-- {meth}`~pylabrobot.centrifuge.centrifuge.Centrifuge.go_to_bucket1`: Rotate to Bucket 1.
-- {meth}`~pylabrobot.centrifuge.centrifuge.Centrifuge.go_to_bucket2`: Rotate to Bucket 2.
-- {meth}`~pylabrobot.centrifuge.centrifuge.Centrifuge.rotate_distance`: Rotate the buckets a specified distance (8000 = 360 degrees).
-- {meth}`~pylabrobot.centrifuge.centrifuge.Centrifuge.start_spin_cycle`: Start centrifuge spin cycle.
+- {meth}`~pylabrobot.centrifuge.centrifuge.Centrifuge.go_to_bucket1`: Rotate/present Bucket 1.
+- {meth}`~pylabrobot.centrifuge.centrifuge.Centrifuge.go_to_bucket2`: Rotate/present Bucket 2.
+- {meth}`~pylabrobot.centrifuge.centrifuge.Centrifuge.spin`: Start a centrifuge spin cycle.
+
+Some standalone door and lock primitives are hardware-dependent. For example, the HighRes MicroSpin firmware handles those operations automatically as part of bucket presentation and spinning; see the MicroSpin guide below for details.
 
 PLR supports the following centrifuges:
 

--- a/docs/user_guide/machines.md
+++ b/docs/user_guide/machines.md
@@ -92,6 +92,7 @@ tr > td:nth-child(5) { width: 15%; }
 |--------------|---------|-------------|--------|
 | Agilent | VSpin | Mostly | {doc}`PLR <01_material-handling/centrifuge/agilent_vspin>` / [OEM](https://www.agilent.com/en/product/automated-liquid-handling/automated-microplate-management/microplate-centrifuge) |
 | Agilent | VSpin Access2 Loader | Full | [PLR](01_material-handling/centrifuge/agilent_vspin.ipynb#loader) / [OEM](https://www.agilent.com/en/product/automated-liquid-handling/automated-microplate-management/microplate-centrifuge) |
+| HighRes Biosolutions | MicroSpin | Mostly | {doc}`PLR <01_material-handling/centrifuge/highres_microspin>` / [OEM](https://highresbio.com/microspin/) |
 | Hettich | SBS 300 R | WIP | [OEM](https://www.hettweb.com/products/sbs300robotic/) |
 | Hettich | ROTANTA 460 Robotic | WIP | [OEM](https://www.hettichlab.com/) |
 | Hettich | Other Generation 2 robotic centrifuges | WIP | [OEM](https://www.hettichlab.com/) |


### PR DESCRIPTION
## Summary
- add HighRes MicroSpin to the machines centrifuge table
- add MicroSpin factory/error/mock-server entries to centrifuge API docs
- update README centrifuge examples and clarify backend-specific positioning/door-lock behavior

## Note on the generic centrifuge docs
- `_centrifuge.md` now lists the current common `Centrifuge` frontend API.
- `start_spin_cycle` still exists but is deprecated in favor of `Centrifuge.spin`, so the guide now points users to `spin`.
- `rotate_distance` is not a `Centrifuge` frontend method and is not used by the current Agilent VSpin backend. VSpin low-level positioning/calibration is done with `VSpinBackend.go_to_position(...)`; the guide now mentions that backend-specific method instead.

## Tests
- `sphinx -b dummy docs /tmp/pylabrobot-docs-check -W --keep-going`