### PR TITLE
v1: `LoadingTray`: pass held plate to backend `close()`

### DIFF
--- a/pylabrobot/agilent/biotek/biotek_tests.py
+++ b/pylabrobot/agilent/biotek/biotek_tests.py
@@ -10,6 +10,7 @@ import pytest
 
 pytest.importorskip("pylibftdi")
 
+from pylabrobot.agilent.biotek.loading_tray_backend import BioTekLoadingTrayBackend
 from pylabrobot.agilent.biotek.plate_readers.base import BioTekBackend
 from pylabrobot.resources import CellVis_24_wellplate_3600uL_Fb, CellVis_96_wellplate_350uL_Fb
 
@@ -64,13 +65,13 @@ class TestCytation5Backend(unittest.IsolatedAsyncioTestCase):
 
   async def test_open(self):
     self.backend.io.read.side_effect = [b"\x06", b"\x03", b"\x03"]
-    await self.backend.open()
+    await BioTekLoadingTrayBackend(driver=self.backend).open()
     self.backend.io.write.assert_called_with(b"J")
 
   async def test_close(self):
     self.backend.io.read.side_effect = [b"\x06", b"\x03", b"\x06", b"\x03", b"\x03"]
     plate = CellVis_24_wellplate_3600uL_Fb(name="plate")
-    await self.backend.close(plate=plate)
+    await BioTekLoadingTrayBackend(driver=self.backend).close(resource=plate)
     self.backend.io.write.assert_called_with(b"A")
 
   async def test_request_current_temperature(self):
@@ -405,7 +406,7 @@ class TestBioTekLoadingTrayBackend(unittest.IsolatedAsyncioTestCase):
 
     self.manager = unittest.mock.Mock()
     self.driver = unittest.mock.MagicMock()
-    self.driver._set_slow_mode = unittest.mock.AsyncMock()
+    self.driver.set_slow_mode = unittest.mock.AsyncMock()
     self.driver.set_plate = unittest.mock.AsyncMock()
     self.driver.send_command = unittest.mock.AsyncMock()
     self.manager.attach_mock(self.driver.set_plate, "set_plate")
@@ -414,13 +415,13 @@ class TestBioTekLoadingTrayBackend(unittest.IsolatedAsyncioTestCase):
     self.plate = CellVis_24_wellplate_3600uL_Fb(name="plate")
 
   async def test_close_sends_plate_geometry_then_closes(self):
-    await self.backend.close(plate=self.plate)
+    await self.backend.close(resource=self.plate)
     self.driver.set_plate.assert_awaited_once_with(self.plate)
     self.driver.send_command.assert_awaited_once_with("A")
     # set_plate must run before the close ("A") command.
     self.assertEqual([call[0] for call in self.manager.mock_calls], ["set_plate", "send_command"])
 
   async def test_close_without_plate_skips_set_plate(self):
-    await self.backend.close(plate=None)
+    await self.backend.close(resource=None)
     self.driver.set_plate.assert_not_awaited()
     self.driver.send_command.assert_awaited_once_with("A")

--- a/pylabrobot/agilent/biotek/biotek_tests.py
+++ b/pylabrobot/agilent/biotek/biotek_tests.py
@@ -395,3 +395,32 @@ class TestCytation5Backend(unittest.IsolatedAsyncioTestCase):
           self.assertTrue(v is not None and math.isnan(v), f"Expected NaN at ({r},{c}), got {v}")
         else:
           self.assertEqual(v, e, f"Mismatch at ({r},{c})")
+
+
+class TestBioTekLoadingTrayBackend(unittest.IsolatedAsyncioTestCase):
+  """The tray must send the plate geometry to the firmware before closing (tall-plate clearance)."""
+
+  async def asyncSetUp(self):
+    from pylabrobot.agilent.biotek.loading_tray_backend import BioTekLoadingTrayBackend
+
+    self.manager = unittest.mock.Mock()
+    self.driver = unittest.mock.MagicMock()
+    self.driver._set_slow_mode = unittest.mock.AsyncMock()
+    self.driver.set_plate = unittest.mock.AsyncMock()
+    self.driver.send_command = unittest.mock.AsyncMock()
+    self.manager.attach_mock(self.driver.set_plate, "set_plate")
+    self.manager.attach_mock(self.driver.send_command, "send_command")
+    self.backend = BioTekLoadingTrayBackend(driver=self.driver)
+    self.plate = CellVis_24_wellplate_3600uL_Fb(name="plate")
+
+  async def test_close_sends_plate_geometry_then_closes(self):
+    await self.backend.close(plate=self.plate)
+    self.driver.set_plate.assert_awaited_once_with(self.plate)
+    self.driver.send_command.assert_awaited_once_with("A")
+    # set_plate must run before the close ("A") command.
+    self.assertEqual([call[0] for call in self.manager.mock_calls], ["set_plate", "send_command"])
+
+  async def test_close_without_plate_skips_set_plate(self):
+    await self.backend.close(plate=None)
+    self.driver.set_plate.assert_not_awaited()
+    self.driver.send_command.assert_awaited_once_with("A")

--- a/pylabrobot/agilent/biotek/loading_tray_backend.py
+++ b/pylabrobot/agilent/biotek/loading_tray_backend.py
@@ -4,6 +4,8 @@ from typing import Optional
 from pylabrobot.agilent.biotek.plate_readers.base import BioTekBackend
 from pylabrobot.capabilities.capability import BackendParams
 from pylabrobot.capabilities.loading_tray.backend import LoadingTrayBackend
+from pylabrobot.resources.plate import Plate
+from pylabrobot.resources.resource import Resource
 
 
 class BioTekLoadingTrayBackend(LoadingTrayBackend):
@@ -26,8 +28,16 @@ class BioTekLoadingTrayBackend(LoadingTrayBackend):
     await self._driver._set_slow_mode(backend_params.slow)
     await self._driver.send_command("J")
 
-  async def close(self, backend_params: Optional[BackendParams] = None):
+  async def close(
+    self,
+    backend_params: Optional[BackendParams] = None,
+    plate: Optional[Resource] = None,
+  ):
     if not isinstance(backend_params, self.CloseParams):
       backend_params = self.CloseParams()
     await self._driver._set_slow_mode(backend_params.slow)
+    # Send the plate geometry to the firmware before closing so the carrier accounts for the
+    # labware height during the close motion. Without this, a tall plate can jam the tray.
+    if isinstance(plate, Plate):
+      await self._driver.set_plate(plate)
     await self._driver.send_command("A")

--- a/pylabrobot/agilent/biotek/loading_tray_backend.py
+++ b/pylabrobot/agilent/biotek/loading_tray_backend.py
@@ -25,19 +25,21 @@ class BioTekLoadingTrayBackend(LoadingTrayBackend):
   async def open(self, backend_params: Optional[BackendParams] = None):
     if not isinstance(backend_params, self.OpenParams):
       backend_params = self.OpenParams()
-    await self._driver._set_slow_mode(backend_params.slow)
+    await self._driver.set_slow_mode(backend_params.slow)
     await self._driver.send_command("J")
 
   async def close(
     self,
     backend_params: Optional[BackendParams] = None,
-    plate: Optional[Resource] = None,
+    resource: Optional[Resource] = None,
   ):
     if not isinstance(backend_params, self.CloseParams):
       backend_params = self.CloseParams()
-    await self._driver._set_slow_mode(backend_params.slow)
+    # Closing invalidates whatever plate geometry the firmware last had loaded.
+    self._driver.clear_plate()
+    await self._driver.set_slow_mode(backend_params.slow)
     # Send the plate geometry to the firmware before closing so the carrier accounts for the
     # labware height during the close motion. Without this, a tall plate can jam the tray.
-    if isinstance(plate, Plate):
-      await self._driver.set_plate(plate)
+    if isinstance(resource, Plate):
+      await self._driver.set_plate(resource)
     await self._driver.send_command("A")

--- a/pylabrobot/agilent/biotek/plate_readers/base.py
+++ b/pylabrobot/agilent/biotek/plate_readers/base.py
@@ -207,22 +207,15 @@ class BioTekBackend(
     assert resp is not None
     return " ".join(resp[1:-1].decode().split(" ")[3:4])
 
-  async def _set_slow_mode(self, slow: bool):
+  async def set_slow_mode(self, slow: bool):
     if self._slow_mode == slow:
       return
     await self.send_command("&", "S1" if slow else "S0")
     self._slow_mode = slow
 
-  async def open(self, slow: bool = False):
-    await self._set_slow_mode(slow)
-    return await self.send_command("J")
-
-  async def close(self, plate: Optional[Plate] = None, slow: bool = False):
+  def clear_plate(self) -> None:
+    """Forget the plate geometry the firmware last had loaded (e.g. after closing the tray)."""
     self._plate = None
-    await self._set_slow_mode(slow)
-    if plate is not None:
-      await self.set_plate(plate)
-    return await self.send_command("A")
 
   async def home(self):
     return await self.send_command("i", "x")

--- a/pylabrobot/agilent/biotek/plate_readers/synergy/synergy_h1.py
+++ b/pylabrobot/agilent/biotek/plate_readers/synergy/synergy_h1.py
@@ -13,6 +13,7 @@ except ImportError:
 
 from pylabrobot.agilent.biotek.loading_tray_backend import BioTekLoadingTrayBackend
 from pylabrobot.agilent.biotek.plate_readers.base import BioTekBackend
+from pylabrobot.capabilities.loading_tray import LoadingTray
 from pylabrobot.capabilities.plate_reading.absorbance import Absorbance
 from pylabrobot.capabilities.plate_reading.fluorescence import Fluorescence
 from pylabrobot.capabilities.plate_reading.luminescence import Luminescence
@@ -127,12 +128,25 @@ class SynergyH1(Resource, Device):
     )
     Device.__init__(self, driver=backend)
     self.driver: SynergyH1Backend = backend
-    self._loading_tray_backend = BioTekLoadingTrayBackend(driver=backend)
     self.absorbance = Absorbance(backend=backend)
     self.luminescence = Luminescence(backend=backend)
     self.fluorescence = Fluorescence(backend=backend)
     self.temperature = TemperatureController(backend=backend)
-    self._capabilities = [self.absorbance, self.luminescence, self.fluorescence, self.temperature]
+    self.loading_tray = LoadingTray(
+      backend=BioTekLoadingTrayBackend(driver=backend),
+      name=name + "_loading_tray",
+      size_x=127.76,
+      size_y=85.48,
+      size_z=0,
+      child_location=Coordinate.zero(),
+    )
+    self._capabilities = [
+      self.absorbance,
+      self.luminescence,
+      self.fluorescence,
+      self.temperature,
+      self.loading_tray,
+    ]
 
     self.plate_holder = PlateHolder(
       name=name + "_plate_holder",
@@ -146,13 +160,3 @@ class SynergyH1(Resource, Device):
 
   def serialize(self) -> dict:
     return {**Resource.serialize(self), **Device.serialize(self)}
-
-  async def open(self, slow: bool = False) -> None:
-    await self._loading_tray_backend.open(
-      backend_params=BioTekLoadingTrayBackend.OpenParams(slow=slow)
-    )
-
-  async def close(self, slow: bool = False) -> None:
-    await self._loading_tray_backend.close(
-      backend_params=BioTekLoadingTrayBackend.CloseParams(slow=slow)
-    )

--- a/pylabrobot/agilent/biotek/plate_readers/synergy/synergy_h1.py
+++ b/pylabrobot/agilent/biotek/plate_readers/synergy/synergy_h1.py
@@ -11,6 +11,7 @@ except ImportError:
   HAS_PYLIBFTDI = False
   FtdiError = Exception  # type: ignore[misc,assignment]
 
+from pylabrobot.agilent.biotek.loading_tray_backend import BioTekLoadingTrayBackend
 from pylabrobot.agilent.biotek.plate_readers.base import BioTekBackend
 from pylabrobot.capabilities.plate_reading.absorbance import Absorbance
 from pylabrobot.capabilities.plate_reading.fluorescence import Fluorescence
@@ -126,6 +127,7 @@ class SynergyH1(Resource, Device):
     )
     Device.__init__(self, driver=backend)
     self.driver: SynergyH1Backend = backend
+    self._loading_tray_backend = BioTekLoadingTrayBackend(driver=backend)
     self.absorbance = Absorbance(backend=backend)
     self.luminescence = Luminescence(backend=backend)
     self.fluorescence = Fluorescence(backend=backend)
@@ -146,7 +148,11 @@ class SynergyH1(Resource, Device):
     return {**Resource.serialize(self), **Device.serialize(self)}
 
   async def open(self, slow: bool = False) -> None:
-    await self.driver.open(slow=slow)
+    await self._loading_tray_backend.open(
+      backend_params=BioTekLoadingTrayBackend.OpenParams(slow=slow)
+    )
 
   async def close(self, slow: bool = False) -> None:
-    await self.driver.close(slow=slow)
+    await self._loading_tray_backend.close(
+      backend_params=BioTekLoadingTrayBackend.CloseParams(slow=slow)
+    )

--- a/pylabrobot/capabilities/loading_tray/backend.py
+++ b/pylabrobot/capabilities/loading_tray/backend.py
@@ -1,7 +1,10 @@
 from abc import ABCMeta, abstractmethod
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from pylabrobot.capabilities.capability import BackendParams, CapabilityBackend
+
+if TYPE_CHECKING:
+  from pylabrobot.resources.resource import Resource
 
 
 class LoadingTrayBackend(CapabilityBackend, metaclass=ABCMeta):
@@ -12,5 +15,15 @@ class LoadingTrayBackend(CapabilityBackend, metaclass=ABCMeta):
     """Open the loading tray."""
 
   @abstractmethod
-  async def close(self, backend_params: Optional[BackendParams] = None):
-    """Close the loading tray."""
+  async def close(
+    self,
+    backend_params: Optional[BackendParams] = None,
+    plate: Optional["Resource"] = None,
+  ):
+    """Close the loading tray.
+
+    Args:
+      plate: the resource currently held by the tray, if any. Backends that need the labware
+        geometry during the close motion (e.g. to give a tall plate enough clearance) can use it;
+        others ignore it.
+    """

--- a/pylabrobot/capabilities/loading_tray/backend.py
+++ b/pylabrobot/capabilities/loading_tray/backend.py
@@ -18,12 +18,12 @@ class LoadingTrayBackend(CapabilityBackend, metaclass=ABCMeta):
   async def close(
     self,
     backend_params: Optional[BackendParams] = None,
-    plate: Optional["Resource"] = None,
+    resource: Optional["Resource"] = None,
   ):
     """Close the loading tray.
 
     Args:
-      plate: the resource currently held by the tray, if any. Backends that need the labware
+      resource: the resource currently held by the tray, if any. Backends that need the labware
         geometry during the close motion (e.g. to give a tall plate enough clearance) can use it;
         others ignore it.
     """

--- a/pylabrobot/capabilities/loading_tray/chatterbox.py
+++ b/pylabrobot/capabilities/loading_tray/chatterbox.py
@@ -1,9 +1,12 @@
 import logging
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from pylabrobot.capabilities.capability import BackendParams
 
 from .backend import LoadingTrayBackend
+
+if TYPE_CHECKING:
+  from pylabrobot.resources.resource import Resource
 
 logger = logging.getLogger(__name__)
 
@@ -14,5 +17,9 @@ class LoadingTrayChatterboxBackend(LoadingTrayBackend):
   async def open(self, backend_params: Optional[BackendParams] = None):
     logger.info("Opening loading tray.")
 
-  async def close(self, backend_params: Optional[BackendParams] = None):
+  async def close(
+    self,
+    backend_params: Optional[BackendParams] = None,
+    plate: Optional["Resource"] = None,
+  ):
     logger.info("Closing loading tray.")

--- a/pylabrobot/capabilities/loading_tray/chatterbox.py
+++ b/pylabrobot/capabilities/loading_tray/chatterbox.py
@@ -20,6 +20,6 @@ class LoadingTrayChatterboxBackend(LoadingTrayBackend):
   async def close(
     self,
     backend_params: Optional[BackendParams] = None,
-    plate: Optional["Resource"] = None,
+    resource: Optional["Resource"] = None,
   ):
     logger.info("Closing loading tray.")

--- a/pylabrobot/capabilities/loading_tray/loading_tray.py
+++ b/pylabrobot/capabilities/loading_tray/loading_tray.py
@@ -42,4 +42,4 @@ class LoadingTray(Capability, ResourceHolder):
   async def close(self, backend_params: Optional[BackendParams] = None):
     # Pass the held resource so backends that need the labware geometry during the close motion
     # (e.g. to clear a tall plate) can use it.
-    await self.backend.close(backend_params=backend_params, plate=self.resource)
+    await self.backend.close(backend_params=backend_params, resource=self.resource)

--- a/pylabrobot/capabilities/loading_tray/loading_tray.py
+++ b/pylabrobot/capabilities/loading_tray/loading_tray.py
@@ -40,4 +40,6 @@ class LoadingTray(Capability, ResourceHolder):
 
   @need_capability_ready
   async def close(self, backend_params: Optional[BackendParams] = None):
-    await self.backend.close(backend_params=backend_params)
+    # Pass the held resource so backends that need the labware geometry during the close motion
+    # (e.g. to clear a tall plate) can use it.
+    await self.backend.close(backend_params=backend_params, plate=self.resource)

--- a/pylabrobot/capabilities/loading_tray/loading_tray_tests.py
+++ b/pylabrobot/capabilities/loading_tray/loading_tray_tests.py
@@ -13,7 +13,7 @@ from pylabrobot.resources.well import Well
 
 
 class _RecordingTrayBackend(LoadingTrayBackend):
-  """Records the plate passed to close()."""
+  """Records the resource passed to close()."""
 
   def __init__(self):
     self.closed_with: Optional[Resource] = "unset"  # type: ignore[assignment]
@@ -24,9 +24,9 @@ class _RecordingTrayBackend(LoadingTrayBackend):
   async def close(
     self,
     backend_params: Optional[BackendParams] = None,
-    plate: Optional[Resource] = None,
+    resource: Optional[Resource] = None,
   ):
-    self.closed_with = plate
+    self.closed_with = resource
 
 
 def _plate() -> Plate:

--- a/pylabrobot/capabilities/loading_tray/loading_tray_tests.py
+++ b/pylabrobot/capabilities/loading_tray/loading_tray_tests.py
@@ -1,0 +1,81 @@
+"""Tests for the LoadingTray capability."""
+
+import unittest
+from typing import Optional
+
+from pylabrobot.capabilities.capability import BackendParams
+from pylabrobot.capabilities.loading_tray.backend import LoadingTrayBackend
+from pylabrobot.capabilities.loading_tray.loading_tray import LoadingTray
+from pylabrobot.resources.plate import Plate
+from pylabrobot.resources.resource import Resource
+from pylabrobot.resources.utils import create_ordered_items_2d
+from pylabrobot.resources.well import Well
+
+
+class _RecordingTrayBackend(LoadingTrayBackend):
+  """Records the plate passed to close()."""
+
+  def __init__(self):
+    self.closed_with: Optional[Resource] = "unset"  # type: ignore[assignment]
+
+  async def open(self, backend_params: Optional[BackendParams] = None):
+    pass
+
+  async def close(
+    self,
+    backend_params: Optional[BackendParams] = None,
+    plate: Optional[Resource] = None,
+  ):
+    self.closed_with = plate
+
+
+def _plate() -> Plate:
+  return Plate(
+    name="plate",
+    size_x=127.0,
+    size_y=85.0,
+    size_z=14.0,
+    ordered_items=create_ordered_items_2d(
+      Well,
+      num_items_x=1,
+      num_items_y=1,
+      dx=10.0,
+      dy=10.0,
+      dz=1.0,
+      item_dx=9.0,
+      item_dy=9.0,
+      size_x=8.0,
+      size_y=8.0,
+      size_z=10.0,
+    ),
+  )
+
+
+def _tray(backend: LoadingTrayBackend, name: str) -> LoadingTray:
+  return LoadingTray(backend=backend, name=name, size_x=137.0, size_y=95.0, size_z=20.0)
+
+
+class TestLoadingTrayClose(unittest.IsolatedAsyncioTestCase):
+  async def test_close_passes_held_plate_to_backend(self):
+    backend = _RecordingTrayBackend()
+    tray = _tray(backend, "tray")
+    await tray._on_setup()
+    plate = _plate()
+    tray.assign_child_resource(plate)
+
+    await tray.close()
+
+    self.assertIs(backend.closed_with, plate)
+
+  async def test_close_passes_none_when_empty(self):
+    backend = _RecordingTrayBackend()
+    tray = _tray(backend, "tray_empty")
+    await tray._on_setup()
+
+    await tray.close()
+
+    self.assertIsNone(backend.closed_with)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/pylabrobot/inheco/scila/scila.py
+++ b/pylabrobot/inheco/scila/scila.py
@@ -32,7 +32,7 @@ class SCILADrawerLoadingTrayBackend(LoadingTrayBackend):
   async def close(
     self,
     backend_params: Optional[BackendParams] = None,
-    plate: Optional[Resource] = None,
+    resource: Optional[Resource] = None,
   ):
     await self._driver.send_command("PrepareForOutput", position=self._drawer_id)
     try:

--- a/pylabrobot/inheco/scila/scila.py
+++ b/pylabrobot/inheco/scila/scila.py
@@ -29,7 +29,11 @@ class SCILADrawerLoadingTrayBackend(LoadingTrayBackend):
     except RuntimeError as e:
       self._handle_warning("open", e)
 
-  async def close(self, backend_params: Optional[BackendParams] = None):
+  async def close(
+    self,
+    backend_params: Optional[BackendParams] = None,
+    plate: Optional[Resource] = None,
+  ):
     await self._driver.send_command("PrepareForOutput", position=self._drawer_id)
     try:
       await self._driver.send_command("CloseDoor")

--- a/pylabrobot/legacy/plate_reading/agilent/biotek_backend.py
+++ b/pylabrobot/legacy/plate_reading/agilent/biotek_backend.py
@@ -2,6 +2,7 @@
 
 from typing import Dict, List, Optional
 
+from pylabrobot.agilent.biotek.loading_tray_backend import BioTekLoadingTrayBackend
 from pylabrobot.agilent.biotek.plate_readers import base as biotek
 from pylabrobot.legacy.plate_reading.backend import PlateReaderBackend
 from pylabrobot.resources import Plate, Well
@@ -16,6 +17,7 @@ class BioTekPlateReaderBackend(PlateReaderBackend):
     device_id: Optional[str] = None,
   ) -> None:
     self._new = biotek.BioTekBackend(timeout=timeout, device_id=device_id)
+    self._loading_tray = BioTekLoadingTrayBackend(driver=self._new)
 
   # Expose internals for subclass compatibility
   @property
@@ -120,10 +122,14 @@ class BioTekPlateReaderBackend(PlateReaderBackend):
     return await self._new.request_firmware_version()
 
   async def open(self, slow=False):
-    return await self._new.open(slow=slow)
+    return await self._loading_tray.open(
+      backend_params=BioTekLoadingTrayBackend.OpenParams(slow=slow)
+    )
 
   async def close(self, plate=None, slow=False):
-    return await self._new.close(plate=plate, slow=slow)
+    return await self._loading_tray.close(
+      backend_params=BioTekLoadingTrayBackend.CloseParams(slow=slow), resource=plate
+    )
 
   async def home(self):
     return await self._new.home()

--- a/pylabrobot/legacy/plate_reading/agilent/biotek_cytation_backend.py
+++ b/pylabrobot/legacy/plate_reading/agilent/biotek_cytation_backend.py
@@ -2,6 +2,7 @@
 
 from typing import Optional
 
+from pylabrobot.agilent.biotek.loading_tray_backend import BioTekLoadingTrayBackend
 from pylabrobot.agilent.biotek.plate_readers.base import BioTekBackend
 from pylabrobot.agilent.biotek.plate_readers.cytation import (
   CytationImagingConfig,
@@ -37,6 +38,7 @@ class CytationBackend(BioTekPlateReaderBackend, ImagerBackend):
     self._microscopy_backend = CytationMicroscopyBackend(
       driver=self._new, imaging_config=imaging_config
     )
+    self._loading_tray = BioTekLoadingTrayBackend(driver=self._new)
 
   @property
   def imaging_config(self):
@@ -72,7 +74,9 @@ class CytationBackend(BioTekPlateReaderBackend, ImagerBackend):
     return self._microscopy_backend.filters
 
   async def close(self, plate=None, slow=False):
-    await self._new.close(plate=plate, slow=slow)
+    await self._loading_tray.close(
+      backend_params=BioTekLoadingTrayBackend.CloseParams(slow=slow), resource=plate
+    )
 
   def start_acquisition(self):
     self._microscopy_backend.start_acquisition()

--- a/pylabrobot/molecular_devices/spectramax/loading_tray_backend.py
+++ b/pylabrobot/molecular_devices/spectramax/loading_tray_backend.py
@@ -1,9 +1,12 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from pylabrobot.capabilities.capability import BackendParams
 from pylabrobot.capabilities.loading_tray.backend import LoadingTrayBackend
 
 from .backend import MolecularDevicesDriver
+
+if TYPE_CHECKING:
+  from pylabrobot.resources.resource import Resource
 
 
 class MolecularDevicesLoadingTrayBackend(LoadingTrayBackend):
@@ -15,5 +18,9 @@ class MolecularDevicesLoadingTrayBackend(LoadingTrayBackend):
   async def open(self, backend_params: Optional[BackendParams] = None):
     await self._driver.send_command("!OPEN")
 
-  async def close(self, backend_params: Optional[BackendParams] = None):
+  async def close(
+    self,
+    backend_params: Optional[BackendParams] = None,
+    plate: Optional["Resource"] = None,
+  ):
     await self._driver.send_command("!CLOSE")

--- a/pylabrobot/molecular_devices/spectramax/loading_tray_backend.py
+++ b/pylabrobot/molecular_devices/spectramax/loading_tray_backend.py
@@ -21,6 +21,6 @@ class MolecularDevicesLoadingTrayBackend(LoadingTrayBackend):
   async def close(
     self,
     backend_params: Optional[BackendParams] = None,
-    plate: Optional["Resource"] = None,
+    resource: Optional["Resource"] = None,
   ):
     await self._driver.send_command("!CLOSE")

--- a/pylabrobot/tecan/infinite/loading_tray_backend.py
+++ b/pylabrobot/tecan/infinite/loading_tray_backend.py
@@ -22,7 +22,7 @@ class TecanInfiniteLoadingTrayBackend(LoadingTrayBackend):
   async def close(
     self,
     backend_params: Optional[BackendParams] = None,
-    plate: Optional["Resource"] = None,
+    resource: Optional["Resource"] = None,
   ):
     await self._driver.send_command("ABSOLUTE MTP,IN")
     await self._driver.send_command("BY#T5000")

--- a/pylabrobot/tecan/infinite/loading_tray_backend.py
+++ b/pylabrobot/tecan/infinite/loading_tray_backend.py
@@ -1,9 +1,12 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from pylabrobot.capabilities.capability import BackendParams
 from pylabrobot.capabilities.loading_tray.backend import LoadingTrayBackend
 
 from .driver import TecanInfiniteDriver
+
+if TYPE_CHECKING:
+  from pylabrobot.resources.resource import Resource
 
 
 class TecanInfiniteLoadingTrayBackend(LoadingTrayBackend):
@@ -16,6 +19,10 @@ class TecanInfiniteLoadingTrayBackend(LoadingTrayBackend):
     await self._driver.send_command("ABSOLUTE MTP,OUT")
     await self._driver.send_command("BY#T5000")
 
-  async def close(self, backend_params: Optional[BackendParams] = None):
+  async def close(
+    self,
+    backend_params: Optional[BackendParams] = None,
+    plate: Optional["Resource"] = None,
+  ):
     await self._driver.send_command("ABSOLUTE MTP,IN")
     await self._driver.send_command("BY#T5000")


### PR DESCRIPTION
## What

`LoadingTray.close()` now passes the **held resource** to the backend, and `BioTekLoadingTrayBackend.close()` sends that plate's geometry to the firmware (`set_plate`) **before** the close command.

## Why

On the Cytation, the firmware needs the plate dimensions to position the carrier with enough clearance during the close motion. Without `set_plate` first, the tray closes using stale/default plate geometry, and a **tall plate jams the tray** (reproduced on a Cytation 5 with a lidded 48-well plate — it jammed until the correct height was pushed via `set_plate`).

The v1 reader backend did this (`close(plate)` called `set_plate(plate)` first); the v1b1 loading-tray refactor split the tray into its own capability/backend and dropped it, since the backend no longer had the plate. This restores it by threading the plate from the capability (which holds it as a `ResourceHolder` child) down to the backend.

## Changes

- `LoadingTrayBackend.close()` gains an optional `plate` parameter.
- `LoadingTray.close()` passes `self.resource` (the held plate).
- `BioTekLoadingTrayBackend.close()` calls `set_plate(plate)` before `"A"` when a plate is present.
- The other backends — chatterbox, Molecular Devices (SpectraMax), Tecan Infinite, Inheco SCILA — accept and ignore the new param (signature-only change).

## Tests

- `loading_tray_tests.py`: the capability passes the held plate (and `None` when empty) to the backend.
- `biotek_tests.py`: `BioTekLoadingTrayBackend.close(plate=...)` calls `set_plate` then `"A"` in that order; `close(plate=None)` skips `set_plate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)