### PR TITLE
v1: `PreciseFlexDriver`: handle user-interrupt, E-stop, and crash interruptions

### DIFF
--- a/pylabrobot/brooks/precise_flex/driver.py
+++ b/pylabrobot/brooks/precise_flex/driver.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import time
 from dataclasses import dataclass
 from typing import Dict, Literal, Optional
 
@@ -9,7 +10,9 @@ from pylabrobot.capabilities.capability import BackendParams
 from pylabrobot.device import Driver
 from pylabrobot.io.socket import Socket
 
+from .data_ids import PowerState
 from .errors import PreciseFlexError
+from .interrupt import halt_and_resync, halt_on_interrupt
 
 logger = logging.getLogger(__name__)
 
@@ -137,6 +140,15 @@ class PreciseFlexDriver(Driver):
     mapping = {"pc": 0, "verbose": 1}
     await self.send_command(f"mode {mapping[mode]}")
 
+  async def request_system_state(self) -> int:
+    """Controller power/system-state word (the ``sysState`` command, == DataID 234).
+
+    See :class:`~pylabrobot.brooks.precise_flex.data_ids.PowerState` for the values;
+    ``PowerState.OFF_HARD_ESTOP`` (15) means a hard E-stop is engaged, ``PowerState.ON_ATTACHED``
+    (21) is the normal running state. Read-only, so it detects an E-stop without provoking an error.
+    """
+    return int(await self.send_command("sysState"))
+
   async def power_on_robot(self):
     """Power on the robot."""
     error: Optional[PreciseFlexError] = None
@@ -152,6 +164,31 @@ class PreciseFlexDriver(Driver):
     if error:
       raise error
     raise RuntimeError("Failed to power on robot after 3 attempts for unknown reasons.")
+
+  async def recover_from_fault(self) -> None:
+    """Recover after a collision / fault that stopped the arm and dropped power, leaving it usable.
+
+    A collision trips an envelope error (``-3100`` hard / ``-3122`` soft, see
+    :func:`~pylabrobot.brooks.precise_flex.errors.is_collision`); the servo stops the arm itself and
+    high power drops. This re-enables power, re-attaches, and re-homes (which only cycles the gripper
+    when the other axes are already homed - absolute encoders retain them - so it does not sweep the
+    arm), leaving it ready to move. It does **not** drive the arm to any pose; confirm the obstacle is
+    removed before calling.
+
+    The envelope error auto-clears, so no explicit clear is needed; a latched fatal that blocks
+    power-on is surfaced by ``power_on_robot`` for the operator to reset (DataID 247) or reboot.
+
+    Raises:
+      PreciseFlexError: if a hard E-stop is engaged (release the button first) or power cannot be
+        re-enabled.
+    """
+    if await self.request_system_state() == PowerState.OFF_HARD_ESTOP:
+      raise PreciseFlexError(
+        -1028, "hard E-Stop engaged - release the E-stop button before recovering"
+      )
+    await self.power_on_robot()
+    await self.attach(1)
+    await self.home()
 
   async def power_off_robot(self):
     """Power off the robot."""
@@ -226,14 +263,45 @@ class PreciseFlexDriver(Driver):
     """
     await self.send_command("homeAll")
 
-  async def _wait_for_eom(self) -> None:
-    """Wait for the robot to reach the end of the current motion.
+  async def _wait_for_eom(
+    self, poll_interval: float = 0.05, settle: float = 0.02, timeout: float = 60.0
+  ) -> None:
+    """Wait (non-blocking) until the arm has stopped moving, keeping the connection responsive.
 
-    Waits for the robot to reach the end of the current motion or until it is stopped by
-    some other means. Does not reply until the robot has stopped.
+    Polls the live joint position (``wherej``) and returns once it stops changing between samples
+    (every axis moving less than ``settle``) - i.e. end of motion. It returns promptly when the arm
+    is already stationary, including when it was stopped short of its last commanded target (after a
+    halt/interrupt or a hand-move), so it never hangs waiting to reach a target that will not be
+    reached.
+
+    This deliberately avoids the firmware ``waitForEom``: that command parks the controller's single
+    command interpreter and makes it ignore everything else on the connection - including ``halt`` -
+    until the move ends (hardware-verified). Polling instead leaves the connection free between
+    samples, so a user interrupt can stop the move mid-flight via ``halt`` and other controller
+    commands (status, vision, barcode) can run during motion.
+
+    Raises:
+      TimeoutError: if the arm never settles within ``timeout`` seconds.
+      OperationInterrupted: on a user interrupt (the arm is halted and the connection kept).
     """
-    await self.send_command("waitForEom")
-    await asyncio.sleep(0.2)
+
+    def _floats(reply: str) -> list[float]:
+      return [float(x) for x in reply.split()]
+
+    # On interrupt, `halt` stops the move on the now-free connection and we resync; the connection is
+    # kept open. Hardware-verified: a clean halt keeps power, attach, and the link (only a collision
+    # trips -3122 and drops power, which needs explicit recovery).
+    async with halt_on_interrupt(lambda: halt_and_resync(self.io, b"halt")):
+      previous = _floats(await self.send_command("wherej"))
+      deadline = time.monotonic() + timeout
+      while True:
+        await asyncio.sleep(poll_interval)
+        current = _floats(await self.send_command("wherej"))
+        if all(abs(c - p) < settle for c, p in zip(current, previous)):
+          return  # stopped moving
+        if time.monotonic() > deadline:
+          raise TimeoutError(f"motion did not settle within {timeout:.0f}s (current={current})")
+        previous = current
 
   async def state(self) -> str:
     """Return state of motion.

--- a/pylabrobot/brooks/precise_flex/errors.py
+++ b/pylabrobot/brooks/precise_flex/errors.py
@@ -1933,3 +1933,33 @@ class PreciseFlexError(Exception):
       super().__init__(f"PreciseFlexError {replycode}: {text}. {description} - {message}")
     else:
       super().__init__(f"PreciseFlexError {replycode}: {message}")
+
+
+class OperationInterrupted(Exception):
+  """Raised when a user interrupt (Jupyter stop / Ctrl+C) halts an in-flight device operation.
+
+  The device has been sent a stop and the connection has been resynced and left open, so the session
+  can continue. Raised in place of a bare ``KeyboardInterrupt``; an ``asyncio.CancelledError`` is
+  re-raised as-is rather than converted, so cancellation semantics are preserved.
+  """
+
+
+# -- collision detection ---------------------------------------------------
+
+# Collision / over-drive errors: the servo trips one of these when an axis is blocked - it hit an
+# obstacle (or is otherwise over-driven) - and the controller stops the arm itself. Two mechanisms:
+# position-tracking (envelope) and torque saturation. Each surfaces as a ``PreciseFlexError`` on the
+# next command:
+#   -3100  hard envelope error  (position tracking; severe, turns power off)
+#   -3122  soft envelope error  (position tracking; leaves power on)
+#   -3101  PID output saturated too long  (torque saturated - over-driven / collided)
+#   -3105  motor stalled  (torque saturated at the peak rating)
+COLLISION_ERROR_CODES = frozenset({-3100, -3101, -3105, -3122})
+
+
+def is_collision(exc: object) -> bool:
+  """Whether ``exc`` is a ``PreciseFlexError`` from a collision / over-drive (the arm hit something) -
+  an envelope (``-3100`` / ``-3122``) or torque-saturation (``-3101`` / ``-3105``) error - as opposed
+  to an ordinary command error. Lets protocol code branch on "did I crash?".
+  """
+  return isinstance(exc, PreciseFlexError) and exc.replycode in COLLISION_ERROR_CODES

--- a/pylabrobot/brooks/precise_flex/interrupt.py
+++ b/pylabrobot/brooks/precise_flex/interrupt.py
@@ -1,0 +1,88 @@
+"""Notebook/asyncio interrupt handling: stop the in-flight operation, keep the connection.
+
+When a user interrupts (Jupyter stop / Ctrl+C) while a command is awaiting a reply, we want to stop
+whatever the device is doing - motion or vision alike - and resync the connection rather than drop
+it. ``halt_on_interrupt`` wraps a blocking command: on interrupt it runs a channel-specific
+stop+resync that is itself protected against a second interrupt, then re-raises an
+``asyncio.CancelledError`` (preserving cancellation) or converts a ``KeyboardInterrupt`` to
+``OperationInterrupted``.
+
+Behaviour by context:
+- Notebook: the kernel stays alive; the device is stopped and the connection resynced, so work
+  continues in the same session.
+- Script via ``asyncio.run``: shutdown cancels the task, so the stop still fires before the process
+  exits (the connection survives only until the process ends).
+- Physical E-stop is a hardware path, not an interrupt: the in-flight command returns an error reply
+  (``PreciseFlexError``) or times out, which is not caught here and propagates normally.
+"""
+
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+from typing import Awaitable, Callable, Optional
+
+from pylabrobot.io.socket import Socket
+
+from .errors import OperationInterrupted
+
+logger = logging.getLogger(__name__)
+
+
+async def _run_to_completion(coro: Awaitable[None]) -> None:
+  """Await ``coro`` to completion even if the surrounding task is interrupted again.
+
+  Shields the work from cancellation and re-awaits if a second interrupt pops the await, so an
+  interrupt-triggered stop can never be left half-sent (double Ctrl+C is common in notebooks).
+  """
+  task = asyncio.ensure_future(coro)
+  while not task.done():
+    try:
+      await asyncio.shield(task)
+    except (KeyboardInterrupt, asyncio.CancelledError):
+      continue
+
+
+async def drain(io: Socket, *, timeout: float = 0.5, max_lines: int = 50) -> None:
+  """Read and discard pending lines until the socket goes quiet, resyncing the stream."""
+  for _ in range(max_lines):
+    try:
+      if not await io.readline(timeout=timeout):
+        return  # peer closed
+    except TimeoutError:
+      return  # quiet -> resynced
+
+
+async def halt_and_resync(io: Socket, stop: Optional[bytes] = None) -> None:
+  """Best-effort: optionally send a ``stop`` command, then drain to resync. Never closes.
+
+  When ``stop`` is given, a leading newline first terminates any command frame that was only
+  partially written when the interrupt landed, so the stop is parsed on its own line. Pass
+  ``stop=None`` to drain-only - a channel with no known abort command, where we just resync and keep
+  it open.
+  """
+  try:
+    if stop is not None:
+      await io.write(b"\n" + stop + b"\n")
+    await drain(io)
+  except Exception:  # best-effort; the connection is deliberately left open
+    logger.warning("interrupt stop/resync I/O failed", exc_info=True)
+
+
+@asynccontextmanager
+async def halt_on_interrupt(stop_action: Callable[[], Awaitable[None]]):
+  """Wrap a blocking command so an interrupt stops the in-flight operation and keeps the connection.
+
+  On ``KeyboardInterrupt`` or ``asyncio.CancelledError``, runs ``stop_action`` to completion
+  (protected against a second interrupt), then re-raises ``CancelledError`` or converts a
+  ``KeyboardInterrupt`` to ``OperationInterrupted``. Any other exception (e.g. a ``PreciseFlexError``
+  from an error reply, as an E-stop produces) propagates unchanged.
+  """
+  try:
+    yield
+  except (KeyboardInterrupt, asyncio.CancelledError) as exc:
+    await _run_to_completion(stop_action())
+    if isinstance(exc, asyncio.CancelledError):
+      raise
+    raise OperationInterrupted(
+      "operation halted by interrupt; device stopped, connection alive"
+    ) from exc

--- a/pylabrobot/brooks/precise_flex/tests/interrupt_tests.py
+++ b/pylabrobot/brooks/precise_flex/tests/interrupt_tests.py
@@ -1,0 +1,181 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from pylabrobot.brooks.precise_flex.driver import PreciseFlexDriver
+from pylabrobot.brooks.precise_flex.errors import (
+  OperationInterrupted,
+  PreciseFlexError,
+  is_collision,
+)
+from pylabrobot.brooks.precise_flex.interrupt import halt_and_resync, halt_on_interrupt
+
+
+def _make_driver() -> PreciseFlexDriver:
+  """A driver whose socket is mocked: writes recorded, reads drain immediately (TimeoutError)."""
+  d = PreciseFlexDriver(host="localhost")
+  d.io = MagicMock()
+  d.io.write = AsyncMock()
+  d.io.readline = AsyncMock(side_effect=TimeoutError())
+  return d
+
+
+class TestWaitForEom(unittest.IsolatedAsyncioTestCase):
+  """The non-blocking motion-wait: polls wherej and returns once the arm stops moving."""
+
+  async def test_returns_when_motion_stops(self):
+    """Returns at the first sample where the position stopped changing between polls."""
+    wherej = iter(
+      ["0 0 0 0 0", "5 5 5 5 5", "9.9 9.9 9.9 9.9 9.9", "10 10 10 10 10", "10 10 10 10 10"]
+    )
+    d = _make_driver()
+    d.send_command = AsyncMock(side_effect=lambda cmd: next(wherej))
+    await d._wait_for_eom(poll_interval=0)  # no error == returned at the settled sample
+
+  async def test_returns_immediately_when_already_stationary(self):
+    """An idle arm (e.g. halted short of its last target) returns at once, never hangs to reach it."""
+    d = _make_driver()
+    d.send_command = AsyncMock(return_value="113 81 218 64 70")  # stable every poll
+    await d._wait_for_eom(poll_interval=0)
+
+  async def test_keyboard_interrupt_halts_and_raises_operation_interrupted(self):
+    """A user interrupt mid-wait sends halt on the connection and surfaces OperationInterrupted."""
+    seq = iter(["0 0 0 0 0"])
+
+    def fake(cmd: str) -> str:
+      try:
+        return next(seq)
+      except StopIteration:
+        raise KeyboardInterrupt()
+
+    d = _make_driver()
+    d.send_command = AsyncMock(side_effect=fake)
+    with self.assertRaises(OperationInterrupted):
+      await d._wait_for_eom(poll_interval=0)
+    self.assertTrue(any(b"halt" in c.args[0] for c in d.io.write.call_args_list))
+
+  async def test_cancelled_error_halts_and_reraises(self):
+    """Cancellation is re-raised (not converted) but still sends halt first."""
+    seq = iter(["0 0 0 0 0"])
+
+    def fake(cmd: str) -> str:
+      try:
+        return next(seq)
+      except StopIteration:
+        raise asyncio.CancelledError()
+
+    d = _make_driver()
+    d.send_command = AsyncMock(side_effect=fake)
+    with self.assertRaises(asyncio.CancelledError):
+      await d._wait_for_eom(poll_interval=0)
+    self.assertTrue(any(b"halt" in c.args[0] for c in d.io.write.call_args_list))
+
+  async def test_timeout_when_never_settles(self):
+    """An arm that never stops moving raises TimeoutError rather than spinning forever."""
+    n = iter(range(1000))
+    d = _make_driver()
+    d.send_command = AsyncMock(side_effect=lambda cmd: f"{next(n)} 0 0 0 0")  # always changing
+    with self.assertRaises(TimeoutError):
+      await d._wait_for_eom(poll_interval=0, timeout=0)
+
+
+class TestInterruptHelpers(unittest.IsolatedAsyncioTestCase):
+  """The reusable guard primitives in interrupt.py."""
+
+  async def test_halt_and_resync_flushes_sends_stop_then_drains(self):
+    """With a stop command it writes a leading-newline-flushed halt, then drains; never closes."""
+    io = MagicMock()
+    io.write = AsyncMock()
+    io.readline = AsyncMock(side_effect=[b"0\r\n", TimeoutError()])
+    await halt_and_resync(io, b"halt")
+    io.write.assert_awaited_once_with(b"\nhalt\n")
+    io.stop.assert_not_called()
+
+  async def test_halt_and_resync_drain_only_when_no_stop(self):
+    """stop=None means resync-only: drain the socket, write nothing."""
+    io = MagicMock()
+    io.write = AsyncMock()
+    io.readline = AsyncMock(side_effect=TimeoutError())
+    await halt_and_resync(io)
+    io.write.assert_not_called()
+
+  async def test_converts_keyboard_interrupt(self):
+    """KeyboardInterrupt -> stop runs, OperationInterrupted raised."""
+    stop = AsyncMock()
+    with self.assertRaises(OperationInterrupted):
+      async with halt_on_interrupt(stop):
+        raise KeyboardInterrupt()
+    stop.assert_awaited_once()
+
+  async def test_reraises_cancelled_error(self):
+    """CancelledError -> stop runs, cancellation re-raised (semantics preserved)."""
+    stop = AsyncMock()
+    with self.assertRaises(asyncio.CancelledError):
+      async with halt_on_interrupt(stop):
+        raise asyncio.CancelledError()
+    stop.assert_awaited_once()
+
+  async def test_passes_through_other_exceptions_without_halting(self):
+    """A normal error (e.g. an error-reply PreciseFlexError, as an E-stop produces) propagates
+    unchanged and does NOT trigger a halt."""
+    stop = AsyncMock()
+    with self.assertRaises(ValueError):
+      async with halt_on_interrupt(stop):
+        raise ValueError()
+    stop.assert_not_awaited()
+
+
+class TestRequestSystemState(unittest.IsolatedAsyncioTestCase):
+  """request_system_state reads the sysState word; PowerState decodes it (15 = hard E-stop)."""
+
+  async def test_returns_state_word_and_decodes_to_powerstate(self):
+    from pylabrobot.brooks.precise_flex.data_ids import PowerState
+
+    d = _make_driver()
+    d.send_command = AsyncMock(return_value="15")
+    state = await d.request_system_state()
+    self.assertEqual(state, 15)
+    self.assertEqual(PowerState(state), PowerState.OFF_HARD_ESTOP)
+
+
+class TestCollisionDetectionAndRecovery(unittest.IsolatedAsyncioTestCase):
+  """Crash interrupts: recognise envelope errors, and recover (re-power + attach + home)."""
+
+  def test_is_collision_recognises_collision_codes_only(self):
+    """Envelope (-3100/-3122) and torque-saturation (-3101/-3105) errors are collisions; an E-stop,
+    a no-attach error, or a non-PreciseFlexError is not."""
+    for code in (-3100, -3101, -3105, -3122):
+      self.assertTrue(is_collision(PreciseFlexError(code, "")), code)
+    self.assertFalse(is_collision(PreciseFlexError(-1028, "")))  # hard E-stop, not a collision
+    self.assertFalse(
+      is_collision(PreciseFlexError(-1009, ""))
+    )  # no robot attached, not a collision
+    self.assertFalse(is_collision(ValueError()))
+
+  async def test_recover_repowers_attaches_and_homes(self):
+    """Recovery from a non-E-stop fault re-enables power, re-attaches, and re-homes."""
+    d = _make_driver()
+    d.request_system_state = AsyncMock(return_value=7)  # off, waiting for enable (not E-stop)
+    d.power_on_robot = AsyncMock()
+    d.attach = AsyncMock()
+    d.home = AsyncMock()
+    await d.recover_from_fault()
+    d.power_on_robot.assert_awaited_once()
+    d.attach.assert_awaited_once_with(1)
+    d.home.assert_awaited_once()
+
+  async def test_recover_refuses_while_estop_engaged(self):
+    """A hard E-stop blocks recovery (release the button first); power is not touched."""
+    d = _make_driver()
+    d.request_system_state = AsyncMock(return_value=15)  # OFF_HARD_ESTOP
+    d.power_on_robot = AsyncMock()
+    d.home = AsyncMock()
+    with self.assertRaises(PreciseFlexError) as ctx:
+      await d.recover_from_fault()
+    self.assertEqual(ctx.exception.replycode, -1028)
+    d.power_on_robot.assert_not_awaited()
+    d.home.assert_not_awaited()
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Makes a PreciseFlex move interruptible and recoverable, handling the three ways a move can be cut short. All three were characterised and validated on the lab PF400.

**Stacks on #1104** (it uses `PowerState` from that PR); now that #1104 is merged into `v1b1` and this branch is rebased on it, the diff is the interrupt files only.

The enabler is a non-blocking motion wait. `_wait_for_eom` now polls `wherej` until the arm stops moving, instead of issuing the firmware `waitForEom`. Hardware finding: `waitForEom` parks the controller's single command interpreter, so a `halt` sent behind it is ignored until the move ends (a `halt` at t=1.0s into a slow move sat unread until the move finished at t=8.5s). The controller also refuses a second connection, so there is no separate halt channel. Polling leaves the connection free between samples, so an interrupt can stop the move mid-flight - and, in future, other controller commands (status / vision / barcode) can run during motion.

The three interruption types:

- **User interrupt** (Ctrl+C / notebook stop) - `interrupt.halt_on_interrupt` wraps the wait; on `KeyboardInterrupt` / `asyncio.CancelledError` it sends `halt` on the now-free connection, drains and resyncs the link, leaves the socket open, then raises `OperationInterrupted` (a `KeyboardInterrupt`) or re-raises `CancelledError` (what notebooks and `asyncio.run` actually deliver). A second interrupt cannot abort the halt (shielded run-to-completion).
- **E-stop** - `request_system_state()` reads the `sysState` word (== DataID 234); `PowerState.OFF_HARD_ESTOP` (15) detects a hard E-stop directly and read-only, without provoking the `-1028` error. Recovery is manual (release the button, then re-enable power).
- **Crash / collision** - the servo stops the arm itself (envelope / torque-saturation error) faster than software can react, and drops power. `errors.is_collision()` recognises `-3100`/`-3101`/`-3105`/`-3122`; `recover_from_fault()` re-enables power, re-attaches, and re-homes (which only cycles the gripper when the other axes are already homed, so it does not sweep the arm). Deliberate, never automatic - a crash means an obstacle is present.

Validated on hardware (lab PF400): a notebook interrupt and a terminal Ctrl+C each halt a move mid-flight (multi-axis) with the connection still usable; the E-stop reads `sysState` 15 and clears to 21 on release + re-power; a real collision returns `-3100`/`-3101` and `recover_from_fault()` brings the arm from `sysState` 7 back to 21, moving only the gripper.

Tests: the poll/settle and immediate-return-when-stationary paths, interrupt-halt + resync, CancelledError re-raise, timeout, the `halt_and_resync` helper, `is_collision` over the collision codes vs E-stop / no-attach / non-PreciseFlexError, and `recover_from_fault` (re-power + attach + home, and the E-stop refusal). Lint, format, and isort clean; no new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
