### PR TITLE
v1: `CytationMicroscopyBackend`: add color brightfield imaging mode

### DIFF
--- a/pylabrobot/agilent/biotek/plate_readers/cytation/microscopy_backend.py
+++ b/pylabrobot/agilent/biotek/plate_readers/cytation/microscopy_backend.py
@@ -43,6 +43,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Color brightfield is not a fixed imaging mode. Instead of a single illuminated acquisition, the
+# instrument illuminates the sample sequentially with three separate LED colors and the host
+# combines the resulting mono frames into one RGB image. These are the firmware LED codes for the
+# three colors, in the order they are cycled (red, green, blue), discovered by reverse-engineering
+# a Gen5 color-brightfield capture: per color the firmware sends `i L0{code}10` (LED on) followed
+# by `i l{code}` (strobe) before each camera trigger. White brightfield (code 5) is used only for
+# setup/focus, never in the cycle.
+COLOR_BRIGHTFIELD_LED_CODES = (6, 7, 8)
+
 
 @dataclass
 class CytationImagingConfig:
@@ -340,6 +349,34 @@ class CytationMicroscopyBackend(MicroscopyBackend):
           raise
     raise TimeoutError("max_image_read_attempts reached")
 
+  async def _set_color_brightfield_led(self, led_code: int, intensity: int) -> None:
+    """Switch color-brightfield illumination to a single LED color and strobe it.
+
+    Unlike other modes, color brightfield has no static LED state: the instrument turns on one of
+    the three LED colors (``i L0{led_code}{intensity}``), strobes it (``i l{led_code}``), then the
+    camera is triggered, repeating once per color. See ``COLOR_BRIGHTFIELD_LED_CODES``.
+    """
+    if not 1 <= intensity <= 10:
+      raise ValueError("intensity must be between 1 and 10")
+    intensity_str = str(intensity).zfill(2)
+    await self.driver.send_command("i", f"L0{led_code}{intensity_str}")
+    await self.driver.send_command("i", f"l{led_code}")
+
+  async def _acquire_color_brightfield_image(self, led_intensity: int) -> Image:
+    """Acquire one color-brightfield image.
+
+    Captures a mono frame under each of the three brightfield LED colors and stacks them into an
+    ``(H, W, 3)`` RGB image. A single exposure/gain (set by the caller) is used for all three
+    channels; Gen5's per-color auto-exposure is not replicated.
+    """
+    import numpy as np
+
+    channels: List[Image] = []
+    for led_code in COLOR_BRIGHTFIELD_LED_CODES:
+      await self._set_color_brightfield_led(led_code, intensity=led_intensity)
+      channels.append(await self.acquire_image())
+    return np.stack(channels, axis=-1)
+
   async def get_exposure(self) -> float:
     """Get current exposure time in ms."""
     return await self.camera.get_exposure()
@@ -348,7 +385,13 @@ class CytationMicroscopyBackend(MicroscopyBackend):
 
   def _imaging_mode_code(self, mode: ImagingMode) -> int:
     """Get filter wheel position index for an imaging mode."""
-    if mode == ImagingMode.BRIGHTFIELD or mode == ImagingMode.PHASE_CONTRAST:
+    if mode in (
+      ImagingMode.BRIGHTFIELD,
+      ImagingMode.PHASE_CONTRAST,
+      ImagingMode.COLOR_BRIGHTFIELD,
+    ):
+      # Color brightfield uses the brightfield light path (filter cube 5); its three colors are
+      # selected via LED codes 6/7/8 during acquisition, not here.
       return 5
     for i, f in enumerate(self.filters):
       if f == mode:
@@ -365,11 +408,11 @@ class CytationMicroscopyBackend(MicroscopyBackend):
   async def set_imaging_mode(self, mode: ImagingMode, led_intensity: int = 10) -> None:
     """Set filter wheel position and LED."""
     if mode == self._imaging_mode:
-      await self.led_on(intensity=led_intensity)
+      # Color brightfield has no single LED state to (re)enable; its colors are cycled per frame
+      # during acquisition (see _acquire_color_brightfield_image).
+      if mode != ImagingMode.COLOR_BRIGHTFIELD:
+        await self.led_on(intensity=led_intensity)
       return
-
-    if mode == ImagingMode.COLOR_BRIGHTFIELD:
-      raise NotImplementedError("Color brightfield not implemented")
 
     await self.led_off()
     filter_index = self._imaging_mode_code(mode)
@@ -377,6 +420,8 @@ class CytationMicroscopyBackend(MicroscopyBackend):
     if self.driver.version.startswith("1"):
       if mode == ImagingMode.PHASE_CONTRAST:
         raise NotImplementedError("Phase contrast not implemented on Cytation 1")
+      elif mode == ImagingMode.COLOR_BRIGHTFIELD:
+        raise NotImplementedError("Color brightfield not implemented on Cytation 1")
       elif mode == ImagingMode.BRIGHTFIELD:
         await self.driver.send_command("Y", "P0c05")
         await self.driver.send_command("Y", "P0f02")
@@ -388,7 +433,9 @@ class CytationMicroscopyBackend(MicroscopyBackend):
         await self.driver.send_command("Y", "P1120")
         await self.driver.send_command("Y", "P0d05")
         await self.driver.send_command("Y", "P1002")
-      elif mode == ImagingMode.BRIGHTFIELD:
+      elif mode in (ImagingMode.BRIGHTFIELD, ImagingMode.COLOR_BRIGHTFIELD):
+        # Color brightfield uses the same light path as brightfield; the three colors are
+        # selected via LED codes during acquisition.
         await self.driver.send_command("Y", "P1101")
         await self.driver.send_command("Y", "P0d05")
         await self.driver.send_command("Y", "P1002")
@@ -397,8 +444,11 @@ class CytationMicroscopyBackend(MicroscopyBackend):
         await self.driver.send_command("Y", f"P0d{filter_index:02}")
         await self.driver.send_command("Y", "P1001")
 
+    # Color brightfield has no single LED state; its colors are cycled per frame during
+    # acquisition (see _acquire_color_brightfield_image).
     self._imaging_mode = mode
-    await self.led_on(intensity=led_intensity)
+    if mode != ImagingMode.COLOR_BRIGHTFIELD:
+      await self.led_on(intensity=led_intensity)
 
   async def set_objective(self, objective: Objective) -> None:
     """Rotate objective turret to the specified objective."""
@@ -594,7 +644,10 @@ class CytationMicroscopyBackend(MicroscopyBackend):
       for x_pos, y_pos in positions:
         await self.set_position(x=x_pos, y=y_pos)
         t0 = time.time()
-        images.append(await self.acquire_image())
+        if mode == ImagingMode.COLOR_BRIGHTFIELD:
+          images.append(await self._acquire_color_brightfield_image(led_intensity=led_intensity))
+        else:
+          images.append(await self.acquire_image())
         t1 = time.time()
         logger.debug("[cytation] acquired image in %.2f seconds", t1 - t0)
     finally:

--- a/pylabrobot/agilent/biotek/plate_readers/cytation/microscopy_backend_tests.py
+++ b/pylabrobot/agilent/biotek/plate_readers/cytation/microscopy_backend_tests.py
@@ -1,0 +1,74 @@
+import unittest
+import unittest.mock
+
+import pytest
+
+pytest.importorskip("numpy")
+
+import numpy as np
+
+from pylabrobot.agilent.biotek.plate_readers.cytation.microscopy_backend import (
+  COLOR_BRIGHTFIELD_LED_CODES,
+  CytationMicroscopyBackend,
+)
+from pylabrobot.capabilities.microscopy.standard import ImagingMode
+
+
+def _make_backend(version: str = "2.07"):
+  """A microscopy backend with a fully mocked serial driver (no hardware)."""
+  driver = unittest.mock.MagicMock()
+  driver.version = version
+  driver.send_command = unittest.mock.AsyncMock()
+  backend = CytationMicroscopyBackend(driver=driver, use_cam=False)
+  return backend, driver
+
+
+class TestColorBrightfield(unittest.IsolatedAsyncioTestCase):
+  """Color brightfield illuminates with three LEDs (codes 6/7/8) and stacks the frames."""
+
+  def test_imaging_mode_code_uses_brightfield_light_path(self):
+    backend, _ = _make_backend()
+    # Color brightfield shares the brightfield filter cube (5); colors come from the LEDs.
+    self.assertEqual(backend._imaging_mode_code(ImagingMode.COLOR_BRIGHTFIELD), 5)
+
+  async def test_acquire_cycles_three_leds_and_stacks_rgb(self):
+    backend, driver = _make_backend()
+    frame = np.zeros((4, 5), dtype=np.uint8)
+    backend.acquire_image = unittest.mock.AsyncMock(return_value=frame)
+
+    image = await backend._acquire_color_brightfield_image(led_intensity=10)
+
+    # One mono frame per color, stacked into an (H, W, 3) RGB image.
+    self.assertEqual(image.shape, (4, 5, 3))
+    self.assertEqual(backend.acquire_image.await_count, 3)
+
+    # Per color, in cycle order: LED on (L0{code}10) then strobe (l{code}).
+    expected = []
+    for code in COLOR_BRIGHTFIELD_LED_CODES:
+      expected.append(unittest.mock.call("i", f"L0{code}10"))
+      expected.append(unittest.mock.call("i", f"l{code}"))
+    self.assertEqual(driver.send_command.await_args_list, expected)
+
+  async def test_set_imaging_mode_matches_brightfield_setup_without_static_led(self):
+    backend, driver = _make_backend(version="2.07")
+    backend._imaging_mode = None
+
+    await backend.set_imaging_mode(ImagingMode.COLOR_BRIGHTFIELD, led_intensity=10)
+
+    sent = [call.args for call in driver.send_command.await_args_list]
+    # Same optics setup as plain brightfield (filter cube 5).
+    for cmd in (("Y", "P1101"), ("Y", "P0d05"), ("Y", "P1002")):
+      self.assertIn(cmd, sent)
+    # No single LED is enabled (colors are cycled during acquisition): only led_off (L0001).
+    self.assertEqual([p for (ch, p) in sent if ch == "i"], ["L0001"])
+    self.assertEqual(backend._imaging_mode, ImagingMode.COLOR_BRIGHTFIELD)
+
+  async def test_color_brightfield_not_supported_on_cytation1(self):
+    backend, _ = _make_backend(version="1.05")
+    backend._imaging_mode = None
+    with self.assertRaises(NotImplementedError):
+      await backend.set_imaging_mode(ImagingMode.COLOR_BRIGHTFIELD, led_intensity=10)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/pylabrobot/capabilities/microscopy/__init__.py
+++ b/pylabrobot/capabilities/microscopy/__init__.py
@@ -4,6 +4,7 @@ from .microscopy import (
   evaluate_focus_nvmg_sobel,
   fraction_overexposed,
   max_pixel_at_fraction,
+  white_balance,
 )
 from .standard import (
   AutoExposure,

--- a/pylabrobot/capabilities/microscopy/microscopy.py
+++ b/pylabrobot/capabilities/microscopy/microscopy.py
@@ -326,3 +326,31 @@ def evaluate_focus_nvmg_sobel(image) -> float:
   mean_gm = np.mean(gradient_magnitude)
   var_gm = np.var(gradient_magnitude)
   return float(var_gm / (mean_gm + 1e-6))
+
+
+def white_balance(image, percentile: float = 98.0):
+  """White-balance an RGB image using the white-patch (bright background) assumption.
+
+  Scales each channel so its high-percentile value -- the bright, ideally neutral background --
+  matches the brightest channel, neutralizing a color cast while preserving relative color. Handy
+  for color-brightfield images, whose three LED channels differ in intensity/response (e.g. green
+  is absorbed by phenol-red media), giving the raw stack a magenta cast.
+
+  Args:
+    image: an ``(H, W, 3)`` RGB array.
+    percentile: per-channel percentile used as the "white" reference (default 98).
+
+  Returns:
+    An ``(H, W, 3)`` uint8 array, white-balanced.
+  """
+  if np is None:
+    raise ImportError("numpy is required for white_balance")
+
+  arr = np.asarray(image, dtype=np.float32)
+  if arr.ndim != 3 or arr.shape[-1] != 3:
+    raise ValueError(f"expected an (H, W, 3) RGB image, got shape {arr.shape}")
+
+  ref = np.percentile(arr.reshape(-1, 3), percentile, axis=0)
+  ref[ref == 0] = 1.0  # avoid divide-by-zero on an empty channel
+  gains = ref.max() / ref
+  return np.clip(arr * gains, 0, 255).astype(np.uint8)

--- a/pylabrobot/capabilities/microscopy/microscopy_tests.py
+++ b/pylabrobot/capabilities/microscopy/microscopy_tests.py
@@ -11,7 +11,7 @@ import numpy  # noqa: E402
 
 from pylabrobot.capabilities.microscopy.backend import MicroscopyBackend
 from pylabrobot.capabilities.microscopy.chatterbox import MicroscopyChatterboxBackend
-from pylabrobot.capabilities.microscopy.microscopy import Microscopy
+from pylabrobot.capabilities.microscopy.microscopy import Microscopy, white_balance
 from pylabrobot.capabilities.microscopy.standard import (
   Exposure,
   FocalPosition,
@@ -169,6 +169,23 @@ class TestChatterboxBackend(unittest.IsolatedAsyncioTestCase):
     self.assertEqual(len(result.images), 1)
     self.assertAlmostEqual(result.exposure_time, 10.0)
     self.assertAlmostEqual(result.focal_height, 1.0)
+
+
+class TestWhiteBalance(unittest.TestCase):
+  def test_neutralizes_color_cast(self):
+    # Uniform magenta field (green at half of red/blue) should come back neutral gray.
+    img = numpy.zeros((8, 8, 3), dtype=numpy.uint8)
+    img[..., 0], img[..., 1], img[..., 2] = 200, 100, 200
+    out = white_balance(img)
+    self.assertEqual(out.shape, (8, 8, 3))
+    self.assertEqual(out.dtype, numpy.uint8)
+    means = [int(out[..., k].mean()) for k in range(3)]
+    self.assertEqual(means[0], means[1])
+    self.assertEqual(means[1], means[2])
+
+  def test_rejects_non_rgb_image(self):
+    with self.assertRaises(ValueError):
+      white_balance(numpy.zeros((8, 8), dtype=numpy.uint8))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Adds support for the **color brightfield** imaging mode on the Cytation (`ImagingMode.COLOR_BRIGHTFIELD`), which until now raised `NotImplementedError`.

Unlike the other modes, color brightfield isn't a single fixed illumination. The instrument illuminates the sample sequentially with **three separate LED colors** and the host combines the resulting mono frames into one `(H, W, 3)` RGB image.

## How it works (reverse-engineered)

Discovered by reverse-engineering a Gen5 color-brightfield USB capture:

- The optics are set up exactly like plain brightfield (filter cube 5).
- Then, per color, the firmware sends `i L0{code}{intensity}` (LED on) followed by `i l{code}` (strobe) before each camera trigger, cycling through LED **codes 6 → 7 → 8**. White brightfield (code 5) is used only for setup/focus, never in the cycle.

`_acquire_color_brightfield_image` captures one mono frame per color and stacks them. White balance / per-color exposure is intentionally **left to the caller** — the raw stacked RGB is returned (phenol-red media is genuinely magenta because green is absorbed, so balancing is application-specific).

## Testing

- **Unit tests** (`microscopy_backend_tests.py`, fully mocked driver, no hardware) pin the exact LED command sequence (`L0610`/`l6`/`L0710`/`l7`/`L0810`/`l8`), the RGB stacking, the brightfield-path setup, and that no static LED is left on.
- **Hardware-tested on a Cytation 5** end-to-end: captured in-focus, color-correct images of stained cells across a 48-well plate.

## Notes / scope

- Implemented for **Cytation 2.x**. Raises `NotImplementedError` on Cytation 1 (that firmware path wasn't captured).
- The R vs B channel mapping (codes 6 vs 8) is assumed; green (code 7) is confirmed. Cyan-stained (X-gal) cells read cyan, consistent with the assumed order, but a known red/blue target would confirm it definitively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)