### PR TITLE
fix(liconic): wait for the z-lift to reach the read position before scanning a barcode

### DIFF
--- a/pylabrobot/storage/liconic/liconic_backend.py
+++ b/pylabrobot/storage/liconic/liconic_backend.py
@@ -573,6 +573,7 @@ class ExperimentalLiconicBackend(IncubatorBackend):
     await self._send_command(f"WR DM25 {pos_num}")  # plate
     await self._send_command(f"WR DM5 {n}")  # plate position in carousel
     await self._send_command("ST 1910")  # move shovel to barcode reading position
+    await self._wait_ready()  # block until the lift reaches the read position
 
     barcode = await self.barcode_scanner.scan()
     logger.info(f"Scanned barcode: {barcode.data}")

--- a/pylabrobot/storage/liconic/liconic_backend_tests.py
+++ b/pylabrobot/storage/liconic/liconic_backend_tests.py
@@ -371,6 +371,24 @@ class TestInitialize(unittest.IsolatedAsyncioTestCase):
     self.backend._wait_ready.assert_awaited()
 
 
+class TestScanBarcode(unittest.IsolatedAsyncioTestCase):
+  """scan_barcode must wait for the z-lift to reach the read position (ST 1910)
+  before triggering the scan, otherwise the beam fires while the lift is still
+  travelling and reads a plate it passes en route, not the target."""
+
+  def setUp(self):
+    self.backend = ExperimentalLiconicBackend(model=LiconicType.STX44_IC, port="/dev/null")
+    self.backend._racks = [liconic_rack_17mm_22("rack1")]
+    self.backend._send_command = AsyncMock(return_value="OK")
+    self.backend._wait_ready = AsyncMock()
+    self.backend.barcode_scanner = AsyncMock()
+
+  async def test_scan_barcode_waits_for_lift(self):
+    await self.backend.scan_barcode(self.backend._racks[0].sites[0])
+    self.backend._send_command.assert_any_call("ST 1910")
+    self.backend._wait_ready.assert_awaited()
+
+
 class TestSerialization(unittest.TestCase):
   def test_serialize_roundtrip(self):
     backend = ExperimentalLiconicBackend(model=LiconicType.STX44_IC, port="/dev/ttyUSB0")


### PR DESCRIPTION
Summary:
## What

`ExperimentalLiconicBackend.scan_barcode()` sent the `ST 1910` move command to position the z-lift at the read height and then immediately triggered the scan, without waiting for the move to finish. The beam latched on while the lift was
still travelling, so it decoded whichever plate it passed en route instead of the requested level — e.g. on an STX220 with plates at levels 22 and 10, Scanning level 5 returned level 10's barcode.

This adds `await self._wait_ready()` between `ST 1910` and the scan, matching every other motion-issuing method in the backend (`open_door`, `close_door`, `initialize`, `take_in_plate`, `move_position_to_position`) and the sibling `read_barcode_inline()`, which already pair their `ST` command with `_wait_ready()`. `scan_barcode()` was the only one missing it. 

Fixes #1115

## Test

Added `TestScanBarcode` to `liconic_backend_tests.py`: it asserts `ST 1910` is sent and `_wait_ready` is awaited. Verified it fails against the pre-fix code. 

Also verified on hardware (STX220): plates loaded at two levels, scanning a lower third level now returns the requested level's barcode rather than one the lift passes on the way down.

Happy to make any changes upon reviewing