### PR TITLE
fix(io/usb): separate read and write executors to prevent a self-stall

### DIFF
--- a/pylabrobot/io/usb.py
+++ b/pylabrobot/io/usb.py
@@ -102,7 +102,11 @@ class USB(IOBase):
     self.read_endpoint: Optional[usb.core.Endpoint] = None
     self.write_endpoint: Optional[usb.core.Endpoint] = None
 
-    self._executor: Optional[ThreadPoolExecutor] = None
+    # Reads and writes use separate single-worker executors. The reader thread parks a long
+    # blocking read on its worker; sharing one worker with writes would let that read starve
+    # (and deadlock against) the write whose response the read is waiting for.
+    self._read_executor: Optional[ThreadPoolExecutor] = None
+    self._write_executor: Optional[ThreadPoolExecutor] = None
 
     # unique id in the logs
     self._unique_id = f"[{hex(self._id_vendor)}:{hex(self._id_product)}][{self._serial_number or ''}][{self._device_address or ''}]"
@@ -127,10 +131,10 @@ class USB(IOBase):
     loop = asyncio.get_running_loop()
     write_endpoint = self.write_endpoint
     dev = self.dev
-    if self._executor is None or dev is None or write_endpoint is None:
+    if self._write_executor is None or dev is None or write_endpoint is None:
       raise RuntimeError(f"Call setup() first for USB device '{self.human_readable_device_name}'.")
     await loop.run_in_executor(
-      self._executor,
+      self._write_executor,
       lambda: dev.write(
         write_endpoint, data, timeout=int(timeout * 1000)
       ),  # PyUSB expects timeout in milliseconds
@@ -138,7 +142,7 @@ class USB(IOBase):
     if len(data) % write_endpoint.wMaxPacketSize == 0:
       # send a zero-length packet to indicate the end of the transfer
       await loop.run_in_executor(
-        self._executor,
+        self._write_executor,
         lambda: dev.write(write_endpoint, b"", timeout=int(timeout * 1000)),
       )
     logger.log(LOG_LEVEL_IO, "%s write: %s", self._unique_id, data)
@@ -265,9 +269,9 @@ class USB(IOBase):
       )
 
     loop = asyncio.get_running_loop()
-    if self._executor is None or self.dev is None:
+    if self._read_executor is None or self.dev is None:
       raise RuntimeError(f"Call setup() first for USB device '{self.human_readable_device_name}'.")
-    return await loop.run_in_executor(self._executor, read_or_timeout)
+    return await loop.run_in_executor(self._read_executor, read_or_timeout)
 
   def get_available_devices(self) -> List["usb.core.Device"]:
     """Get a list of available devices that match the specified vendor and product IDs, and serial
@@ -447,7 +451,8 @@ class USB(IOBase):
       while self._read_packet() is not None:
         pass
 
-    self._executor = ThreadPoolExecutor(max_workers=self.max_workers)
+    self._read_executor = ThreadPoolExecutor(max_workers=self.max_workers)
+    self._write_executor = ThreadPoolExecutor(max_workers=self.max_workers)
 
   async def stop(self):
     """Close the USB connection to the machine. Safe to call multiple times."""
@@ -458,9 +463,10 @@ class USB(IOBase):
     usb.util.dispose_resources(self.dev)
     self.dev = None
 
-    if self._executor is not None:
-      self._executor.shutdown(wait=True)
-      self._executor = None
+    for executor in (self._read_executor, self._write_executor):
+      if executor is not None:
+        executor.shutdown(wait=True)
+    self._read_executor = self._write_executor = None
 
   def serialize(self) -> dict:
     """Serialize the backend to a dictionary."""


### PR DESCRIPTION
## Problem

`pylabrobot/io/usb.py` shares a single-worker `ThreadPoolExecutor` between `read()` and `write()`. The Hamilton `HamiltonLiquidHandler` reader thread (`hamilton/usb/driver.py::_continuously_read`) loops on `await io.read()`, whose blocking `read_or_timeout` (up to `read_timeout`, default 30s) holds that one worker. A `write()` issued while a read is in flight then can't get the worker, so the command is never sent — and the read keeps blocking for a response that will never come. They deadlock until an unrelated in-flight response frees the worker.

This serializes any read/write interleaving that occurs during a long-running move.

## Symptom (STAR diagonal)

With the parallelization from #1128, driving the 96-head diagonally overlaps an `X0:XP` X-arm move with `H0` head commands. If `move_y` reads a register (e.g. snapshotting Y speed/accel via `H0:RA`) before issuing `H0:YA`, the read holds the sole worker while the `YA` write queues behind it; neither progresses until the X-arm move finishes. Measured on hardware: the diagonal collapsed from **~2.3s (overlapped)** to **~4.4s (serialized)**.

### Root-causing

- Killing the reader thread and driving raw single-threaded `io.read`/`io.write` (same sequential pattern): the 2nd read returns **@0.02s, mid-move** → the device is innocent.
- Instrumenting `_continuously_read`: the 2nd command's task is **absent from `_waiting_tasks` until the move ends** → its `await io.write` was queued, not a demux miss.
- Bumping the pool to 2 workers: the full `RA,RA→YA` sequence overlaps again.

## Fix

Give reads and writes their own single-worker executors (`_read_executor` / `_write_executor`) so a blocking read can never starve a write. IN and OUT are independent endpoints, so this is also cleaner than raising `max_workers`.

## Validation

- Hardware: the PR #1128 diagonal demo (unpatched, through the normal `send_command` path) now overlaps — **diagonal 2.28s = max(legs)**, vs 4.44s before.
- `pytest` over `io/`, `hamilton/`, and the legacy hamilton backends: **453 passed**; STAR/USB/TCP suites: 117 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)