### PR TITLE
v1: `STARBackend`: drop unused `HamiltonSTARDeck` import

### DIFF
--- a/pylabrobot/hamilton/liquid_handlers/star/star.py
+++ b/pylabrobot/hamilton/liquid_handlers/star/star.py
@@ -12,7 +12,7 @@ from pylabrobot.capabilities.liquid_handling.pip import PIP
 from pylabrobot.device import Device
 from pylabrobot.resources import Coordinate
 from pylabrobot.resources.hamilton import HamiltonDeck, STARDeck, STARLetDeck
-from pylabrobot.resources.hamilton.hamilton_decks import HamiltonCoreGrippers, HamiltonSTARDeck
+from pylabrobot.resources.hamilton.hamilton_decks import HamiltonCoreGrippers
 
 from .chatterbox import STARChatterboxDriver
 from .core import CoreGripper


### PR DESCRIPTION
Removes an unused `HamiltonSTARDeck` import in `star.py` (keeping `HamiltonCoreGrippers`). It trips `F401` and so the `v1b1` Linting check fails for every PR based on `v1b1`, not just this one. No behaviour change; nothing imports the symbol from `star.star`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)