### PR TITLE
`resources.utils`: accept item_dx/item_dy=None to declare a single-item dimension

### DIFF
--- a/pylabrobot/resources/agenbio/plates.py
+++ b/pylabrobot/resources/agenbio/plates.py
@@ -178,8 +178,8 @@ def AGenBio_1_troughplate_190000uL_Fl(name: str, lid: Optional[Lid] = None) -> P
       dx=10.1,
       dy=7.6,
       dz=5.88,
-      item_dx=INNER_WELL_WIDTH,
-      item_dy=INNER_WELL_HEIGHT,
+      item_dx=None,  # single column
+      item_dy=None,  # single row
       **well_kwargs,
     ),
   )
@@ -228,8 +228,8 @@ def AGenBio_1_troughplate_100000uL_Fl(name: str, lid: Optional[Lid] = None) -> P
       dx=9.8,
       dy=7.6,
       dz=5.88,
-      item_dx=INNER_WELL_WIDTH,
-      item_dy=INNER_WELL_HEIGHT,
+      item_dx=None,  # single column
+      item_dy=None,  # single row
       **well_kwargs,
     ),
   )

--- a/pylabrobot/resources/utils.py
+++ b/pylabrobot/resources/utils.py
@@ -84,8 +84,8 @@ def create_equally_spaced_2d(
   dx: float,
   dy: float,
   dz: float,
-  item_dx: float,
-  item_dy: float,
+  item_dx: Optional[float],
+  item_dy: Optional[float],
   **kwargs,
 ) -> List[List[T]]:
   """Make equally spaced resources in a 2D grid. Also see :meth:`create_equally_spaced_x` and
@@ -98,8 +98,8 @@ def create_equally_spaced_2d(
     dx: The bottom left corner for items in the left column
     dy: The bottom left corner for items in the bottom row
     dz: The z coordinate for all items
-    item_dx: The spacing of the items in the x direction (origin to origin)
-    item_dy: The spacing of the items in the y direction (origin to origin)
+    item_dx: The spacing of the items in the x direction (origin to origin), or None when num_items_x is 1
+    item_dy: The spacing of the items in the y direction (origin to origin), or None when num_items_y is 1
     **kwargs: Additional keyword arguments to pass to the resource constructor
 
   Returns:
@@ -109,6 +109,13 @@ def create_equally_spaced_2d(
 
   # TODO: It probably makes more sense to transpose this.
 
+  if num_items_x > 1 and item_dx is None:
+    raise ValueError("item_dx is required (got None) when num_items_x > 1")
+  if num_items_y > 1 and item_dy is None:
+    raise ValueError("item_dy is required (got None) when num_items_y > 1")
+  spacing_x = 0.0 if item_dx is None else item_dx
+  spacing_y = 0.0 if item_dy is None else item_dy
+
   items: List[List[T]] = []
   for i in range(num_items_x):
     items.append([])
@@ -116,8 +123,8 @@ def create_equally_spaced_2d(
       name = f"{klass.__name__.lower()}_{i}_{j}"
       item = klass(name=name, **kwargs)
       item.location = Coordinate(
-        x=dx + i * item_dx,
-        y=dy + (num_items_y - j - 1) * item_dy,
+        x=dx + i * spacing_x,
+        y=dy + (num_items_y - j - 1) * spacing_y,
         z=dz,
       )
       items[i].append(item)
@@ -131,7 +138,7 @@ def create_equally_spaced_x(
   dx: float,
   dy: float,
   dz: float,
-  item_dx: float,
+  item_dx: Optional[float],
   **kwargs,
 ) -> List[T]:
   """Make equally spaced resources over the x-axis. See :meth:`create_equally_spaced_2d` for more
@@ -143,7 +150,7 @@ def create_equally_spaced_x(
     dx: The bottom left corner for items in the left column
     dy: The bottom left corner for items in the bottom row
     dz: The z coordinate for all items
-    item_dx: The spacing of the items in the x direction (origin to origin)
+    item_dx: The spacing of the items in the x direction (origin to origin), or None when num_items_x is 1
     **kwargs: Additional keyword arguments to pass to the resource constructor
 
   Returns:
@@ -158,7 +165,7 @@ def create_equally_spaced_x(
     dy=dy,
     dz=dz,
     item_dx=item_dx,
-    item_dy=0,
+    item_dy=None,
     **kwargs,
   )
   return [items[i][0] for i in range(num_items_x)]
@@ -170,7 +177,7 @@ def create_equally_spaced_y(
   dx: float,
   dy: float,
   dz: float,
-  item_dy: float,
+  item_dy: Optional[float],
   **kwargs,
 ) -> List[T]:
   """Make equally spaced resources over the y-axis. See :meth:`create_equally_spaced_2d` for more
@@ -182,7 +189,7 @@ def create_equally_spaced_y(
     dx: The bottom left corner for items in the left column
     dy: The bottom left corner for items in the bottom row
     dz: The z coordinate for all items
-    item_dy: The spacing of the items in the y direction (origin to origin)
+    item_dy: The spacing of the items in the y direction (origin to origin), or None when num_items_y is 1
     **kwargs: Additional keyword arguments to pass to the resource constructor
 
   Returns:
@@ -196,7 +203,7 @@ def create_equally_spaced_y(
     dx=dx,
     dy=dy,
     dz=dz,
-    item_dx=0,
+    item_dx=None,
     item_dy=item_dy,
     **kwargs,
   )
@@ -210,8 +217,8 @@ def create_ordered_items_2d(
   dx: float,
   dy: float,
   dz: float,
-  item_dx: float,
-  item_dy: float,
+  item_dx: Optional[float],
+  item_dy: Optional[float],
   **kwargs,
 ) -> Dict[str, T]:
   """Make ordered resources in a 2D grid, with the keys being the identifiers in transposed
@@ -224,8 +231,8 @@ def create_ordered_items_2d(
     dx: The bottom left corner for items in the left column wrt the parent
     dy: The bottom left corner for items in the bottom row wrt the parent
     dz: The z coordinate for all items
-    item_dx: The spacing of the items in the x direction (origin to origin)
-    item_dy: The spacing of the items in the y direction (origin to origin)
+    item_dx: The spacing of the items in the x direction (origin to origin), or None when num_items_x is 1
+    item_dy: The spacing of the items in the y direction (origin to origin), or None when num_items_y is 1
     **kwargs: Additional keyword arguments to pass to the resource constructor
 
   Returns:

--- a/pylabrobot/resources/utils_tests.py
+++ b/pylabrobot/resources/utils_tests.py
@@ -3,6 +3,7 @@ import pytest
 from pylabrobot.resources.coordinate import Coordinate
 from pylabrobot.resources.resource import Resource
 from pylabrobot.resources.utils import (
+  create_ordered_items_2d,
   label_to_row_index,
   query,
   row_index_to_label,
@@ -83,3 +84,40 @@ def test_deep():
   child1.assign_child_resource(grandchild, location=Coordinate(1, 1, 0))
 
   assert query(root, Resource) == [child1, grandchild]
+
+
+def test_item_spacing_none_for_single_item_dimension():
+  """item_dx/item_dy=None declares a dimension that holds a single item: the item
+  is placed at (dx, dy, dz) with no spacing, and passing None where the dimension
+  spans more than one item raises ValueError."""
+  # None on a 1x1 grid -> the sole item sits at the origin offset, no phantom shift
+  items = create_ordered_items_2d(
+    Well,
+    num_items_x=1,
+    num_items_y=1,
+    dx=5,
+    dy=6,
+    dz=7,
+    item_dx=None,
+    item_dy=None,
+    size_x=8,
+    size_y=8,
+    size_z=8,
+  )
+  assert items["A1"].location == Coordinate(5, 6, 7)
+
+  # None where the dimension actually spans (>1 items) is a misuse, not "no spacing"
+  with pytest.raises(ValueError):
+    create_ordered_items_2d(
+      Well,
+      num_items_x=2,
+      num_items_y=1,
+      dx=0,
+      dy=0,
+      dz=0,
+      item_dx=None,
+      item_dy=None,
+      size_x=8,
+      size_y=8,
+      size_z=8,
+    )


### PR DESCRIPTION
item_dx/item_dy on create_equally_spaced_2d/_x/_y and create_ordered_items_2d are now Optional[float]. They stay required (no default) on purpose: a caller must explicitly pass a float spacing or None, so the value can never be silently omitted.

None declares "this dimension holds a single item, so there is no inter-item spacing." Previously single-item definitions passed the well's own size as the pitch, which was silently multiplied by zero and read as a real spacing - misleading. Passing None when the dimension actually spans more than one item raises ValueError, which also catches a forgotten spacing.

No behavior change for existing float callers. The two AGenBio single-well reservoirs adopt None as the first users. Builds on the prior docstring commit clarifying these args as origin-to-origin spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
