### PR TITLE
feat(STAR): parallelize firmware commands across modules

### DIFF
--- a/pylabrobot/hamilton/liquid_handlers/star/driver.py
+++ b/pylabrobot/hamilton/liquid_handlers/star/driver.py
@@ -6,6 +6,7 @@ import enum
 import logging
 import math
 import re
+from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass, field
 from typing import Any, List, Optional, Tuple
 
@@ -127,6 +128,81 @@ class STARConfiguration:
 
 
 # ---------------------------------------------------------------------------
+# Firmware command lock
+# ---------------------------------------------------------------------------
+
+
+class _FirmwareLock:
+  """Coordinates firmware commands across modules.
+
+  Two layers, both handled by ``slave_module(module)`` / ``c0()`` so callers never touch the
+  internals:
+
+  * A readers/writer gate between the C0 master and the slave modules. A slave-module
+    command blocks the C0 master while in flight; a C0 master command (``c0()``) is
+    *exclusive*: it waits for all slave-module commands to drain, then runs alone. So no
+    slave-module command ever overlaps a C0 master command.
+
+  * A per-module mutex so at most one command per module is in flight. Different modules
+    still overlap — an X0 arm move can run alongside an H0 head move and Px channel commands
+    — but you never have two X0, two H0, etc. at once. Modules without a dedicated mutex are
+    gated but not per-module serialized.
+
+  Read-only request commands (``R*``) are not coordinated here at all — they take no lock
+  and run fully in parallel (see ``STARDriver.send_command``).
+
+  The first slave-module command acquires the exclusive lock and the last one releases it,
+  so a C0 command simply takes the same lock and automatically waits the slaves out.
+  """
+
+  # Slave modules that serialize against themselves: H0 (96-head), X0 (X-drives),
+  # R0 (iSWAP), I0 (autoload). All Px pipetting channels (P1..PG) share one mutex.
+  _SERIALIZED_MODULES = ("H0", "X0", "R0", "I0")
+
+  def __init__(self):
+    # Per-module mutexes: at most one in-flight command per module.
+    self._px_lock = asyncio.Lock()  # shared by all P1..PG pipetting channels
+    self._module_locks = {module: asyncio.Lock() for module in self._SERIALIZED_MODULES}
+
+    # Readers/writer gate: slave-module commands vs the exclusive C0 master.
+    self._slave_count = 0
+    self._slave_count_lock = asyncio.Lock()
+    self._exclusive_lock = asyncio.Lock()
+
+  def _module_lock(self, module: str) -> Optional[asyncio.Lock]:
+    """The per-module mutex for ``module``, or None if it needs no per-module serialization."""
+    if module.startswith("P"):
+      return self._px_lock  # P1..PG pipetting channels
+    return self._module_locks.get(module)
+
+  @asynccontextmanager
+  async def slave_module(self, module: str):
+    """Run a slave-module command: serialize on its module mutex and block the C0 master."""
+    module_lock = self._module_lock(module)
+    async with AsyncExitStack() as stack:
+      if module_lock is not None:
+        await stack.enter_async_context(module_lock)
+      # Join the slave group; first in acquires the exclusive lock, last out releases it.
+      async with self._slave_count_lock:
+        self._slave_count += 1
+        if self._slave_count == 1:
+          await self._exclusive_lock.acquire()
+      try:
+        yield
+      finally:
+        async with self._slave_count_lock:
+          self._slave_count -= 1
+          if self._slave_count == 0:
+            self._exclusive_lock.release()
+
+  @asynccontextmanager
+  async def c0(self):
+    """Run an exclusive C0 master command. Waits for all slave commands, then runs alone."""
+    async with self._exclusive_lock:
+      yield
+
+
+# ---------------------------------------------------------------------------
 # STARDriver
 # ---------------------------------------------------------------------------
 
@@ -162,6 +238,10 @@ class STARDriver(HamiltonLiquidHandler):
     )
     self.deck = deck
     self.left_side_panel_installed = left_side_panel_installed
+
+    # Coordinates firmware commands: C0 master commands run exclusively; Px/H0/X0 overlap
+    # across modules but serialize within a module, and none of them overlap C0.
+    self._fw_lock = _FirmwareLock()
     # Injection-only bundle, consumed at setup to seed each capability's own
     # `.configuration`. The runtime home is `star.iswap.configuration`, not here.
     self._configuration = configuration if configuration is not None else STARConfiguration()
@@ -184,6 +264,25 @@ class STARDriver(HamiltonLiquidHandler):
     # Authoritative channel count discovered during setup via RT (request_tip_presence).
     # Falls back to machine_conf.num_pip_channels until populated.
     self._num_channels: Optional[int] = None
+
+  async def send_command(self, module: str, command: str, *args, **kwargs):
+    """Send a firmware command under the firmware lock.
+
+    Request commands (command starting with "R") are read-only on every module, so they
+    take no lock and run fully in parallel. A C0 master command runs exclusively — nothing
+    else is in flight. Every other (slave-module) command blocks the C0 master, overlaps
+    commands on *other* modules (so an X0 X-arm move, an H0 head move, and Px channel
+    commands can run together), but serializes against other commands on its *own* module.
+    """
+    if command.startswith("R"):
+      return await super().send_command(module, command, *args, **kwargs)
+
+    if module == "C0":
+      async with self._fw_lock.c0():
+        return await super().send_command(module, command, *args, **kwargs)
+
+    async with self._fw_lock.slave_module(module):
+      return await super().send_command(module, command, *args, **kwargs)
 
   # -- HamiltonLiquidHandler abstract methods --------------------------------
 

--- a/pylabrobot/hamilton/liquid_handlers/star/pip_backend.py
+++ b/pylabrobot/hamilton/liquid_handlers/star/pip_backend.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import asyncio
 import enum
 import logging
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Sequence, Tuple, Union
 
@@ -34,45 +33,6 @@ if TYPE_CHECKING:
   from .driver import STARDriver
 
 logger = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Firmware command lock
-# ---------------------------------------------------------------------------
-
-
-class _FirmwareLock:
-  """Coordinates Px and C0 firmware commands.
-
-  Px commands (per-channel) can run in parallel with each other.
-  C0 commands (master module) need exclusive access: no Px or C0 may be in flight.
-  """
-
-  def __init__(self):
-    self._px_count = 0
-    self._px_count_lock = asyncio.Lock()
-    self._exclusive_lock = asyncio.Lock()
-
-  @asynccontextmanager
-  async def px(self):
-    """Run a Px command. Multiple Px can be in flight simultaneously."""
-    async with self._px_count_lock:
-      self._px_count += 1
-      if self._px_count == 1:
-        await self._exclusive_lock.acquire()
-    try:
-      yield
-    finally:
-      async with self._px_count_lock:
-        self._px_count -= 1
-        if self._px_count == 0:
-          self._exclusive_lock.release()
-
-  @asynccontextmanager
-  async def c0(self):
-    """Run a C0 command. Waits for all Px to finish, then runs exclusively."""
-    async with self._exclusive_lock:
-      yield
 
 
 # ---------------------------------------------------------------------------
@@ -243,15 +203,6 @@ class STARPIPBackend(PIPBackend):
     self.driver = driver
     self.traversal_height = traversal_height
     self.channels: List[PIPChannel] = []
-    self._fw_lock = _FirmwareLock()
-
-  async def send_command(self, module: str, command: str, **kwargs):
-    """Send a firmware command. C0 gets exclusive access; Px commands run in parallel."""
-    if module == "C0":
-      async with self._fw_lock.c0():
-        return await self.driver.send_command(module=module, command=command, **kwargs)
-    async with self._fw_lock.px():
-      return await self.driver.send_command(module=module, command=command, **kwargs)
 
   async def _on_setup(self, backend_params: Optional[BackendParams] = None):
     self.channels = [PIPChannel(self.driver, i, backend=self) for i in range(self.num_channels)]
@@ -1456,11 +1407,11 @@ class STARPIPBackend(PIPBackend):
 
   async def spread_pip_channels(self):
     """Spread PIP channels (C0:JE)."""
-    return await self.send_command(module="C0", command="JE")
+    return await self.driver.send_command(module="C0", command="JE")
 
   async def move_all_channels_in_z_safety(self):
     """Move all pipetting channels to Z-safety position (C0:ZA)."""
-    return await self.send_command(module="C0", command="ZA")
+    return await self.driver.send_command(module="C0", command="ZA")
 
   async def move_all_pipetting_channels_to_defined_position(
     self,
@@ -1742,7 +1693,7 @@ class STARPIPBackend(PIPBackend):
 
   async def request_tip_presence(self) -> List[Optional[bool]]:
     """Measure tip presence on all channels using their sleeve sensors."""
-    resp = await self.send_command(module="C0", command="RT", fmt="rt# (n)")
+    resp = await self.driver.send_command(module="C0", command="RT", fmt="rt# (n)")
     return [bool(v) for v in resp.get("rt")]
 
   async def request_tadm_status(self) -> List[int]:
@@ -1751,7 +1702,7 @@ class STARPIPBackend(PIPBackend):
     Returns:
       A list of 0/1 ints, one per channel: 0 = TADM off, 1 = TADM on.
     """
-    resp = await self.send_command(module="C0", command="QS", fmt="qs# (n)")
+    resp = await self.driver.send_command(module="C0", command="QS", fmt="qs# (n)")
     return [int(v) for v in resp.get("qs", [])]
 
   async def prepare_for_manual_channel_operation(self, channel: int):
@@ -1776,7 +1727,7 @@ class STARPIPBackend(PIPBackend):
 
   async def request_pip_height_last_lld(self) -> List[float]:
     """Return absolute liquid heights (mm) from the last LLD event for each channel."""
-    resp = await self.send_command(module="C0", command="RL", fmt="lh#### (n)")
+    resp = await self.driver.send_command(module="C0", command="RL", fmt="lh#### (n)")
     return [float(v / 10) for v in resp.get("lh")]
 
   async def position_components_for_free_iswap_y_range(self):

--- a/pylabrobot/hamilton/liquid_handlers/star/pip_channel.py
+++ b/pylabrobot/hamilton/liquid_handlers/star/pip_channel.py
@@ -91,10 +91,6 @@ class PIPChannel:
     self.index = index
     self.backend = backend
 
-  async def send_command(self, *args, **kwargs):
-    """Send a firmware command. C0 commands are serialized; Px commands go direct."""
-    return await self.backend.send_command(*args, **kwargs)
-
   @property
   def module_id(self) -> str:
     """Firmware module identifier for this channel (e.g. ``"P1"``)."""
@@ -104,7 +100,7 @@ class PIPChannel:
 
   async def request_firmware_version(self) -> datetime.date:
     """Query the firmware version of this channel (Px:RF)."""
-    resp = await self.send_command(
+    resp = await self.driver.send_command(
       module=self.module_id,
       command="RF",
       fmt="rf" + "&" * 17,
@@ -124,7 +120,7 @@ class PIPChannel:
       ``aspiration_cycles``, and ``dispensing_cycles``.
     """
 
-    resp = await self.send_command(
+    resp = await self.driver.send_command(
       module=self.module_id,
       command="RV",
       fmt="na##########nb##########nc##########nd##########",
@@ -141,7 +137,7 @@ class PIPChannel:
   async def request_dispensing_drive_position(self) -> float:
     """Request the current position of the channel's dispensing drive"""
 
-    resp = await self.send_command(
+    resp = await self.driver.send_command(
       module=self.module_id,
       command="RD",
       fmt="rd##### #####",
@@ -191,7 +187,7 @@ class PIPChannel:
     acceleration_increment = _vol_to_disp_inc(acceleration)
     acceleration_increment_thousands = round(acceleration_increment * 0.001)
 
-    await self.send_command(
+    await self.driver.send_command(
       module=self.module_id,
       command="DS",
       ds=f"{relative_vol_movement_increment:05}",
@@ -282,7 +278,7 @@ class PIPChannel:
     if not (0 <= current_limit <= 7):
       raise ValueError(f"current_limit must be between 0 and 7, got {current_limit}")
 
-    return await self.send_command(
+    return await self.driver.send_command(
       module=self.module_id,
       command="ZA",
       za=f"{z_inc:05}",
@@ -327,7 +323,7 @@ class PIPChannel:
         f"for tip length {tip_len} mm on channel {self.index}"
       )
 
-    await self.send_command(
+    await self.driver.send_command(
       module="C0",
       command="KZ",
       pn=f"{self.index + 1:02}",
@@ -430,7 +426,7 @@ class PIPChannel:
     y_position = round(y * 10)
     if not 0 <= y_position <= 6500:
       raise ValueError("y_position must be between 0 and 650 mm")
-    await self.send_command(
+    await self.driver.send_command(
       module="C0",
       command="KY",
       pn=f"{self.index + 1:02}",
@@ -441,7 +437,7 @@ class PIPChannel:
 
   async def request_probe_z_position(self) -> float:
     """Request the z-position of the channel probe (EXCLUDING the tip)"""
-    resp = await self.send_command(module=self.module_id, command="RZ", fmt="rz######")
+    resp = await self.driver.send_command(module=self.module_id, command="RZ", fmt="rz######")
     increments = resp["rz"]
     return _z_inc_to_mm(increments)
 
@@ -482,7 +478,7 @@ class PIPChannel:
   # -- Px:QC  volume in tip ---------------------------------------------------
 
   async def request_volume_in_tip(self) -> float:
-    resp = await self.send_command(self.module_id, "QC", fmt="qc##### (n)")
+    resp = await self.driver.send_command(self.module_id, "QC", fmt="qc##### (n)")
     _, current_volume = resp["qc"]  # first is max volume
     return float(current_volume) / 10
 
@@ -570,7 +566,7 @@ class PIPChannel:
         + f" and {_z_inc_to_mm(9_999)} mm, is {post_detection_dist} mm"
       )
 
-    await self.send_command(
+    await self.driver.send_command(
       module=self.module_id,
       command="ZL",
       zh=f"{lowest_immers_pos_increments:05}",  # Lowest immersion position [increment]
@@ -810,7 +806,7 @@ class PIPChannel:
         + f" and {_z_inc_to_mm(9_999)} mm, is {post_detection_dist} mm"
       )
 
-    resp_raw = await self.send_command(
+    resp_raw = await self.driver.send_command(
       module=self.module_id,
       command="ZE",
       zh=f"{lowest_immers_pos_increments:05}",
@@ -868,7 +864,7 @@ class PIPChannel:
 
       Consider this method an easter egg. Not for serious use.
     """
-    await self.send_command(module=self.module_id, command="SI")
+    await self.driver.send_command(module=self.module_id, command="SI")
 
   # ---------------------------------------------------------------------------
   # Probe / query methods — delegate to backend C0 helpers as needed.
@@ -1208,7 +1204,7 @@ class PIPChannel:
         f"Post detection distance must be between 0 and 245 mm, is {post_detection_dist}"
       )
 
-    ztouch_probed_z_height = await self.send_command(
+    ztouch_probed_z_height = await self.driver.send_command(
       module=self.module_id,
       command="ZH",
       zb=f"{start_pos_search_increments:05}",
@@ -1349,7 +1345,7 @@ class PIPChannel:
       raise ValueError(f"Current limit must be between 0 and 7, is {current_limit_int}")
 
     # Send Px:YL command
-    await self.send_command(
+    await self.driver.send_command(
       module=self.module_id,
       command="YL",
       ya=f"{max_y_search_pos_increments:05}",


### PR DESCRIPTION
## Summary

Moves the STAR firmware command lock out of `STARPIPBackend` and into `STARDriver`, so it coordinates **every** module instead of only the pipetting channels. Previously the 96-head (`H0`) and X-arm (`X0`) called `driver.send_command` directly and bypassed the lock entirely.

The lock now models the firmware's master/slave structure:

- **`C0` master commands run exclusively** — no other command is in flight.
- **Slave-module commands (`Px` / `H0` / `X0`) overlap across modules** but serialize within a module (no two `H0`, two `X0`, or two `Px` at once). Implemented as a readers/writer gate (`slave_module()` vs `c0()`) plus a per-module mutex.
- **Read-only request commands (`R*`) are lock-free on every module** — they take no lock and run fully in parallel, even alongside a same-module move or an exclusive `C0` master command.

The practical payoff: an X-arm (`X0:XP`) move and a 96-head Y (`H0:YA`) move can now run concurrently, so the 96-head can travel a **diagonal** — something the exclusive `C0:EM` combined move can never be parallelised into.

## Changes

- `star/driver.py`: `_FirmwareLock` (per-module mutexes + master/slave gate) and a `send_command` override that applies it.
- `star/pip_backend.py`: dropped the old PIP-only lock; `send_command` now just delegates to the driver.
- `docs/cookbook/star_parallel_head96_xy.py`: runnable sample that overlaps `X0` + `H0` to sweep the 96-head along a diagonal (with acceleration-level matching for a clean line).
- `CHANGELOG.md`: entries under Unreleased.

## Testing

- Full STAR suite green (`pylabrobot/hamilton/liquid_handlers/star/`, 117 passed).
- `ruff check` / `ruff format --check` clean on changed files; no new `mypy` errors.
- Verified on hardware (STAR + CoRe 96-head): concurrent `X0 || H0` moves the head ~400 mm in X and ~350 mm in Y together in ~2.3 s vs ~4.4 s sequential — a clean diagonal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)