### PR TITLE
v1: `PreciseFlexArmBackend`: move per-model specifics up to the device front-ends

### DIFF
--- a/pylabrobot/brooks/__init__.py
+++ b/pylabrobot/brooks/__init__.py
@@ -1,6 +1,5 @@
 from .precise_flex import (
   PreciseFlex400,
-  PreciseFlex3400Backend,
   PreciseFlexArmBackend,
   PreciseFlexDriver,
 )

--- a/pylabrobot/brooks/precise_flex/__init__.py
+++ b/pylabrobot/brooks/precise_flex/__init__.py
@@ -41,15 +41,13 @@ from pylabrobot.brooks.precise_flex.kinematics import (
 )
 from pylabrobot.brooks.precise_flex.precise_flex import (
   PreciseFlex400,
-  PreciseFlex400Backend,
-  PreciseFlex3400Backend,
+  PreciseFlex3400,
 )
 
 __all__ = [
   "Axis",
   "PreciseFlex400",
-  "PreciseFlex400Backend",
-  "PreciseFlex3400Backend",
+  "PreciseFlex3400",
   "PreciseFlexArmBackend",
   "PreciseFlexCartesianPose",
   "PreciseFlexConfiguration",

--- a/pylabrobot/brooks/precise_flex/arm_backend.py
+++ b/pylabrobot/brooks/precise_flex/arm_backend.py
@@ -3,9 +3,8 @@
 import dataclasses
 import logging
 import warnings
-from abc import ABC
 from dataclasses import dataclass
-from typing import Dict, List, Literal, Optional
+from typing import ClassVar, Dict, List, Literal, Optional
 
 from pylabrobot.capabilities.arms.backend import (
   CanFreedrive,
@@ -55,7 +54,7 @@ def _zip_axis_ranges(
   return {axis: (low[axis], high[axis]) for axis in low.keys() & high.keys()}
 
 
-def _snap_to_current(ik_joints: JointPose, current: JointPose, wrist: Wrist) -> JointPose:
+def _snap_to_current(ik_joints: JointPose, current: JointPose, wrist: Optional[Wrist]) -> JointPose:
   """Shift each rotary joint by 360° multiples toward `current`, then re-enforce
   the wrist-sign half on J4 so the result still matches `wrist`. Avoids
   gratuitous full-turn moves when multiple IK solutions are equivalent.
@@ -70,7 +69,7 @@ def _snap_to_current(ik_joints: JointPose, current: JointPose, wrist: Wrist) -> 
   return out
 
 
-class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive, ABC):
+class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive):
   """Backend for the PreciseFlex robotic arm.
 
   Default to using Cartesian coordinates; some methods in Brook's TCS
@@ -79,6 +78,27 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
   Documentation and error codes available at
   https://www2.brooksautomation.com/#Root/Welcome.htm
   """
+
+  # Validated parked orientations: planar folds differing only in which way the arm faces, named for
+  # the direction the gripper points (BACK / RIGHT / FRONT). The Z column (Axis.BASE) is omitted on
+  # purpose - ``park()`` fills it from the discovered travel (3/4 of it) so one orientation works on
+  # any reach; set Axis.BASE yourself to override. The gripper and rail are left untouched so parking
+  # never drops a held plate or assumes a rail. Assign one to ``parking_position`` to change the park.
+  PARKING_POSITION_BACK: ClassVar[JointPose] = {
+    Axis.SHOULDER: 90.0,
+    Axis.ELBOW: 180.0,
+    Axis.WRIST: 90.0,
+  }
+  PARKING_POSITION_RIGHT: ClassVar[JointPose] = {
+    Axis.SHOULDER: 0.0,
+    Axis.ELBOW: 180.0,
+    Axis.WRIST: 180.0,
+  }
+  PARKING_POSITION_FRONT: ClassVar[JointPose] = {
+    Axis.SHOULDER: -90.0,
+    Axis.ELBOW: 180.0,
+    Axis.WRIST: 270.0,
+  }
 
   def __init__(
     self,
@@ -90,6 +110,7 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     has_rail: bool = False,
     read_kinematics_from_device: bool = True,
     recover_out_of_range_at_setup: bool = True,
+    parking_position: Optional[JointPose] = None,
   ) -> None:
     """
     Args:
@@ -114,6 +135,10 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
         Depends on the mounted gripper. The conversion mm → firmware units is
         linear with slope 1: ``units = closed_gripper_position + (width_mm -
         min_gripper_width)``.
+      parking_position: initial value for the public, runtime-settable ``parking_position`` that
+        ``park()`` moves to. Leave None (the default) and setup fills the generic default RIGHT pose
+        (planar fold, Z column at 3/4 of the discovered travel); reassign it any time to park
+        elsewhere. While unset (no configuration), ``park()`` falls back to ``movetosafe``.
     """
     super().__init__()
     self.driver = driver
@@ -130,8 +155,12 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     )
     self._read_kinematics_from_device = read_kinematics_from_device
     self._recover_out_of_range_at_setup = recover_out_of_range_at_setup
-    # Device configuration, resolved once at setup; None until then.
+    # Device configuration, resolved once at setup; None until then. Set before parking_position so its
+    # validating setter can check assignments against the soft limits once they are known.
     self._configuration: Optional[PreciseFlexConfiguration] = None
+    # Public and runtime-settable (validated on assignment); setup fills the default RIGHT pose when
+    # this is left None.
+    self.parking_position = parking_position
     if is_dual_gripper:
       warnings.warn(
         "Dual gripper support is experimental and may not work as expected.", UserWarning
@@ -152,6 +181,8 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       )
       return
     self._adopt_configuration(self._configuration)
+    if self.parking_position is None:
+      self.parking_position = self.PARKING_POSITION_RIGHT
     self._log_configuration_summary(self._configuration)
     self._assess_configuration(self._configuration)
     await self._handle_out_of_range_axes()
@@ -321,7 +352,8 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     joints[Axis.SHOULDER] = ik_joints[2]
     joints[Axis.ELBOW] = ik_joints[3]
     joints[Axis.WRIST] = ik_joints[4]
-    joints[Axis.RAIL] = cart.rail_position
+    if cart.rail_position is not None:
+      joints[Axis.RAIL] = cart.rail_position
     return joints
 
   # -- high-level motion API -------------------------------------------------
@@ -390,12 +422,57 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """Stops the current robot immediately but leaves power on."""
     await self.driver.send_command("halt")
 
-  async def park(self, backend_params: Optional[BackendParams] = None) -> None:
-    """Move the robot to its parking position.
+  @property
+  def parking_position(self) -> Optional[JointPose]:
+    """The pose ``park()`` moves to. Assign one of the ``PARKING_POSITION_BACK/RIGHT/FRONT`` class
+    constants or any JointPose; the assignment is validated (keys must be ``Axis`` members, values must
+    be within the soft limits once the configuration is known). None until setup, where it defaults to
+    ``PARKING_POSITION_RIGHT``. A pose that omits ``Axis.BASE`` has its Z filled at park time."""
+    return self._parking_position
 
-    Does not include checks for collision with 3rd party obstacles inside the work volume of the robot.
+  @parking_position.setter
+  def parking_position(self, position: Optional[JointPose]) -> None:
+    if position is not None:
+      self._validate_parking_position(position)
+    self._parking_position: Optional[JointPose] = dict(position) if position is not None else None
+
+  async def park(self, backend_params: Optional[BackendParams] = None) -> None:
+    """Move to ``self.parking_position``; defaults at setup, reassignable at runtime.
+
+    ``parking_position`` is filled at setup with ``PARKING_POSITION_RIGHT`` (a planar fold facing
+    right, Z column at 3/4 of its discovered travel); assign one of the ``PARKING_POSITION_*`` class
+    constants or any JointPose to park elsewhere. Falls back to the firmware ``movetosafe`` while it is
+    unset. No collision checks against 3rd-party obstacles.
     """
-    await self.driver.send_command("movetosafe")
+    if self.parking_position is not None:
+      await self.move_to_joint_position(
+        position=self._parking_pose_with_default_z(self.parking_position)
+      )
+    else:
+      await self.driver.send_command("movetosafe")
+
+  def _validate_parking_position(self, position: JointPose) -> None:
+    """Reject anything that is not a JointPose of in-range axes (limits checked once known)."""
+    if not isinstance(position, dict) or not position:
+      raise ValueError(f"parking_position must be a non-empty JointPose, got {position!r}")
+    for axis, value in position.items():
+      if not isinstance(axis, Axis):
+        raise ValueError(f"parking_position keys must be Axis members, got {axis!r}")
+      if not isinstance(value, (int, float)):
+        raise ValueError(f"parking_position[{axis.name}] must be a number, got {value!r}")
+      if self._configuration is not None:
+        lo, hi = self._configuration.soft_limits[axis]
+        if not lo <= value <= hi:
+          raise ValueError(
+            f"parking_position[{axis.name}]={value} is outside the soft limits [{lo}, {hi}]"
+          )
+
+  def _parking_pose_with_default_z(self, position: JointPose) -> JointPose:
+    """Fill the Z column (``Axis.BASE``) at 3/4 of the discovered travel when the pose omits it."""
+    if Axis.BASE in position or self._configuration is None:
+      return position
+    _, z_max = self._configuration.z_range
+    return {Axis.BASE: 0.75 * z_max, **position}
 
   async def move_rail(self, rail_position: float) -> None:
     """Move the rail to the specified position.
@@ -977,7 +1054,7 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """Per-axis rated speed at 100%; J1/J5 in mm/s, J2-J4 in deg/s."""
     return _parse_per_axis(await self.request_parameter(DataID.REFERENCE_SPEED))
 
-  async def request_reference_accel(self) -> Dict[Axis, float]:
+  async def request_reference_acceleration(self) -> Dict[Axis, float]:
     """Per-axis rated acceleration at 100%."""
     return _parse_per_axis(await self.request_parameter(DataID.REFERENCE_ACCEL))
 
@@ -1009,7 +1086,7 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """Rated Cartesian (translational) speed at 100%, in mm/s."""
     return _parse_scalar(await self.request_parameter(DataID.REFERENCE_CARTESIAN_SPEED))
 
-  async def request_reference_cartesian_accel(self) -> float:
+  async def request_reference_cartesian_acceleration(self) -> float:
     """Rated Cartesian (translational) acceleration at 100%, in mm/s^2."""
     return _parse_scalar(await self.request_parameter(DataID.REFERENCE_CARTESIAN_ACCEL))
 
@@ -1017,11 +1094,11 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """Global cap on the speed percentage (one value, applies to all joints)."""
     return _parse_scalar(await self.request_parameter(DataID.MAX_SPEED_PERCENT))
 
-  async def request_max_accel_percent(self) -> float:
+  async def request_max_acceleration_percent(self) -> float:
     """Global cap on the acceleration percentage (one value, applies to all joints)."""
     return _parse_scalar(await self.request_parameter(DataID.MAX_ACCEL_PERCENT))
 
-  async def request_max_decel_percent(self) -> float:
+  async def request_max_deceleration_percent(self) -> float:
     """Global cap on the deceleration percentage (one value, applies to all joints)."""
     return _parse_scalar(await self.request_parameter(DataID.MAX_DECEL_PERCENT))
 
@@ -1082,10 +1159,10 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     # Combine the per-axis 100% references with the global percent caps into the
     # effective per-joint maxima, so consumers get usable limits, not raw factors.
     reference_speed = await self.request_reference_speed()
-    reference_accel = await self.request_reference_accel()
+    reference_acceleration = await self.request_reference_acceleration()
     speed_pct = await self.request_max_speed_percent()
-    accel_pct = await self.request_max_accel_percent()
-    decel_pct = await self.request_max_decel_percent()
+    acceleration_pct = await self.request_max_acceleration_percent()
+    deceleration_pct = await self.request_max_deceleration_percent()
 
     # Kinematics: read the link/tool geometry from the controller by default, so
     # the driver is correct for whichever 400 variant is plugged in; fall back to
@@ -1134,10 +1211,16 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       soft_limits=soft_limits,
       hard_limits=await self.request_joint_limits(hard=True),
       max_joint_speed={a: v * speed_pct / 100 for a, v in reference_speed.items()},
-      max_joint_accel={a: v * accel_pct / 100 for a, v in reference_accel.items()},
-      max_joint_decel={a: v * decel_pct / 100 for a, v in reference_accel.items()},
+      max_joint_acceleration={
+        a: v * acceleration_pct / 100 for a, v in reference_acceleration.items()
+      },
+      max_joint_deceleration={
+        a: v * deceleration_pct / 100 for a, v in reference_acceleration.items()
+      },
       max_cartesian_speed=(await self.request_reference_cartesian_speed()) * speed_pct / 100,
-      max_cartesian_accel=(await self.request_reference_cartesian_accel()) * accel_pct / 100,
+      max_cartesian_acceleration=(await self.request_reference_cartesian_acceleration())
+      * acceleration_pct
+      / 100,
       power_state=await self.request_power_state(),
       kinematics=kinematic_params,
       kinematics_source=kinematics_source,
@@ -1205,15 +1288,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       value: The signal value to set. 0 = off, non-zero = on.
     """
     await self.driver.send_command(f"sig {signal_number} {value}")
-
-  async def request_system_state(self) -> int:
-    """Get the global system state code.
-
-    Returns:
-      The global system state code. Please see documentation for DataID 234.
-    """
-    response = await self.driver.send_command("sysState")
-    return int(response)
 
   async def request_tool_transformation_values(
     self,
@@ -1409,7 +1483,7 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       raise ValueError(f"speed2_pct must be between 0 and 100, got {speed2_pct}")
     await self.driver.send_command(f"Speed2 {profile_index} {speed2_pct}")
 
-  async def request_profile_accel(self, profile_index: int) -> float:
+  async def request_profile_acceleration(self, profile_index: int) -> float:
     """Get the acceleration property of the specified profile.
 
     Args:
@@ -1419,10 +1493,10 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       float: The current acceleration as a percentage. 100 = maximum acceleration.
     """
     response = await self.driver.send_command(f"Accel {profile_index}")
-    profile, accel = response.split()
-    return float(accel)
+    profile, acceleration = response.split()
+    return float(acceleration)
 
-  async def set_profile_accel(self, profile_index: int, acceleration_pct: float) -> None:
+  async def set_profile_acceleration(self, profile_index: int, acceleration_pct: float) -> None:
     """Set the acceleration property of the specified profile.
 
     Args:
@@ -1436,7 +1510,7 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       raise ValueError(f"acceleration_pct must be between 0 and 100, got {acceleration_pct}")
     await self.driver.send_command(f"Accel {profile_index} {acceleration_pct}")
 
-  async def request_profile_accel_ramp(self, profile_index: int) -> float:
+  async def request_profile_acceleration_ramp(self, profile_index: int) -> float:
     """Get the acceleration ramp property of the specified profile.
 
     Args:
@@ -1446,19 +1520,21 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       float: The current acceleration ramp time in seconds.
     """
     response = await self.driver.send_command(f"AccRamp {profile_index}")
-    profile, accel_ramp = response.split()
-    return float(accel_ramp)
+    profile, acceleration_ramp = response.split()
+    return float(acceleration_ramp)
 
-  async def set_profile_accel_ramp(self, profile_index: int, accel_ramp_seconds: float) -> None:
+  async def set_profile_acceleration_ramp(
+    self, profile_index: int, acceleration_ramp_seconds: float
+  ) -> None:
     """Set the acceleration ramp property of the specified profile.
 
     Args:
       profile_index: The profile index to modify.
-      accel_ramp_seconds: The new acceleration ramp time in seconds.
+      acceleration_ramp_seconds: The new acceleration ramp time in seconds.
     """
-    await self.driver.send_command(f"AccRamp {profile_index} {accel_ramp_seconds}")
+    await self.driver.send_command(f"AccRamp {profile_index} {acceleration_ramp_seconds}")
 
-  async def request_profile_decel(self, profile_index: int) -> float:
+  async def request_profile_deceleration(self, profile_index: int) -> float:
     """Get the deceleration property of the specified profile.
 
     Args:
@@ -1468,10 +1544,10 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       float: The current deceleration as a percentage. 100 = maximum deceleration.
     """
     response = await self.driver.send_command(f"Decel {profile_index}")
-    profile, decel = response.split()
-    return float(decel)
+    profile, deceleration = response.split()
+    return float(deceleration)
 
-  async def set_profile_decel(self, profile_index: int, deceleration_pct: float) -> None:
+  async def set_profile_deceleration(self, profile_index: int, deceleration_pct: float) -> None:
     """Set the deceleration property of the specified profile.
 
     Args:
@@ -1485,7 +1561,7 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       raise ValueError(f"deceleration_pct must be between 0 and 100, got {deceleration_pct}")
     await self.driver.send_command(f"Decel {profile_index} {deceleration_pct}")
 
-  async def request_profile_decel_ramp(self, profile_index: int) -> float:
+  async def request_profile_deceleration_ramp(self, profile_index: int) -> float:
     """Get the deceleration ramp property of the specified profile.
 
     Args:
@@ -1495,17 +1571,19 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       float: The current deceleration ramp time in seconds.
     """
     response = await self.driver.send_command(f"DecRamp {profile_index}")
-    profile, decel_ramp = response.split()
-    return float(decel_ramp)
+    profile, deceleration_ramp = response.split()
+    return float(deceleration_ramp)
 
-  async def set_profile_decel_ramp(self, profile_index: int, decel_ramp_seconds: float) -> None:
+  async def set_profile_deceleration_ramp(
+    self, profile_index: int, deceleration_ramp_seconds: float
+  ) -> None:
     """Set the deceleration ramp property of the specified profile.
 
     Args:
       profile_index: The profile index to modify.
-      decel_ramp_seconds: The new deceleration ramp time in seconds.
+      deceleration_ramp_seconds: The new deceleration ramp time in seconds.
     """
-    await self.driver.send_command(f"DecRamp {profile_index} {decel_ramp_seconds}")
+    await self.driver.send_command(f"DecRamp {profile_index} {deceleration_ramp_seconds}")
 
   async def request_profile_in_range(self, profile_index: int) -> float:
     """Get the InRange property of the specified profile.
@@ -1589,8 +1667,8 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       profile: Profile index to set values for.
       speed_pct: Percentage of maximum speed (0-100). 100 = full speed.
       speed2_pct: Secondary speed setting (0-100), typically for Cartesian moves. Normally 0.
-      acceleration_pct: Percentage of maximum acceleration (0-100). 100 = full accel.
-      deceleration_pct: Percentage of maximum deceleration (0-100). 100 = full decel.
+      acceleration_pct: Percentage of maximum acceleration (0-100). 100 = full acceleration.
+      deceleration_pct: Percentage of maximum deceleration (0-100). 100 = full deceleration.
       acceleration_ramp: Acceleration ramp time in seconds.
       deceleration_ramp: Deceleration ramp time in seconds.
       in_range: InRange value, from -1 to 100. -1 = allow blending, 0 = stop without checking, >0 = enforce position accuracy.

--- a/pylabrobot/brooks/precise_flex/config.py
+++ b/pylabrobot/brooks/precise_flex/config.py
@@ -60,10 +60,10 @@ class PreciseFlexConfiguration:
   hard_limits: Dict[Axis, tuple]
   # Effective per-joint maxima (reference x the global percent cap, already applied).
   max_joint_speed: Dict[Axis, float]
-  max_joint_accel: Dict[Axis, float]
-  max_joint_decel: Dict[Axis, float]
+  max_joint_acceleration: Dict[Axis, float]
+  max_joint_deceleration: Dict[Axis, float]
   max_cartesian_speed: float
-  max_cartesian_accel: float
+  max_cartesian_acceleration: float
   power_state: int
   # --- supplied / derived ---
   kinematics: "kinematics.PF400Params" = dataclasses.field(default_factory=kinematics.PF400Params)

--- a/pylabrobot/brooks/precise_flex/confirmed_firmware_versions.py
+++ b/pylabrobot/brooks/precise_flex/confirmed_firmware_versions.py
@@ -8,7 +8,7 @@ discovered stack here:
 - ``SUPPORTED_ROBOT_TYPES`` gates the client-side kinematics. This driver's FK/IK
   is the PreciseFlex 400 two-link SCARA geometry, so other models would get
   silently-wrong joint targets and are flagged.
-- ``CONFIRMED_FIRMWARE_VERSIONS`` is the list of full (model, GPL, TCS, module-set)
+- ``CONFIRMED_FIRMWARE_VERSIONS`` is the set of full (model, GPL, TCS, module-set)
   software stacks validated against this driver; an unlisted one logs a warning
   asking for a report so it can be added.
 
@@ -37,20 +37,22 @@ class ConfirmedFirmware:
   modules: tuple  # one "name version" per loaded TCS module
 
 
-CONFIRMED_FIRMWARE_VERSIONS = [
-  ConfirmedFirmware(
-    robot_type=12,
-    gpl_version="GPL 5.1D4",
-    tcs_version="TCP Command Server 3.0D4",
-    modules=(
-      "IntelliGuide 1.0",
-      "Load-Save Module 3.0B2",
-      "PARobot Auto Center Module 3.0D3",
-      "PARobot Module 3.0D4",
-      "SSGrip Module 3.0D4",
+CONFIRMED_FIRMWARE_VERSIONS = frozenset(
+  [
+    ConfirmedFirmware(
+      robot_type=12,
+      gpl_version="GPL 5.1D4",
+      tcs_version="TCP Command Server 3.0D4",
+      modules=(
+        "IntelliGuide 1.0",
+        "Load-Save Module 3.0B2",
+        "PARobot Auto Center Module 3.0D3",
+        "PARobot Module 3.0D4",
+        "SSGrip Module 3.0D4",
+      ),
     ),
-  ),
-]
+  ]
+)
 
 # Trailing build date (e.g. "10-25-2024" or "Apr 25 2025") and anything after it.
 _DATE = re.compile(r",?\s*(\d{1,2}[-/]\d{1,2}[-/]\d{2,4}|[A-Za-z]{3,9}\.?\s+\d{1,2},?\s+\d{4}).*$")

--- a/pylabrobot/brooks/precise_flex/precise_flex.py
+++ b/pylabrobot/brooks/precise_flex/precise_flex.py
@@ -1,34 +1,13 @@
 """PreciseFlex device front-ends - the user-facing per-model device classes."""
 
-from typing import Optional
-
 from pylabrobot.capabilities.arms.orientable_arm import OrientableGripperArm
-from pylabrobot.capabilities.arms.standard import JointPose
-from pylabrobot.capabilities.capability import BackendParams
 from pylabrobot.device import Device
 from pylabrobot.resources.resource import Resource
 
 from .arm_backend import PreciseFlexArmBackend
-from .config import Axis
 from .driver import PreciseFlexDriver
 
-
-class PreciseFlex400Backend(PreciseFlexArmBackend):
-  """Backend for the PreciseFlex 400 robotic arm."""
-
-  _PARKING_POSITION: JointPose = {
-    Axis.BASE: 170.0,
-    Axis.SHOULDER: 0.0,
-    Axis.ELBOW: 180.0,
-    Axis.WRIST: -180.0,
-  }
-
-  async def park(self, backend_params: Optional[BackendParams] = None) -> None:
-    """Move the PF400 to its parking position via joint move.
-
-    Sends an explicit joint target instead of the firmware ``movetosafe`` command.
-    """
-    await self.move_to_joint_position(position=self._PARKING_POSITION)
+# -- PreciseFlex 400 -------------------------------------------------------
 
 
 class PreciseFlex400(Device):
@@ -60,8 +39,8 @@ class PreciseFlex400(Device):
     """
     driver = PreciseFlexDriver(host=host, port=port, timeout=timeout)
     super().__init__(driver=driver)
-    self.driver: PreciseFlexDriver = driver
-    backend = PreciseFlex400Backend(
+    self.driver: PreciseFlexDriver
+    backend = PreciseFlexArmBackend(
       driver=driver,
       has_rail=has_rail,
       gripper_length=gripper_length,
@@ -74,21 +53,46 @@ class PreciseFlex400(Device):
     self._capabilities = [self.arm]
 
 
-class PreciseFlex3400Backend(PreciseFlexArmBackend):
-  """Backend for the PreciseFlex 3400 robotic arm."""
+# -- PreciseFlex 3400 ------------------------------------------------------
+
+
+class PreciseFlex3400(Device):
+  """Device wrapper for the PreciseFlex 3400 robotic arm.
+
+  Mirrors :class:`PreciseFlex400`. The 3400 is the same two-link SCARA family (its link
+  lengths are read from the controller at setup), with a taller reach.
+  """
 
   def __init__(
     self,
-    driver: PreciseFlexDriver,
-    gripper_length: float,
-    gripper_z_offset: float,
+    host: str,
     closed_gripper_position: float,
+    gripper_length: float,
+    port: int = 10100,
     has_rail: bool = False,
+    timeout: int = 20,
+    gripper_z_offset: float = 0.0,
   ) -> None:
-    super().__init__(
+    """
+    Args:
+      closed_gripper_position: firmware-unit value at which the jaws are at the backend's
+        :attr:`~PreciseFlexArmBackend.min_gripper_width`. Depends on the mounted gripper;
+        calibrate before first use.
+      gripper_length: wrist-axis → TCP distance in mm. Required - unlike the PF400 there is
+        no stock default, because the 3400 ships with an IntelliGuide gripper whose length
+        differs; set it for the gripper actually mounted.
+      gripper_z_offset: vertical offset in mm from the wrist plate to the tool tip.
+    """
+    driver = PreciseFlexDriver(host=host, port=port, timeout=timeout)
+    super().__init__(driver=driver)
+    self.driver: PreciseFlexDriver
+    backend = PreciseFlexArmBackend(
       driver=driver,
       has_rail=has_rail,
       gripper_length=gripper_length,
       gripper_z_offset=gripper_z_offset,
       closed_gripper_position=closed_gripper_position,
     )
+    self.reference = Resource(name="PreciseFlex3400", size_x=200, size_y=200, size_z=200)
+    self.arm = OrientableGripperArm(backend=backend, reference_resource=self.reference)
+    self._capabilities = [self.arm]

--- a/pylabrobot/brooks/precise_flex/tests/arm_backend_tests.py
+++ b/pylabrobot/brooks/precise_flex/tests/arm_backend_tests.py
@@ -2,16 +2,16 @@ import unittest
 from typing import Tuple
 from unittest.mock import AsyncMock, MagicMock
 
-from pylabrobot.brooks.precise_flex import Axis, PreciseFlex400Backend
+from pylabrobot.brooks.precise_flex import Axis, PreciseFlexArmBackend
 
 
 def _make_backend(
   closed_gripper_position: float = 500.0,
-) -> Tuple[PreciseFlex400Backend, MagicMock]:
+) -> Tuple[PreciseFlexArmBackend, MagicMock]:
   driver = MagicMock()
   driver.send_command = AsyncMock(return_value="")
   driver.io._host = "localhost"
-  backend = PreciseFlex400Backend(
+  backend = PreciseFlexArmBackend(
     driver=driver,
     gripper_length=162.0,
     gripper_z_offset=0.0,
@@ -79,7 +79,6 @@ class TestPreciseFlex400OutOfRangeRecovery(unittest.IsolatedAsyncioTestCase):
   def setUp(self):
     self.backend, self.driver = _make_backend()
     self.driver._wait_for_eom = AsyncMock()
-    self.backend._request_speed = AsyncMock(return_value=50.0)
     # Minimal stub configuration: only the soft limits the recovery logic reads.
     self.backend._configuration = MagicMock(
       soft_limits={
@@ -88,6 +87,22 @@ class TestPreciseFlex400OutOfRangeRecovery(unittest.IsolatedAsyncioTestCase):
         Axis.WRIST: (-960.0, 960.0),
       }
     )
+
+  def _stub_transport(self, wherej: str) -> None:
+    """Stub the driver: ``wherej`` returns ``wherej``, ``Speed`` a 50% profile, other writes no-op.
+
+    The recovery logic reads the live pose and profile speed over the transport, so we feed those
+    rather than reassigning backend methods (mirrors the STAR tests' driver-boundary mocking).
+    """
+
+    async def respond(command: str) -> str:
+      if command == "wherej":
+        return wherej
+      if command.startswith("Speed "):
+        return f"{self.backend.profile_index} 50.0"
+      return ""
+
+    self.driver.send_command = AsyncMock(side_effect=respond)
 
   def _move_one_axis_cmds(self) -> list[str]:
     return [
@@ -99,21 +114,99 @@ class TestPreciseFlex400OutOfRangeRecovery(unittest.IsolatedAsyncioTestCase):
   async def test_recover_moves_offenders_toward_limit_in_order_and_skips_wrist(self):
     """Each recoverable offender is driven 1 unit *inside* the violated limit (above-max down,
     below-min up), shoulder before elbow per _RECOVERY_ORDER; the wrist is never auto-moved."""
-    self.backend.request_joint_position = AsyncMock(
-      return_value={Axis.SHOULDER: 93.5, Axis.ELBOW: 9.0, Axis.WRIST: 962.0}
-    )
+    # wherej (no rail): base shoulder elbow wrist gripper - shoulder/elbow/wrist out of range.
+    self._stub_transport("0 93.5 9.0 962.0 0")
     recovered = await self.backend.recover_axes_within_limits()
     self.assertEqual(recovered, {Axis.SHOULDER: 92.0, Axis.ELBOW: 13.0})  # wrist excluded
-    cmds = self._move_one_axis_cmds()
     self.assertEqual(
-      cmds, ["MoveOneAxis 2 92.0 1", "MoveOneAxis 3 13.0 1"]
+      self._move_one_axis_cmds(), ["MoveOneAxis 2 92.0 1", "MoveOneAxis 3 13.0 1"]
     )  # shoulder (2) before elbow (3)
 
   async def test_recover_skips_axis_too_far_out_of_range(self):
     """An axis past its limit by more than max_distance is left in place (no unattended big sweep)."""
-    self.backend.request_joint_position = AsyncMock(
-      return_value={Axis.SHOULDER: 120.0}  # 27 deg past the 93 limit, beyond the 5 cap
-    )
+    # shoulder 120 deg is 27 past the 93 limit, beyond the 5 cap; elbow/wrist in range.
+    self._stub_transport("0 120.0 30.0 0.0 0")
     recovered = await self.backend.recover_axes_within_limits()
     self.assertEqual(recovered, {})
     self.assertEqual(self._move_one_axis_cmds(), [])
+
+
+class TestPreciseFlexParking(unittest.IsolatedAsyncioTestCase):
+  def setUp(self):
+    self.backend, self.driver = _make_backend()
+    self.driver._wait_for_eom = AsyncMock()
+
+  def _full_soft_limits(self) -> MagicMock:
+    return MagicMock(
+      z_range=(0.0, 400.0),
+      soft_limits={
+        Axis.BASE: (0.0, 400.0),
+        Axis.SHOULDER: (-93.0, 93.0),
+        Axis.ELBOW: (12.0, 348.0),
+        Axis.WRIST: (-960.0, 960.0),
+      },
+    )
+
+  def _movej_cmds(self) -> list[str]:
+    return [
+      c.args[0] for c in self.driver.send_command.call_args_list if c.args[0].startswith("moveJ")
+    ]
+
+  def test_named_constants_are_orientation_only_planar_folds(self):
+    """The three parking orientations are planar folds (ELBOW 180) that never pin Z (Axis.BASE), so
+    one orientation works on any reach; they differ only in which way the gripper faces."""
+    for pose in (
+      PreciseFlexArmBackend.PARKING_POSITION_BACK,
+      PreciseFlexArmBackend.PARKING_POSITION_RIGHT,
+      PreciseFlexArmBackend.PARKING_POSITION_FRONT,
+    ):
+      self.assertNotIn(Axis.BASE, pose)
+      self.assertEqual(pose[Axis.ELBOW], 180.0)
+    self.assertEqual(PreciseFlexArmBackend.PARKING_POSITION_BACK[Axis.SHOULDER], 90.0)
+    self.assertEqual(PreciseFlexArmBackend.PARKING_POSITION_FRONT[Axis.SHOULDER], -90.0)
+
+  def test_assignment_rejects_non_axis_keys(self):
+    """The validating setter refuses a pose keyed by anything but Axis members."""
+    bad_pose: dict = {"base": 100.0}
+    with self.assertRaises(ValueError):
+      self.backend.parking_position = bad_pose
+
+  def test_assignment_rejects_out_of_limit_value_once_configured(self):
+    """Once the soft limits are known, a value outside them is rejected at assignment."""
+    self.backend._configuration = MagicMock(soft_limits={Axis.SHOULDER: (-93.0, 93.0)})
+    with self.assertRaises(ValueError):
+      self.backend.parking_position = {Axis.SHOULDER: 200.0}
+
+  def test_assignment_accepts_named_constant(self):
+    """A named constant assigns cleanly and round-trips through the getter."""
+    self.backend.parking_position = PreciseFlexArmBackend.PARKING_POSITION_FRONT
+    pose = self.backend.parking_position
+    assert pose is not None
+    self.assertEqual(pose[Axis.SHOULDER], -90.0)
+
+  async def test_park_fills_z_at_three_quarters_travel_and_keeps_orientation(self):
+    """park() fills the omitted Z column at 3/4 of the discovered travel and keeps the orientation."""
+    self.backend._configuration = self._full_soft_limits()
+    # Current pose deliberately differs from the target (base 50 not 300; orientation 10/200/90 not
+    # 0/180/180) so the assertion proves park() supplied the fill and orientation, not the live pose.
+    self.driver.send_command = AsyncMock(return_value="50 10 200 90 0")
+    self.backend.parking_position = PreciseFlexArmBackend.PARKING_POSITION_RIGHT
+    await self.backend.park()
+    # Z filled at 3/4 of 400 = 300; orientation = RIGHT (0/180/180); gripper carried from current.
+    self.assertEqual(self._movej_cmds(), ["moveJ 1 300.0 0.0 180.0 180.0 0.0"])
+
+  async def test_park_respects_an_explicit_base(self):
+    """A pose that already sets Axis.BASE is parked as-is (no Z fill)."""
+    self.backend._configuration = self._full_soft_limits()
+    # base 50 in the current pose so the explicit 123 (neither the 300 fill nor the live 50) proves
+    # the supplied base is honored and not Z-filled; elbow/wrist carry from current.
+    self.driver.send_command = AsyncMock(return_value="50 10 200 90 0")
+    self.backend.parking_position = {Axis.BASE: 123.0, Axis.SHOULDER: 0.0}
+    await self.backend.park()
+    self.assertEqual(self._movej_cmds(), ["moveJ 1 123.0 0.0 200.0 90.0 0.0"])
+
+  async def test_park_without_position_falls_back_to_movetosafe(self):
+    """While parking_position is unset (no configuration), park() uses the firmware movetosafe."""
+    await self.backend.park()
+    self.driver.send_command.assert_awaited_once_with("movetosafe")
+    self.assertEqual(self._movej_cmds(), [])


### PR DESCRIPTION
PreciseFlex did not follow the v1 device shape. The per-model logic lived in capability-backend subclasses: `PreciseFlex400Backend`, a thin subclass whose only addition was a hardcoded park pose, and `PreciseFlex3400Backend`, which was constructed directly from a driver and had no device front-end at all - the pre-v1 backend-is-the-entry-point shape, so the 3400 was not reachable through the v1 Device interface. In v1 the model belongs at the Device layer and the capability backend is model-agnostic and driver-bound (cf. `STAR`/`STARLet`, which are Device subclasses over one shared backend). Model-specific backend subclasses inverted that: they put model identity in the capability layer, and the only thing they actually encoded - park pose, gripper defaults - is per-model configuration that belongs at the device the user selects.

This moves the model up to the Device. `PreciseFlex400` and `PreciseFlex3400` are now the per-model entry points (the 3400 gains a device front-end it never had), each supplying its own setup over a single shared `PreciseFlexArmBackend`; both backend subclasses are removed.

Changes:

- generic runtime-settable parking: `parking_position` defaults to the RIGHT pose (planar fold, Z column at 3/4 of the discovered travel) and can be reassigned at runtime, replacing the per-subclass hardcoded pose
- acceleration/deceleration spelled out across config and backend (no more `accel`/`decel`)
- `CONFIRMED_FIRMWARE_VERSIONS` is now a `frozenset`
- removed the backend `request_system_state` (redundant with `PreciseFlexDriver.request_system_state`; system state is a driver responsibility; no callers) and the vestigial `ABC` base (the class declares no abstract methods)

The `arm_backend.py` layering/reorg is deliberately split into a separate, easier-to-verify follow-up PR so this one stays small and reviewable.

Standalone - independent of the other open PreciseFlex work; vision lands separately.

Tests: the gripper-width mapping, out-of-range recovery, and the new parking suite cover the shared backend. Lint, format, and isort all green. Type-checking shows only the pre-existing `v1b1` base failures - the backend source adds none (the two `arm_backend.py` warnings are in untouched IK code); the new parking tests use the same `AsyncMock` method-assignment idiom mypy already flags across the existing suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
