### PR TITLE
v1: `CytationMicroscopyBackend`: add 10x objective field of view to `image_size`

### DIFF
--- a/pylabrobot/agilent/biotek/plate_readers/cytation/microscopy_backend.py
+++ b/pylabrobot/agilent/biotek/plate_readers/cytation/microscopy_backend.py
@@ -562,6 +562,10 @@ class CytationMicroscopyBackend(MicroscopyBackend):
       def image_size(magnification: float) -> Tuple[float, float]:
         if magnification == 4:
           return (3474 / 1000, 3474 / 1000)
+        if magnification == 10:
+          # Estimated from the ~13880 um * magnification^-1 pattern of the other entries; the
+          # 4/20/40x values are measured. Refine with a measured 10x field of view if available.
+          return (1388 / 1000, 1388 / 1000)
         if magnification == 20:
           return (694 / 1000, 694 / 1000)
         if magnification == 40:


### PR DESCRIPTION
> **Draft** — the 10x FOV value is estimated, not measured. Opening for review/confirmation.

## What

`image_size()` in `capture()` only had entries for 4x/20x/40x objectives, so capturing with a **10x** objective raised `ValueError: Don't know image size for magnification 10`. This adds a 10x entry.

## Caveat

The value (1388 µm) is **estimated** from the `~13880 µm · magnification⁻¹` pattern the existing (measured) 4x/20x/40x entries follow:

| mag | FOV (µm) | mag · FOV |
|----:|---------:|----------:|
| 4   | 3474     | 13896     |
| 20  | 694      | 13880     |
| 40  | 347      | 13880     |
| **10** | **1388 (est.)** | **13880** |

It affects tile spacing / count for multi-tile `coverage`, so it should be confirmed against a measured 10x field of view before this is relied on for stitching. Single-tile captures at 10x are unaffected by the exact value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)