### PR TITLE
v1: `PreciseFlexArmBackend`: raise `OutOfRangeOfMotionError` and auto-recover out-of-range axes

### DIFF
--- a/pylabrobot/brooks/precise_flex/__init__.py
+++ b/pylabrobot/brooks/precise_flex/__init__.py
@@ -34,7 +34,7 @@ from pylabrobot.brooks.precise_flex.config import (
   PreciseFlexConfiguration,
 )
 from pylabrobot.brooks.precise_flex.driver import PreciseFlexDriver
-from pylabrobot.brooks.precise_flex.errors import PreciseFlexError
+from pylabrobot.brooks.precise_flex.errors import OutOfRangeOfMotionError, PreciseFlexError
 from pylabrobot.brooks.precise_flex.kinematics import (
   PreciseFlexCartesianPose,
   WorkEnvelope,
@@ -53,5 +53,6 @@ __all__ = [
   "PreciseFlexConfiguration",
   "PreciseFlexDriver",
   "PreciseFlexError",
+  "OutOfRangeOfMotionError",
   "WorkEnvelope",
 ]

--- a/pylabrobot/brooks/precise_flex/arm_backend.py
+++ b/pylabrobot/brooks/precise_flex/arm_backend.py
@@ -189,7 +189,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
         "Dual gripper support is experimental and may not work as expected.", UserWarning
       )
 
-  # [PLR]
   async def _on_setup(self, backend_params: Optional[BackendParams] = None) -> None:
     await super()._on_setup(backend_params=backend_params)
     await self.stop_freedrive_mode()
@@ -217,7 +216,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
 
   # -- parsing helpers ----------------------------------------------------------------------
 
-  # [int]
   def _parse_xyz_response(
     self, parts: List[str]
   ) -> tuple[float, float, float, float, float, float]:
@@ -232,7 +230,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       float(parts[5]),
     )
 
-  # [int]
   def _parse_angles_response(self, parts: List[str]) -> JointPose:
     """Parse angle values from a response string.
 
@@ -261,7 +258,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
 
   # -- raw parameters -----------------------------------------------------------------------
 
-  # [cmd]
   async def request_parameter(
     self,
     data_id: int,
@@ -294,7 +290,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       response = await self.driver.send_command(f"pd {data_id}")
     return response
 
-  # [cmd]
   async def set_parameter(
     self,
     data_id: int,
@@ -331,7 +326,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       else:
         await self.driver.send_command(f"pc {data_id} {value}")
 
-  # [cmd]
   async def set_axis_parameter(
     self,
     data_id: int,
@@ -361,7 +355,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       data_id, value, unit_number=robot_number, sub_unit=0, array_index=int(axis)
     )
 
-  # [cmd]
   async def nop(self) -> None:
     """No operation command.
 
@@ -372,7 +365,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
 
   # -- digital I/O --------------------------------------------------------------------------
 
-  # [cmd]
   async def request_signal(self, signal_number: int) -> int:
     """Get the value of the specified digital input or output signal.
 
@@ -386,7 +378,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     sig_id, sig_val = response.split()
     return int(sig_val)
 
-  # [cmd]
   async def set_signal(self, signal_number: int, value: int) -> None:
     """Set the specified digital input or output signal.
 
@@ -402,7 +393,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
 
   # -- motion primitives --------------------------------------------------------------------
 
-  # [int]
   async def _move_j(self, profile_index: int, joint_coords: JointPose) -> None:
     """Move the robot using joint coordinates, handling rail configuration. Raw moveJ - the
     out-of-range guard lives in the caller (``_guarded_move_j``), not in this primitive."""
@@ -425,7 +415,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       )
     await self.driver.send_command(f"moveJ {profile_index} {angles_str}")
 
-  # [int]
   async def _move_one_axis(self, axis: Axis, position: float) -> None:
     """Move a single axis to an absolute position (firmware ``MoveOneAxis``).
 
@@ -435,7 +424,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """
     await self.driver.send_command(f"MoveOneAxis {int(axis)} {position} {self.profile_index}")
 
-  # [int]
   async def _move_to_stored_location(self, location_index: int, profile_index: int) -> None:
     """Move to the location specified by the station index using the specified profile.
 
@@ -448,7 +436,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """
     await self.driver.send_command(f"move {location_index} {profile_index}")
 
-  # [int]
   async def _move_to_stored_location_appro(self, location_index: int, profile_index: int) -> None:
     """Approach the location specified by the station index using the specified profile.
 
@@ -463,7 +450,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """
     await self.driver.send_command(f"moveAppro {location_index} {profile_index}")
 
-  # [int]
   async def _set_joint_angles(
     self,
     location_index: int,
@@ -490,7 +476,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
         f"{joint_position[Axis.GRIPPER]}"
       )
 
-  # [int]
   async def _cart_to_joints(self, cart: PreciseFlexCartesianPose) -> JointPose:
     """Convert a Cartesian location into a full joint dict using our IK.
 
@@ -517,7 +502,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
 
   # -- speed & motion profiles --------------------------------------------------------------
 
-  # [cmd]
   async def request_monitor_speed(self) -> int:
     """Get the global system (monitor) speed.
 
@@ -527,7 +511,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     response = await self.driver.send_command("mspeed")
     return int(response)
 
-  # [cmd]
   async def set_monitor_speed(self, speed_pct: int) -> None:
     """Set the global system (monitor) speed.
 
@@ -541,7 +524,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       raise ValueError(f"speed_pct must be between 0 and 100, got {speed_pct}")
     await self.driver.send_command(f"mspeed {speed_pct}")
 
-  # [cmd]
   async def request_payload(self) -> int:
     """Get the payload percent value for the current robot.
 
@@ -551,7 +533,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     response = await self.driver.send_command("payload")
     return int(response)
 
-  # [cmd]
   async def set_payload(self, payload_pct: int) -> None:
     """Set the payload percent of maximum for the currently selected or attached robot.
 
@@ -568,7 +549,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       raise ValueError("Payload percent must be between 0 and 100")
     await self.driver.send_command(f"payload {payload_pct}")
 
-  # [cmd]
   async def request_profile_speed(self, profile_index: int) -> float:
     """Get the speed property of the specified profile.
 
@@ -582,7 +562,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     profile, speed = response.split()
     return float(speed)
 
-  # [cmd]
   async def set_profile_speed(self, profile_index: int, speed_pct: float) -> None:
     """Set the speed property of the specified profile.
 
@@ -597,7 +576,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       raise ValueError(f"speed_pct must be between 0 and 100, got {speed_pct}")
     await self.driver.send_command(f"Speed {profile_index} {speed_pct}")
 
-  # [cmd]
   async def request_profile_speed2(self, profile_index: int) -> float:
     """Get the speed2 property of the specified profile.
 
@@ -611,7 +589,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     profile, speed2 = response.split()
     return float(speed2)
 
-  # [cmd]
   async def set_profile_speed2(self, profile_index: int, speed2_pct: float) -> None:
     """Set the speed2 property of the specified profile.
 
@@ -627,7 +604,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       raise ValueError(f"speed2_pct must be between 0 and 100, got {speed2_pct}")
     await self.driver.send_command(f"Speed2 {profile_index} {speed2_pct}")
 
-  # [cmd]
   async def request_profile_acceleration(self, profile_index: int) -> float:
     """Get the acceleration property of the specified profile.
 
@@ -641,7 +617,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     profile, acceleration = response.split()
     return float(acceleration)
 
-  # [cmd]
   async def set_profile_acceleration(self, profile_index: int, acceleration_pct: float) -> None:
     """Set the acceleration property of the specified profile.
 
@@ -656,7 +631,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       raise ValueError(f"acceleration_pct must be between 0 and 100, got {acceleration_pct}")
     await self.driver.send_command(f"Accel {profile_index} {acceleration_pct}")
 
-  # [cmd]
   async def request_profile_acceleration_ramp(self, profile_index: int) -> float:
     """Get the acceleration ramp property of the specified profile.
 
@@ -670,7 +644,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     profile, acceleration_ramp = response.split()
     return float(acceleration_ramp)
 
-  # [cmd]
   async def set_profile_acceleration_ramp(
     self, profile_index: int, acceleration_ramp_seconds: float
   ) -> None:
@@ -682,7 +655,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """
     await self.driver.send_command(f"AccRamp {profile_index} {acceleration_ramp_seconds}")
 
-  # [cmd]
   async def request_profile_deceleration(self, profile_index: int) -> float:
     """Get the deceleration property of the specified profile.
 
@@ -696,7 +668,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     profile, deceleration = response.split()
     return float(deceleration)
 
-  # [cmd]
   async def set_profile_deceleration(self, profile_index: int, deceleration_pct: float) -> None:
     """Set the deceleration property of the specified profile.
 
@@ -711,7 +682,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       raise ValueError(f"deceleration_pct must be between 0 and 100, got {deceleration_pct}")
     await self.driver.send_command(f"Decel {profile_index} {deceleration_pct}")
 
-  # [cmd]
   async def request_profile_deceleration_ramp(self, profile_index: int) -> float:
     """Get the deceleration ramp property of the specified profile.
 
@@ -725,7 +695,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     profile, deceleration_ramp = response.split()
     return float(deceleration_ramp)
 
-  # [cmd]
   async def set_profile_deceleration_ramp(
     self, profile_index: int, deceleration_ramp_seconds: float
   ) -> None:
@@ -737,7 +706,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """
     await self.driver.send_command(f"DecRamp {profile_index} {deceleration_ramp_seconds}")
 
-  # [cmd]
   async def request_profile_in_range(self, profile_index: int) -> float:
     """Get the InRange property of the specified profile.
 
@@ -754,7 +722,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     profile, in_range = response.split()
     return float(in_range)
 
-  # [cmd]
   async def set_profile_in_range(self, profile_index: int, in_range_value: float) -> None:
     """Set the InRange property of the specified profile.
 
@@ -772,7 +739,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       raise ValueError("InRange value must be between -1 and 100")
     await self.driver.send_command(f"InRange {profile_index} {in_range_value}")
 
-  # [cmd]
   async def request_profile_straight(self, profile_index: int) -> bool:
     """Get the Straight property of the specified profile.
 
@@ -788,7 +754,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     profile, straight = response.split()
     return straight == "True"
 
-  # [cmd]
   async def set_profile_straight(self, profile_index: int, straight_mode: bool) -> None:
     """Set the Straight property of the specified profile.
 
@@ -804,7 +769,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     straight_int = 1 if straight_mode else 0
     await self.driver.send_command(f"Straight {profile_index} {straight_int}")
 
-  # [cmd]
   async def request_motion_profile_values(
     self, profile: int
   ) -> tuple[int, float, float, float, float, float, float, float, bool]:
@@ -842,7 +806,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       int(parts[8]) != 0,
     )
 
-  # [cmd]
   async def set_motion_profile_values(
     self,
     profile: int,
@@ -889,19 +852,16 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       f"{acceleration_ramp} {deceleration_ramp} {in_range} {straight_int}"
     )
 
-  # [int]
   async def _set_speed(self, speed_pct: float):
     """Set the speed percentage of the arm's movement (0-100)."""
     await self.set_profile_speed(self.profile_index, speed_pct)
 
-  # [int]
   async def _request_speed(self) -> float:
     """Get the current speed percentage of the arm's movement."""
     return await self.request_profile_speed(self.profile_index)
 
   # -- brakes, torque & freedrive -----------------------------------------------------------
 
-  # [cmd]
   async def release_brake(self, axis: int) -> None:
     """Release the axis brake.
 
@@ -914,7 +874,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """
     await self.driver.send_command(f"releaseBrake {axis}")
 
-  # [cmd]
   async def set_brake(self, axis: int) -> None:
     """Set the axis brake.
 
@@ -926,7 +885,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """
     await self.driver.send_command(f"setBrake {axis}")
 
-  # [cmd]
   async def zero_torque(self, enable: bool, axis_mask: int = 1) -> None:
     """Sets or clears zero torque mode for the selected robot.
 
@@ -942,7 +900,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     else:
       await self.driver.send_command("zeroTorque 0")
 
-  # [PLR]
   async def start_freedrive_mode(
     self, free_axes: Optional[List[int]] = None, backend_params=None
   ) -> None:
@@ -965,19 +922,16 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     for axis in free_axes:
       await self.driver.send_command(f"freemode {axis}")
 
-  # [PLR]
   async def stop_freedrive_mode(self, backend_params=None) -> None:
     """Exit freedrive mode for all axes."""
     await self.driver.send_command("freemode -1")
 
-  # [PLR]
   async def halt(self, backend_params: Optional[BackendParams] = None):
     """Stops the current robot immediately but leaves power on."""
     await self.driver.send_command("halt")
 
   # -- gripper primitives -------------------------------------------------------------------
 
-  # [cmd]
   async def change_config(self, grip_mode: int = 0) -> None:
     """Change Robot configuration from Righty to Lefty or vice versa using customizable locations.
 
@@ -993,7 +947,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """
     await self.driver.send_command(f"ChangeConfig {grip_mode}")
 
-  # [cmd]
   async def change_config2(self, grip_mode: int = 0) -> None:
     """Change Robot configuration from Righty to Lefty or vice versa using algorithm.
 
@@ -1009,7 +962,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """
     await self.driver.send_command(f"ChangeConfig2 {grip_mode}")
 
-  # [int]
   async def _request_grip_close_pos(self) -> float:
     """Get the gripper close position for the servoed gripper.
 
@@ -1019,7 +971,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     data = await self.driver.send_command("GripClosePos")
     return float(data)
 
-  # [int]
   async def _set_grip_close_pos(self, close_position: float) -> None:
     """Set the gripper close position for the servoed gripper.
 
@@ -1030,7 +981,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """
     await self.driver.send_command(f"GripClosePos {close_position}")
 
-  # [int]
   async def _request_grip_open_pos(self) -> float:
     """Get the gripper open position for the servoed gripper.
 
@@ -1040,7 +990,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     data = await self.driver.send_command("GripOpenPos")
     return float(data)
 
-  # [int]
   async def _set_grip_open_pos(self, open_position: float) -> None:
     """Set the gripper open position for the servoed gripper.
 
@@ -1049,7 +998,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """
     await self.driver.send_command(f"GripOpenPos {open_position}")
 
-  # [int]
   async def _request_grasp_data(self) -> tuple[float, float, float]:
     """Get the data to be used for the next force-controlled PickPlate command grip operation.
 
@@ -1062,7 +1010,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       raise PreciseFlexError(-1, "Unexpected response format from GraspData command.")
     return (float(parts[0]), float(parts[1]), float(parts[2]))
 
-  # [int]
   async def _set_grasp_data(
     self, plate_width: float, finger_speed_pct: float, grasp_force: float
   ) -> None:
@@ -1084,12 +1031,10 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       raise ValueError(f"finger_speed_pct must be between 0 and 100, got {finger_speed_pct}")
     await self.driver.send_command(f"GraspData {plate_width} {finger_speed_pct} {grasp_force}")
 
-  # [int]
   async def _set_grip_detail(self):
     """Configure a default vertical station type for pick/place operations."""
     await self.driver.send_command(f"StationType {self.location_index} 1 0 100 0 10")
 
-  # [int]
   def _mm_to_firmware_units(self, width_mm: float) -> float:
     """Convert a jaw width (mm) to the firmware's native position unit.
 
@@ -1100,7 +1045,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
 
   # -- rail primitives ----------------------------------------------------------------------
 
-  # [int]
   async def _set_rail_position(self, station_id: int, rail_position: float) -> None:
     """Set the rail position for the specified station.
 
@@ -1110,7 +1054,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """
     await self.driver.send_command(f"Rail {station_id} {rail_position}")
 
-  # [int]
   async def _move_rail(self, station_id: Optional[int] = None, mode: int = 1) -> None:
     """Move the rail to the position stored at the specified station.
 
@@ -1129,57 +1072,45 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
 
   # -- identity & status reads --------------------------------------------------------------
 
-  # [cmd]
   async def request_manufacturer(self) -> str:
     return (await self.request_parameter(DataID.MANUFACTURER)).strip()
 
-  # [cmd]
   async def request_controller_model(self) -> str:
     return (await self.request_parameter(DataID.CONTROLLER_MODEL)).strip()
 
-  # [cmd]
   async def request_hardware_version(self) -> str:
     return (await self.request_parameter(DataID.HARDWARE_VERSION)).strip()
 
-  # [cmd]
   async def request_gpl_version(self) -> str:
     """Controller firmware/runtime version (distinct from ``request_version``, the TCS app)."""
     return (await self.request_parameter(DataID.GPL_VERSION)).strip()
 
-  # [cmd]
   async def request_controller_serial(self) -> str:
     return (await self.request_parameter(DataID.CONTROLLER_SERIAL)).strip()
 
-  # [cmd]
   async def request_robot_name(self) -> str:
     return (await self.request_parameter(DataID.ROBOT_NAME)).strip()
 
-  # [cmd]
   async def request_robot_type(self) -> int:
     """Built-in kinematic model id (PF400 = 12)."""
     return int(_parse_scalar(await self.request_parameter(DataID.ROBOT_TYPE)))
 
-  # [cmd]
   async def request_axis_count(self) -> int:
     """Number of servoed axes."""
     return int(_parse_scalar(await self.request_parameter(DataID.NUM_AXES)))
 
-  # [cmd]
   async def request_extra_axis_count(self) -> int:
     """Number of non-servoed (extra) axes."""
     return int(_parse_scalar(await self.request_parameter(DataID.EXTRA_AXES)))
 
-  # [cmd]
   async def request_axis_mask(self) -> int:
     """Capability/option bit field (rail, dual gripper, ...)."""
     return int(_parse_scalar(await self.request_parameter(DataID.AXIS_MASK)))
 
-  # [cmd]
   async def request_power_state(self) -> int:
     """Power / auto-execute state word."""
     return int(_parse_scalar(await self.request_parameter(DataID.POWER_STATE)))
 
-  # [cmd]
   async def request_version(self) -> str:
     """Get the current version of TCS and any installed plug-ins.
 
@@ -1190,7 +1121,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
 
   # -- kinematics & reference limits --------------------------------------------------------
 
-  # [cmd]
   async def request_joint_limits(self, hard: bool = False) -> Dict[Axis, tuple[float, float]]:
     """Per-axis travel limits as {Axis: (min, max)}.
 
@@ -1203,29 +1133,24 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       _parse_per_axis(await self.request_parameter(max_id)),
     )
 
-  # [cmd]
   async def request_reference_speed(self) -> Dict[Axis, float]:
     """Per-axis rated speed at 100%; J1/J5 in mm/s, J2-J4 in deg/s."""
     return _parse_per_axis(await self.request_parameter(DataID.REFERENCE_SPEED))
 
-  # [cmd]
   async def request_reference_acceleration(self) -> Dict[Axis, float]:
     """Per-axis rated acceleration at 100%."""
     return _parse_per_axis(await self.request_parameter(DataID.REFERENCE_ACCEL))
 
-  # [cmd]
   async def request_link_lengths(self) -> tuple[float, float]:
     """(l1, l2) SCARA link lengths in mm: shoulder->elbow, elbow->wrist."""
     per_axis = _parse_per_axis(await self.request_parameter(DataID.LINK_LENGTHS))
     return per_axis[Axis.SHOULDER], per_axis[Axis.ELBOW]
 
-  # [cmd]
   async def request_tool_length(self) -> float:
     """Wrist->TCP distance in mm (z of the tool-offset transform)."""
     values = [float(v) for v in (await self.request_parameter(DataID.TOOL_OFFSET)).split(",")]
     return values[2]
 
-  # [cmd]
   async def request_kinematic_parameters(self) -> "kinematics.PF400Params":
     """Build PF400Params from the controller's stored geometry.
 
@@ -1240,34 +1165,28 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       gripper_length=await self.request_tool_length(),
     )
 
-  # [cmd]
   async def request_reference_cartesian_speed(self) -> float:
     """Rated Cartesian (translational) speed at 100%, in mm/s."""
     return _parse_scalar(await self.request_parameter(DataID.REFERENCE_CARTESIAN_SPEED))
 
-  # [cmd]
   async def request_reference_cartesian_acceleration(self) -> float:
     """Rated Cartesian (translational) acceleration at 100%, in mm/s^2."""
     return _parse_scalar(await self.request_parameter(DataID.REFERENCE_CARTESIAN_ACCEL))
 
-  # [cmd]
   async def request_max_speed_percent(self) -> float:
     """Global cap on the speed percentage (one value, applies to all joints)."""
     return _parse_scalar(await self.request_parameter(DataID.MAX_SPEED_PERCENT))
 
-  # [cmd]
   async def request_max_acceleration_percent(self) -> float:
     """Global cap on the acceleration percentage (one value, applies to all joints)."""
     return _parse_scalar(await self.request_parameter(DataID.MAX_ACCEL_PERCENT))
 
-  # [cmd]
   async def request_max_deceleration_percent(self) -> float:
     """Global cap on the deceleration percentage (one value, applies to all joints)."""
     return _parse_scalar(await self.request_parameter(DataID.MAX_DECEL_PERCENT))
 
   # -- tool & base frame --------------------------------------------------------------------
 
-  # [cmd]
   async def request_base(self) -> tuple[float, float, float, float]:
     """Get the robot base offset.
 
@@ -1280,7 +1199,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       raise PreciseFlexError(-1, "Unexpected response format from base command.")
     return (float(parts[0]), float(parts[1]), float(parts[2]), float(parts[3]))
 
-  # [cmd]
   async def set_base(
     self, x_offset: float, y_offset: float, z_offset: float, z_rotation: float
   ) -> None:
@@ -1298,7 +1216,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """
     await self.driver.send_command(f"base {x_offset} {y_offset} {z_offset} {z_rotation}")
 
-  # [cmd]
   async def request_tool_transformation_values(
     self,
   ) -> tuple[float, float, float, float, float, float]:
@@ -1316,7 +1233,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     x, y, z, yaw, pitch, roll = self._parse_xyz_response(parts)
     return (x, y, z, yaw, pitch, roll)
 
-  # [int]
   async def _set_tool_transformation_values(
     self, x: float, y: float, z: float, yaw: float, pitch: float, roll: float
   ) -> None:
@@ -1339,7 +1255,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
 
   # -- robot selection ----------------------------------------------------------------------
 
-  # [cmd]
   async def reset(self, robot_number: int) -> None:
     """Reset the threads associated with the specified robot.
 
@@ -1356,7 +1271,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       raise ValueError("Robot number must be greater than zero")
     await self.driver.send_command(f"reset {robot_number}")
 
-  # [cmd]
   async def request_selected_robot(self) -> int:
     """Get the number of the currently selected robot.
 
@@ -1366,7 +1280,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     response = await self.driver.send_command("selectRobot")
     return int(response)
 
-  # [cmd]
   async def select_robot(self, robot_number: int) -> None:
     """Change the robot associated with this communications link.
 
@@ -1381,7 +1294,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
 
   # -- configuration discovery & adoption ---------------------------------------------------
 
-  # [cmd]
   @property
   def configuration(self) -> "PreciseFlexConfiguration":
     """The device configuration resolved at setup. Raises before setup()."""
@@ -1389,7 +1301,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       raise RuntimeError("Configuration is not available until setup() has run.")
     return self._configuration
 
-  # [int]
   async def _request_configuration(self) -> "PreciseFlexConfiguration":
     """Read the controller's identity, axes, limits, kinematics, and envelope.
 
@@ -1479,7 +1390,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       reach_class=reach_class,
     )
 
-  # [int]
   async def _request_state(
     self,
   ) -> tuple[JointPose, PreciseFlexCartesianPose]:
@@ -1490,7 +1400,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     pose = dataclasses.replace(pose, rotation=Rotation(x=-180, y=90, z=pose.rotation.yaw))
     return joints, pose
 
-  # [int]
   def _adopt_configuration(self, config: "PreciseFlexConfiguration") -> None:
     """Adopt the discovered configuration as the source of truth for later commands.
 
@@ -1505,7 +1414,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     self._has_rail = config.has_rail
     self._is_dual_gripper = config.is_dual_gripper
 
-  # [int]
   def _assess_configuration(self, config: "PreciseFlexConfiguration") -> None:
     """Warn about an unsupported model, a missing TCS module, or an untested combo.
 
@@ -1541,7 +1449,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
         suggest_entry(config.robot_type, config.gpl_version, config.tcs_version, config.modules),
       )
 
-  # [int]
   def _log_configuration_summary(self, config: "PreciseFlexConfiguration") -> None:
     """Log a single structured summary of the discovered device: name, connection,
     firmware, this unit's configuration, and the resulting capabilities."""
@@ -1578,7 +1485,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
 
   # -- homing & range recovery --------------------------------------------------------------
 
-  # [cmd]
   # Axes auto-recovered when out of range, in a deliberately safe order: the
   # gripper jaw first (no arm motion), then the Z column (vertical clearance), then
   # the rotary links shoulder -> elbow (smallest swept volume last to first).
@@ -1648,7 +1554,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       await self._set_speed(prior_speed)  # don't leave the profile at the slow recovery speed
     return recovered
 
-  # [int]
   async def _is_robot_homed(self) -> bool:
     """Whether all axes are homed (DataID 2800).
 
@@ -1657,7 +1562,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """
     return _parse_scalar(await self.request_parameter(DataID.ROBOT_HOMED)) == 1.0
 
-  # [int]
   async def _handle_out_of_range_axes(self) -> None:
     """Warn about every out-of-range axis, then correct what is recoverable, or raise.
 
@@ -1699,7 +1603,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
         axes=outside,
       )
 
-  # [int]
   def _axes_outside_soft_limits(self, joints: JointPose) -> Dict[Axis, tuple]:
     """Axes whose value lies outside their soft limit, as ``axis -> (value, (lo, hi))``.
 
@@ -1716,7 +1619,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
         outside[axis] = (value, (lo, hi))
     return outside
 
-  # [int]
   @staticmethod
   def _fmt_axes(axes: Dict[Axis, tuple]) -> str:
     """Format ``{axis: (value, (lo, hi))}`` for logs/errors, e.g.
@@ -1725,7 +1627,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       f"{axis.name} at {value} (soft limit {limit})" for axis, (value, limit) in axes.items()
     )
 
-  # [int]
   def _assert_within_soft_limits(self, current: JointPose, target: JointPose) -> None:
     """Guard a commanded move. The controller rejects every move with -1012 while an axis is out of
     range - whether that is the *current* pose or the commanded *target*. They are distinct failures
@@ -1755,7 +1656,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
         f"would reject the move (-1012). Re-teach this pose within the envelope."
       )
 
-  # [int]
   async def _guarded_move_j(self, build_target: Callable[[JointPose], JointPose]) -> None:
     """The single guarded path to the raw ``_move_j`` primitive: read the live pose, check it and
     the target against the soft limits, send the move, and on out-of-range recover once and retry.
@@ -1808,7 +1708,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
 
   # -- joint-space motion -------------------------------------------------------------------
 
-  # [PLR]
   async def request_joint_position(
     self, backend_params: Optional[BackendParams] = None
   ) -> JointPose:
@@ -1824,7 +1723,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       raise PreciseFlexError(-1, "Unexpected response format from wherej command.")
     return self._parse_angles_response(parts)
 
-  # [PLR]
   @dataclass
   class MoveToJointPositionParams(BackendParams):
     """PreciseFlex arm parameters for joint-space moves.
@@ -1848,7 +1746,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       await self._set_speed(backend_params.speed_pct)
     await self._guarded_move_j(lambda current: {**current, **position})
 
-  # [PLR]
   async def request_gripper_pose(
     self, backend_params: Optional[BackendParams] = None
   ) -> PreciseFlexCartesianPose:
@@ -1858,7 +1755,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
 
   # -- cartesian motion ---------------------------------------------------------------------
 
-  # [PLR]
   @dataclass
   class MoveToLocationParams(BackendParams):
     """PreciseFlex arm parameters for Cartesian-space moves.
@@ -1904,7 +1800,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     joints = await self._cart_to_joints(coords)
     await self._guarded_move_j(lambda _current: joints)
 
-  # [cmd]
   async def dest_c(self, arg1: int = 0) -> tuple[float, float, float, float, float, float, int]:
     """Get the destination or current Cartesian location of the robot.
 
@@ -1929,7 +1824,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     config = int(parts[6])
     return (x, y, z, yaw, pitch, roll, config)
 
-  # [cmd]
   async def dest_j(self, arg1: int = 0) -> JointPose:
     """Get the destination or current joint location of the robot.
 
@@ -1952,7 +1846,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       raise PreciseFlexError(-1, "Unexpected response format from destJ command.")
     return self._parse_angles_response(parts)
 
-  # [cmd]
   async def here_j(self, location_index: int) -> None:
     """Record the current position of the selected robot into the specified Location as angles.
 
@@ -1963,7 +1856,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """
     await self.driver.send_command(f"hereJ {location_index}")
 
-  # [cmd]
   async def here_c(self, location_index: int) -> None:
     """Record the current position of the selected robot into the specified Location as Cartesian.
 
@@ -1985,7 +1877,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
   _gripper_soft_min: Optional[float] = None
   _gripper_soft_max: Optional[float] = None
 
-  # [PLR]
   async def move_gripper(
     self,
     width: float,
@@ -2027,7 +1918,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       await self._set_grip_open_pos(units)
       await self.driver.send_command("gripper 1")
 
-  # [PLR]
   async def is_gripper_closed(self, backend_params: Optional[BackendParams] = None) -> bool:
     """(Single Gripper Only) Tests if the gripper is fully closed by checking the end-of-travel sensor.
 
@@ -2039,7 +1929,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     response = await self.driver.send_command("IsFullyClosed")
     return int(response) == -1
 
-  # [cmd]
   async def are_grippers_closed(self) -> tuple[bool, bool]:
     """(Dual Gripper Only) Tests if each gripper is fully closed by checking the end-of-travel sensors."""
     if not self._is_dual_gripper:
@@ -2052,7 +1941,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
 
   # -- rail ---------------------------------------------------------------------------------
 
-  # [cmd]
   async def move_rail(self, rail_position: float) -> None:
     """Move the rail to the specified position.
 
@@ -2069,7 +1957,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
 
   # -- pick & place -------------------------------------------------------------------------
 
-  # [PLR]
   @dataclass
   class PickUpParams(BackendParams):
     """PreciseFlex arm parameters for plate pickup.
@@ -2111,7 +1998,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     )
     await self._pick_plate_j(position)
 
-  # [PLR]
   @dataclass
   class DropParams(BackendParams):
     """PreciseFlex arm parameters for plate drop.
@@ -2144,7 +2030,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       backend_params = PreciseFlexArmBackend.DropParams()
     await self._place_plate_j(position)
 
-  # [PLR]
   async def pick_up_at_location(
     self,
     location: Coordinate,
@@ -2183,7 +2068,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     )
     await self._pick_plate_c(cartesian_position=coords)
 
-  # [PLR]
   async def drop_at_location(
     self,
     location: Coordinate,
@@ -2217,7 +2101,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     )
     await self._place_plate_c(cartesian_position=coords)
 
-  # [int]
   async def _pick_plate_j(self, joint_position: JointPose):
     """Pick a plate from the specified position using joint coordinates."""
     await self._set_joint_angles(self.location_index, joint_position)
@@ -2229,7 +2112,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     if ret_code == "0":
       raise PreciseFlexError(-1, "the force-controlled gripper detected no plate present.")
 
-  # [int]
   async def _place_plate_j(self, joint_position: JointPose):
     """Place a plate at the specified position using joint coordinates."""
     await self._set_joint_angles(self.location_index, joint_position)
@@ -2239,13 +2121,11 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       f"placeplate {self.location_index} {horizontal_compliance_int} {self.horizontal_compliance_torque}"
     )
 
-  # [int]
   async def _pick_plate_c(self, cartesian_position: PreciseFlexCartesianPose):
     """Pick a plate at a Cartesian position via IK + joint-space pickplate."""
     joints = await self._cart_to_joints(cartesian_position)
     await self._pick_plate_j(joints)
 
-  # [int]
   async def _place_plate_c(self, cartesian_position: PreciseFlexCartesianPose):
     """Place a plate at a Cartesian position via IK + joint-space placeplate."""
     joints = await self._cart_to_joints(cartesian_position)
@@ -2253,7 +2133,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
 
   # -- parking ------------------------------------------------------------------------------
 
-  # [cmd]
   @property
   def parking_position(self) -> Optional[JointPose]:
     """The pose ``park()`` moves to. Assign one of the ``PARKING_POSITION_BACK/RIGHT/FRONT`` class
@@ -2262,14 +2141,12 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     ``PARKING_POSITION_RIGHT``. A pose that omits ``Axis.BASE`` has its Z filled at park time."""
     return self._parking_position
 
-  # [cmd]
   @parking_position.setter
   def parking_position(self, position: Optional[JointPose]) -> None:
     if position is not None:
       self._validate_parking_position(position)
     self._parking_position: Optional[JointPose] = dict(position) if position is not None else None
 
-  # [PLR]
   async def park(self, backend_params: Optional[BackendParams] = None) -> None:
     """Move to ``self.parking_position``; defaults at setup, reassignable at runtime.
 
@@ -2285,7 +2162,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     else:
       await self.driver.send_command("movetosafe")
 
-  # [int]
   def _validate_parking_position(self, position: JointPose) -> None:
     """Reject anything that is not a JointPose of in-range axes (limits checked once known)."""
     if not isinstance(position, dict) or not position:
@@ -2302,7 +2178,6 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
             f"parking_position[{axis.name}]={value} is outside the soft limits [{lo}, {hi}]"
           )
 
-  # [int]
   def _parking_pose_with_default_z(self, position: JointPose) -> JointPose:
     """Fill the Z column (``Axis.BASE``) at 3/4 of the discovered travel when the pose omits it."""
     if Axis.BASE in position or self._configuration is None:

--- a/pylabrobot/brooks/precise_flex/arm_backend.py
+++ b/pylabrobot/brooks/precise_flex/arm_backend.py
@@ -21,7 +21,7 @@ import dataclasses
 import logging
 import warnings
 from dataclasses import dataclass
-from typing import ClassVar, Dict, List, Literal, Optional
+from typing import Callable, ClassVar, Dict, List, Literal, Optional
 
 from pylabrobot.capabilities.arms.backend import (
   CanFreedrive,
@@ -42,7 +42,7 @@ from .confirmed_firmware_versions import (
 )
 from .data_ids import DataID
 from .driver import PreciseFlexDriver
-from .errors import PreciseFlexError
+from .errors import OutOfRangeOfMotionError, PreciseFlexError
 from .kinematics import ElbowOrientation, PreciseFlexCartesianPose, Wrist
 from .tcs_modules import missing_required_modules
 
@@ -130,7 +130,7 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     is_dual_gripper: bool = False,
     has_rail: bool = False,
     read_kinematics_from_device: bool = True,
-    recover_out_of_range_at_setup: bool = True,
+    recover_out_of_range: bool = True,
     parking_position: Optional[JointPose] = None,
   ) -> None:
     """
@@ -146,11 +146,13 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
         the controller at setup and use them for kinematics; the constructor's
         ``gripper_length`` then acts only as a fallback. Set False to force the
         constructor values regardless of what the controller reports.
-      recover_out_of_range_at_setup: when True (the default), setup tries to drive a
-        small out-of-range excursion back inside the soft limits (slow single-axis move
-        toward in-range) via ``recover_axes_within_limits``. Set False to skip that.
-        Either way, setup raises if any axis is still out of range afterward, since the
-        controller would otherwise reject every commanded move (-1012).
+      recover_out_of_range: when True (the default), an out-of-range axis (its current position
+        outside its soft limit - a state the controller rejects every commanded move for, -1012) is
+        driven back into range once via ``recover_axes_within_limits``, the same way at both moments
+        it matters: at setup, and before a commanded move (which then retries). If it is still out of
+        range after that, ``OutOfRangeOfMotionError`` propagates (no loop). Set False to forbid this
+        autonomous motion - an out-of-range axis then raises instead, carrying recovery instructions.
+        Every recovery is logged.
       closed_gripper_position: firmware-unit value (passed to ``GripClosePos`` /
         ``GripOpenPos``) at which the jaws are at :attr:`min_gripper_width`.
         Depends on the mounted gripper. The conversion mm → firmware units is
@@ -175,7 +177,7 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       gripper_length=gripper_length, gripper_z_offset=gripper_z_offset
     )
     self._read_kinematics_from_device = read_kinematics_from_device
-    self._recover_out_of_range_at_setup = recover_out_of_range_at_setup
+    self._recover_out_of_range = recover_out_of_range
     # Device configuration, resolved once at setup; None until then. Set before parking_position so its
     # validating setter can check assignments against the soft limits once they are known.
     self._configuration: Optional[PreciseFlexConfiguration] = None
@@ -402,7 +404,8 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
 
   # [int]
   async def _move_j(self, profile_index: int, joint_coords: JointPose) -> None:
-    """Move the robot using joint coordinates, handling rail configuration."""
+    """Move the robot using joint coordinates, handling rail configuration. Raw moveJ - the
+    out-of-range guard lives in the caller (``_guarded_move_j``), not in this primitive."""
     if self._has_rail:
       angles_str = (
         f"{joint_coords[Axis.BASE]} "
@@ -492,9 +495,9 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     """Convert a Cartesian location into a full joint dict using our IK.
 
     Any of cart.orientation, cart.wrist, and cart.rail_position left as None
-    default to the current pose — picks the configuration closest to where the
+    default to the current pose - picks the configuration closest to where the
     arm is now. Fetches current joint state for the gripper and rail axes so
-    callers can use the result directly with `_move_j` or `_set_joint_angles`.
+    callers get a complete joint dict, ready for `_guarded_move_j`.
     """
     joints, current = await self._request_state()
     cart = dataclasses.replace(
@@ -1313,13 +1316,16 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     x, y, z, yaw, pitch, roll = self._parse_xyz_response(parts)
     return (x, y, z, yaw, pitch, roll)
 
-  # [cmd]
-  async def set_tool_transformation_values(
+  # [int]
+  async def _set_tool_transformation_values(
     self, x: float, y: float, z: float, yaw: float, pitch: float, roll: float
   ) -> None:
-    """Set the robot tool transformation.
+    """Set the robot tool transformation (private).
 
-    The robot must be attached to set the tool. Setting the tool pauses any robot motion in progress.
+    Private because the client kinematics read the tool once at setup into the frozen configuration;
+    changing it live desyncs `request_gripper_pose` from the controller's `wherec` until the
+    configuration is rebuilt. The robot must be attached to set the tool, and setting it pauses any
+    robot motion in progress.
 
     Args:
       x: Tool X coordinate.
@@ -1573,7 +1579,7 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
   # -- homing & range recovery --------------------------------------------------------------
 
   # [cmd]
-  # Axes auto-recovered when parked out of range, in a deliberately safe order: the
+  # Axes auto-recovered when out of range, in a deliberately safe order: the
   # gripper jaw first (no arm motion), then the Z column (vertical clearance), then
   # the rotary links shoulder -> elbow (smallest swept volume last to first).
   # The wrist is intentionally absent: rotating it back to +/-180 can self-collide, so
@@ -1655,11 +1661,11 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
   async def _handle_out_of_range_axes(self) -> None:
     """Warn about every out-of-range axis, then correct what is recoverable, or raise.
 
-    An axis parked outside its soft limit makes the arm unusable - the controller rejects
-    every commanded move with -1012. Setup logs the full set first (either way), then, with
-    ``recover_out_of_range_at_setup`` on (the default), drives each recoverable offender back
-    into range. If recovery is off or leaves any axis out, setup raises with explicit
-    recovery steps rather than leaving a dead arm.
+    An axis out of range (its current position outside its soft limit) makes the arm unusable - the
+    controller rejects every commanded move with -1012. Setup logs the full set first (either way),
+    then, with ``recover_out_of_range`` on (the default), drives each recoverable offender back into
+    range. If recovery is off or leaves any axis out, setup raises with explicit recovery steps
+    rather than leaving a dead arm.
 
     No-op until the robot is homed: an unhomed incremental axis reads a meaningless ~0
     (so the check would false-positive), and the controller blocks the recovery move with
@@ -1673,27 +1679,24 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       )
       return
 
-    def fmt(axes: Dict[Axis, tuple]) -> str:
-      return "; ".join(
-        f"{axis.name} at {value} (soft limit {limit})" for axis, (value, limit) in axes.items()
-      )
-
     outside = self._axes_outside_soft_limits(await self.request_joint_position())
     if not outside:
       return
     logger.warning(
-      "[PreciseFlex %s] axes out of soft limit at setup: %s", self.driver.io._host, fmt(outside)
+      "[PreciseFlex %s] axes out of soft limit at setup: %s",
+      self.driver.io._host,
+      self._fmt_axes(outside),
     )
-    if self._recover_out_of_range_at_setup:
+    if self._recover_out_of_range:
       await self.recover_axes_within_limits()
       outside = self._axes_outside_soft_limits(await self.request_joint_position())
     if outside:
-      raise PreciseFlexError(
-        -1012,
-        f"axis outside its soft limit after setup: {fmt(outside)}. The controller rejects all "
+      raise OutOfRangeOfMotionError(
+        f"axis outside its soft limit after setup: {self._fmt_axes(outside)}. The controller rejects all "
         f"commanded moves in this state. Recover with recover_axes_within_limits(), or freedrive "
         f"the axis back into range manually (required for the wrist, or when an axis is far past "
         f"its limit).",
+        axes=outside,
       )
 
   # [int]
@@ -1714,27 +1717,90 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     return outside
 
   # [int]
-  def _assert_within_soft_limits(self, current: JointPose, target: JointPose) -> None:
-    """Turn the controller's cryptic ``-1012`` into a clear client-side error.
+  @staticmethod
+  def _fmt_axes(axes: Dict[Axis, tuple]) -> str:
+    """Format ``{axis: (value, (lo, hi))}`` for logs/errors, e.g.
+    ``BASE at 0.959 (soft limit (1.5, 401.5))``."""
+    return "; ".join(
+      f"{axis.name} at {value} (soft limit {limit})" for axis, (value, limit) in axes.items()
+    )
 
-    Two cases block a commanded move: an axis already parked outside its soft limit
-    (the controller then rejects *every* commanded move until it is recovered), and
-    a target outside its soft limit (rejected outright). Freedrive can hand-move an
-    axis past a soft limit, so a taught pose can land outside the commandable
-    envelope. No-op until the configuration has been discovered.
+  # [int]
+  def _assert_within_soft_limits(self, current: JointPose, target: JointPose) -> None:
+    """Guard a commanded move. The controller rejects every move with -1012 while an axis is out of
+    range - whether that is the *current* pose or the commanded *target*. They are distinct failures
+    with distinct types:
+
+    - an axis whose *current* position is out of range is a recoverable arm *state* (e.g. it lost
+      power and drifted past its limit) -> ``OutOfRangeOfMotionError``, which the caller can recover
+      and retry. Homing will not fix it (the rotary axes are absolute); call
+      ``recover_axes_within_limits()`` to drive it back into range.
+    - an axis whose *target* is out of range is a bad request (freedrive can hand-move an axis past a
+      soft limit, so a taught pose can land outside the commandable envelope) -> ``ValueError``;
+      re-teach the pose.
+
+    No-op until the configuration is discovered.
     """
-    for axis, (value, limit) in self._axes_outside_soft_limits(current).items():
-      raise ValueError(
-        f"{axis.name} is parked at {value}, outside its soft limit {limit}; the "
-        f"controller rejects commanded moves while an axis is out of range (-1012). "
-        f"Homing will not recover it (the rotary axes are absolute); call "
-        f"recover_axes_within_limits() to drive it back into range, then retry."
+    out_of_range = self._axes_outside_soft_limits(current)
+    if out_of_range:
+      raise OutOfRangeOfMotionError(
+        f"axis out of range: {self._fmt_axes(out_of_range)}. The controller rejects every commanded "
+        f"move while an axis is out of range. Homing will not recover it (the rotary axes are "
+        f"absolute); call recover_axes_within_limits() to drive it back into range.",
+        axes=out_of_range,
       )
     for axis, (value, limit) in self._axes_outside_soft_limits(target).items():
       raise ValueError(
         f"{axis.name} target {value} is outside its soft limit {limit}; the controller "
         f"would reject the move (-1012). Re-teach this pose within the envelope."
       )
+
+  # [int]
+  async def _guarded_move_j(self, build_target: Callable[[JointPose], JointPose]) -> None:
+    """The single guarded path to the raw ``_move_j`` primitive: read the live pose, check it and
+    the target against the soft limits, send the move, and on out-of-range recover once and retry.
+    Both ``move_to_joint_position`` (a partial spec merged over the live pose) and
+    ``move_to_location`` (a full pose from IK) funnel through here, so no commanded move reaches
+    ``_move_j`` unchecked.
+
+    ``build_target`` maps the freshly-read pose to the full target joints - the only part that
+    differs between the two callers. It re-runs each attempt, so a recovery move that shifts an
+    unspecified axis is reflected in the next merge.
+
+    When an axis is out of range the controller blocks the move (-1012). With ``recover_out_of_range``
+    set, this drives the offending axes back into range once (``recover_axes_within_limits``) and
+    retries; otherwise the ``OutOfRangeOfMotionError`` propagates. Recovery uses ``_move_one_axis``, a
+    different primitive, so it cannot recurse here.
+    """
+
+    async def attempt() -> None:
+      current = await self.request_joint_position()
+      target = build_target(current)
+      self._assert_within_soft_limits(current, target)
+      await self._move_j(profile_index=self.profile_index, joint_coords=target)
+
+    try:
+      await attempt()
+    except OutOfRangeOfMotionError as exc:
+      if not self._recover_out_of_range:
+        raise
+      host = self.driver.io._host
+      logger.warning(
+        "[PreciseFlex %s] commanded move blocked - %s; auto-recovery on -> recovering and retrying",
+        host,
+        self._fmt_axes(exc.axes),
+      )
+      await self.recover_axes_within_limits()
+      try:
+        await attempt()  # re-reads the live pose - recovery just moved an axis
+      except OutOfRangeOfMotionError as exc2:
+        logger.error(
+          "[PreciseFlex %s] auto-recovery did not clear %s - freedrive/manual recovery needed",
+          host,
+          self._fmt_axes(exc2.axes),
+        )
+        raise
+      logger.info("[PreciseFlex %s] out-of-range axes recovered; move retried successfully", host)
 
   # ========================================================================================
   # L3 - high-level capability API
@@ -1774,15 +1840,13 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     position: JointPose,
     backend_params: Optional[BackendParams] = None,
   ) -> None:
-    """Move the arm to the specified joint position."""
+    """Move the arm to the specified joint position. A partial spec is merged over the live pose;
+    the move is guarded against out-of-range axes (see ``_guarded_move_j``)."""
     if not isinstance(backend_params, self.MoveToJointPositionParams):
       backend_params = PreciseFlexArmBackend.MoveToJointPositionParams()
     if backend_params.speed_pct is not None:
       await self._set_speed(backend_params.speed_pct)
-    current = await self.request_joint_position()
-    joint_coords = {**current, **position}
-    self._assert_within_soft_limits(current, joint_coords)
-    await self._move_j(profile_index=self.profile_index, joint_coords=joint_coords)
+    await self._guarded_move_j(lambda current: {**current, **position})
 
   # [PLR]
   async def request_gripper_pose(
@@ -1817,7 +1881,8 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
     direction: float,
     backend_params: Optional[BackendParams] = None,
   ) -> None:
-    """Move the arm to the specified Cartesian location."""
+    """Move the arm to the specified Cartesian location. The IK target is guarded against
+    out-of-range axes (see ``_guarded_move_j``)."""
     if not isinstance(backend_params, self.MoveToLocationParams):
       backend_params = PreciseFlexArmBackend.MoveToLocationParams()
     if backend_params.speed_pct is not None:
@@ -1837,7 +1902,7 @@ class PreciseFlexArmBackend(OrientableGripperArmBackend, HasJoints, CanFreedrive
       wrist=backend_params.wrist,
     )
     joints = await self._cart_to_joints(coords)
-    await self._move_j(profile_index=self.profile_index, joint_coords=joints)
+    await self._guarded_move_j(lambda _current: joints)
 
   # [cmd]
   async def dest_c(self, arg1: int = 0) -> tuple[float, float, float, float, float, float, int]:

--- a/pylabrobot/brooks/precise_flex/errors.py
+++ b/pylabrobot/brooks/precise_flex/errors.py
@@ -1944,6 +1944,20 @@ class OperationInterrupted(Exception):
   """
 
 
+class OutOfRangeOfMotionError(Exception):
+  """An axis's current position is outside its soft limits, so the controller rejects every
+  commanded move (-1012) until it is driven back into range.
+
+  Its own type so the recover-and-retry path can catch this recoverable arm *state* without also
+  catching a bad commanded *target* (which stays a ``ValueError``). ``axes`` maps each offending
+  ``Axis`` to ``(value, (lo, hi))``.
+  """
+
+  def __init__(self, message: str, axes: dict):
+    super().__init__(message)
+    self.axes = axes
+
+
 # -- collision detection ---------------------------------------------------
 
 # Collision / over-drive errors: the servo trips one of these when an axis is blocked - it hit an

--- a/pylabrobot/brooks/precise_flex/precise_flex.py
+++ b/pylabrobot/brooks/precise_flex/precise_flex.py
@@ -22,7 +22,7 @@ class PreciseFlex400(Device):
     timeout: int = 20,
     gripper_length: float = 162.0,
     gripper_z_offset: float = 0.0,
-    recover_out_of_range_at_setup: bool = True,
+    recover_out_of_range: bool = True,
   ) -> None:
     """
     Args:
@@ -33,9 +33,9 @@ class PreciseFlex400(Device):
         matches the stock single gripper on the PF400.
       gripper_z_offset: vertical offset in mm from the wrist plate to the tool tip.
         Defaults to 0 mm.
-      recover_out_of_range_at_setup: when True (the default), setup tries to drive a
-        small out-of-range excursion back inside the soft limits; set False to skip
-        that. Either way setup raises if an axis is still out of range afterward.
+      recover_out_of_range: when True (the default), an out-of-range axis is driven back into range
+        once - at setup and before a commanded move (which then retries). Set False to forbid this
+        autonomous motion; an out-of-range axis then raises instead, carrying recovery instructions.
     """
     driver = PreciseFlexDriver(host=host, port=port, timeout=timeout)
     super().__init__(driver=driver)
@@ -46,7 +46,7 @@ class PreciseFlex400(Device):
       gripper_length=gripper_length,
       gripper_z_offset=gripper_z_offset,
       closed_gripper_position=closed_gripper_position,
-      recover_out_of_range_at_setup=recover_out_of_range_at_setup,
+      recover_out_of_range=recover_out_of_range,
     )
     self.reference = Resource(name="PreciseFlex400", size_x=200, size_y=200, size_z=200)
     self.arm = OrientableGripperArm(backend=backend, reference_resource=self.reference)
@@ -72,6 +72,7 @@ class PreciseFlex3400(Device):
     has_rail: bool = False,
     timeout: int = 20,
     gripper_z_offset: float = 0.0,
+    recover_out_of_range: bool = True,
   ) -> None:
     """
     Args:
@@ -82,6 +83,9 @@ class PreciseFlex3400(Device):
         no stock default, because the 3400 ships with an IntelliGuide gripper whose length
         differs; set it for the gripper actually mounted.
       gripper_z_offset: vertical offset in mm from the wrist plate to the tool tip.
+      recover_out_of_range: when True (the default), an out-of-range axis is driven back into range
+        once - at setup and before a commanded move (which then retries). Set False to forbid this
+        autonomous motion; an out-of-range axis then raises instead, carrying recovery instructions.
     """
     driver = PreciseFlexDriver(host=host, port=port, timeout=timeout)
     super().__init__(driver=driver)
@@ -92,6 +96,7 @@ class PreciseFlex3400(Device):
       gripper_length=gripper_length,
       gripper_z_offset=gripper_z_offset,
       closed_gripper_position=closed_gripper_position,
+      recover_out_of_range=recover_out_of_range,
     )
     self.reference = Resource(name="PreciseFlex3400", size_x=200, size_y=200, size_z=200)
     self.arm = OrientableGripperArm(backend=backend, reference_resource=self.reference)

--- a/pylabrobot/brooks/precise_flex/tests/arm_backend_tests.py
+++ b/pylabrobot/brooks/precise_flex/tests/arm_backend_tests.py
@@ -1,8 +1,13 @@
 import unittest
 from typing import Tuple
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from pylabrobot.brooks.precise_flex import Axis, PreciseFlexArmBackend
+from pylabrobot.brooks.precise_flex import (
+  Axis,
+  OutOfRangeOfMotionError,
+  PreciseFlexArmBackend,
+)
+from pylabrobot.resources import Coordinate
 
 
 def _make_backend(
@@ -210,3 +215,100 @@ class TestPreciseFlexParking(unittest.IsolatedAsyncioTestCase):
     await self.backend.park()
     self.driver.send_command.assert_awaited_once_with("movetosafe")
     self.assertEqual(self._movej_cmds(), [])
+
+
+_LOGGER = "pylabrobot.brooks.precise_flex.arm_backend"
+
+
+class TestPreciseFlex400AutoRecoverOnMove(unittest.IsolatedAsyncioTestCase):
+  """A commanded move that finds an axis out of range: default recovers; opt-out raises."""
+
+  def setUp(self):
+    self.backend, self.driver = _make_backend()
+    self.driver._wait_for_eom = AsyncMock()
+    self.backend._configuration = MagicMock(
+      soft_limits={
+        Axis.SHOULDER: (-93.0, 93.0),
+        Axis.ELBOW: (12.0, 348.0),
+        Axis.WRIST: (-960.0, 960.0),
+      }
+    )
+
+  def _stub(self, out_of_range: str, recovered: str = "") -> None:
+    """wherej returns ``out_of_range`` until a MoveOneAxis fires, then ``recovered`` (if given)."""
+    state = {"recovered": False}
+
+    async def respond(command: str) -> str:
+      if command == "wherej":
+        return recovered if (state["recovered"] and recovered) else out_of_range
+      if command.startswith("Speed "):
+        return f"{self.backend.profile_index} 50.0"
+      if command.startswith("MoveOneAxis"):
+        state["recovered"] = True
+      return ""
+
+    self.driver.send_command = AsyncMock(side_effect=respond)
+
+  def _cmds(self, prefix: str) -> list[str]:
+    return [
+      c.args[0] for c in self.driver.send_command.call_args_list if c.args[0].startswith(prefix)
+    ]
+
+  async def test_opted_out_raises_and_does_not_move_or_recover(self):
+    """Opted out: an out-of-range axis raises OutOfRangeOfMotionError; no recovery, no moveJ."""
+    self.backend._recover_out_of_range = False
+    self._stub("0 93.5 90.0 0.0 0")  # base shoulder elbow wrist gripper; shoulder 93.5 > 93
+    with self.assertRaises(OutOfRangeOfMotionError) as ctx:
+      await self.backend.move_to_joint_position({Axis.SHOULDER: 0.0})
+    self.assertIn(Axis.SHOULDER, ctx.exception.axes)
+    self.assertEqual(self._cmds("MoveOneAxis"), [])
+    self.assertEqual(self._cmds("moveJ"), [])
+
+  async def test_on_recovers_offender_then_retries_move(self):
+    """Opt-in on: the offending axis is nudged in range (MoveOneAxis), then the moveJ is retried."""
+    self.backend._recover_out_of_range = True
+    self._stub("0 93.5 90.0 0.0 0", recovered="0 92.0 90.0 0.0 0")
+    with self.assertLogs(_LOGGER, level="INFO") as cm:
+      await self.backend.move_to_joint_position({Axis.SHOULDER: 0.0})
+    self.assertEqual(self._cmds("MoveOneAxis"), ["MoveOneAxis 2 92.0 1"])  # shoulder back in range
+    self.assertEqual(len(self._cmds("moveJ")), 1)  # move retried and sent
+    log = "\n".join(cm.output)
+    self.assertIn("commanded move blocked", log)  # WARNING on entry
+    self.assertIn("retried successfully", log)  # INFO on success
+
+  async def test_on_but_unrecoverable_reraises_once_without_moving(self):
+    """Opt-in on but the axis is too far out (recovery skips it): re-raise after one try, no loop."""
+    self.backend._recover_out_of_range = True
+    self._stub("0 120.0 90.0 0.0 0")  # shoulder 27 past the limit, beyond the recovery cap
+    with self.assertLogs(_LOGGER, level="ERROR") as cm:
+      with self.assertRaises(OutOfRangeOfMotionError):
+        await self.backend.move_to_joint_position({Axis.SHOULDER: 0.0})
+    self.assertEqual(self._cmds("moveJ"), [])  # never moved
+    self.assertIn("auto-recovery did not clear", "\n".join(cm.output))  # ERROR before re-raise
+
+  async def test_in_range_move_reads_position_once(self):
+    """Happy path: the out-of-range check reuses the merge read, so a move issues a single wherej
+    before moveJ (no redundant position read)."""
+    self._stub("0 0.0 90.0 0.0 0")  # all axes in range
+    await self.backend.move_to_joint_position({Axis.SHOULDER: 10.0})
+    self.assertEqual(self._cmds("wherej"), ["wherej"])  # exactly one position read
+    self.assertEqual(len(self._cmds("moveJ")), 1)
+
+  async def test_move_to_location_is_also_guarded(self):
+    """The Cartesian path funnels through the same guard: an out-of-range axis raises and sends no
+    moveJ, like the joint path. The IK target is stubbed - it is the guard wiring, not IK, pinned
+    here."""
+    self.backend._recover_out_of_range = False
+    self._stub("0 93.5 90.0 0.0 0")  # current shoulder 93.5 > 93, out of range
+    in_range = {
+      Axis.BASE: 0.0,
+      Axis.SHOULDER: 0.0,
+      Axis.ELBOW: 90.0,
+      Axis.WRIST: 0.0,
+      Axis.GRIPPER: 0.0,
+    }
+    with patch.object(self.backend, "_cart_to_joints", AsyncMock(return_value=in_range)):
+      with self.assertRaises(OutOfRangeOfMotionError) as ctx:
+        await self.backend.move_to_location(Coordinate(400.0, 0.0, 200.0), 0.0)
+    self.assertIn(Axis.SHOULDER, ctx.exception.axes)
+    self.assertEqual(self._cmds("moveJ"), [])


### PR DESCRIPTION
Distinguishes a recoverable arm *state* from a bad request, and recovers the former. An axis whose current position sits outside its soft limits puts the controller in a state where it rejects every commanded move (-1012); that is now a typed `OutOfRangeOfMotionError`, separate from a bad commanded *target*, which stays a `ValueError`. This extends the setup-time recovery already in `v1b1` to commanded moves, behind one flag.

```python
from pylabrobot.brooks.precise_flex import OutOfRangeOfMotionError, PreciseFlex400

# Default (recover_out_of_range=True): an axis that drifted out of range is driven
# back in, then the move proceeds - no special handling needed.
pf = PreciseFlex400(host="192.168.0.1", closed_gripper_position=...)
await pf.setup()
await pf.arm.move_to_location(Coordinate(400, 0, 200), direction=0.0)

# Opt out of the autonomous motion and handle it yourself.
pf = PreciseFlex400(host=..., closed_gripper_position=..., recover_out_of_range=False)
try:
    await pf.arm.move_to_location(Coordinate(400, 0, 200))
except OutOfRangeOfMotionError as e:
    await pf.arm.backend.recover_axes_within_limits()  # or freedrive the axis back
```

- `OutOfRangeOfMotionError` (standalone exception, exported): raised when an axis's current position is outside its soft limits. It carries `axes` (`{axis -> (value, (lo, hi))}`) so recovery knows what to move, and is its own type so the recover-and-retry path can catch the recoverable state without also catching a bad target.
- One guard, `_guarded_move_j`: reads the live pose, checks both current and target against the soft limits, sends the `moveJ`, and on out-of-range recovers once (`recover_axes_within_limits`) then retries. Both `move_to_joint_position` (a partial spec merged over the live pose) and `move_to_location` (a full pose from IK) funnel through it, so no commanded move reaches the raw `_move_j` primitive unchecked.
- `recover_out_of_range` (default True), on `PreciseFlexArmBackend` and both the `PreciseFlex400` / `PreciseFlex3400` wrappers: drives an out-of-range axis back into range once, the same way at setup and before a commanded move (which then retries). Set False to forbid this autonomous motion; an out-of-range axis then raises instead, carrying recovery instructions. Recovery uses `_move_one_axis`, a different primitive, so it never recurses through the guard and runs at most once per move (no loop).
- The current-vs-target split is the whole reason the type exists: recovery is the right response to a bad *current* state, never to a bad *target* (which is a re-teach, not a recover).

Behaviour change: setup's out-of-range failure now raises `OutOfRangeOfMotionError` rather than `PreciseFlexError(-1012)`. `v1b1` is unreleased; the new type is more specific and carries the same guidance.

Rider: `set_tool_transformation_values` is made private (`_set_tool_transformation_values`). The client kinematics read the tool once into the frozen configuration at setup, so changing it live desyncs `request_gripper_pose` from the controller until the configuration is rebuilt.

Tests: default-recovers vs opt-out-raises on a joint move; recover-then-retry sends `MoveOneAxis` then `moveJ` with the expected warning/info logs; an unrecoverable axis re-raises once without moving; an in-range move reads the pose exactly once (no redundant read); and `move_to_location` is guarded the same as the joint path.

Lint, format, and isort clean; no new mypy errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
