### PR TITLE
`OpentronsOT2ChatterboxBackend`: a dry-run OT-2 backend with I/O logging, via a transport seam

### DIFF
--- a/pylabrobot/liquid_handling/backends/__init__.py
+++ b/pylabrobot/liquid_handling/backends/__init__.py
@@ -4,6 +4,7 @@ from .chatterbox_backend import ChatterBoxBackend
 from .hamilton.STAR_backend import STAR, STARBackend
 from .hamilton.vantage_backend import Vantage, VantageBackend
 from .opentrons_backend import OpentronsOT2Backend
+from .opentrons_chatterbox import OpentronsOT2ChatterboxBackend
 from .opentrons_simulator import OpentronsOT2Simulator
 from .serializing_backend import SerializingBackend
 from .tecan.EVO_backend import EVO, EVOBackend

--- a/pylabrobot/liquid_handling/backends/opentrons_backend.py
+++ b/pylabrobot/liquid_handling/backends/opentrons_backend.py
@@ -31,9 +31,6 @@ from pylabrobot.resources.tip_rack import TipRack
 try:
   import ot_api
 
-  # for run cancellation
-  import ot_api.requestor as _req
-
   USE_OT = True
 except ImportError as e:
   USE_OT = False
@@ -77,8 +74,12 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
     self.host = host
     self.port = port
 
-    ot_api.set_host(host)
-    ot_api.set_port(port)
+    # All hardware I/O goes through this handle so a subclass (e.g. the chatterbox)
+    # can dry-run the backend by swapping it for a recording stand-in.
+    self._ot = ot_api
+
+    self._ot.set_host(host)
+    self._ot.set_port(port)
 
     self.ot_api_version: Optional[str] = None
     self.left_pipette: Optional[Dict[str, str]] = None
@@ -97,16 +98,16 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
 
   async def setup(self, skip_home: bool = False):
     # create run
-    run_id = ot_api.runs.create()
-    ot_api.set_run(run_id)
+    run_id = self._ot.runs.create()
+    self._ot.set_run(run_id)
 
     # get pipettes, then assign them
-    self.left_pipette, self.right_pipette = ot_api.lh.add_mounted_pipettes()
+    self.left_pipette, self.right_pipette = self._ot.lh.add_mounted_pipettes()
 
     self.left_pipette_has_tip = self.right_pipette_has_tip = False
 
     # get api version
-    health = ot_api.health.get()
+    health = self._ot.health.get()
     self.ot_api_version = health["api_version"]
 
     if not skip_home:
@@ -124,16 +125,16 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
     self.right_pipette = None
 
     # cancel the HTTP-API run if it exists (helpful to make device available again in official Opentrons app)
-    run_id = getattr(ot_api, "run_id", None)
+    run_id = getattr(self._ot, "run_id", None)
     if run_id:
       try:
-        _req.post(f"/runs/{run_id}/cancel")
+        self._ot.requestor.post(f"/runs/{run_id}/cancel")
       except Exception:
         try:
-          _req.post(f"/runs/{run_id}/actions/cancel")
+          self._ot.requestor.post(f"/runs/{run_id}/actions/cancel")
         except Exception:
           try:
-            _req.delete(f"/runs/{run_id}")
+            self._ot.requestor.delete(f"/runs/{run_id}")
           except Exception:
             pass
 
@@ -231,7 +232,7 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
       ],
     }
 
-    data = ot_api.labware.define(lw)
+    data = self._ot.labware.define(lw)
     namespace, definition, version = data["data"]["definitionUri"].split("/")
 
     # assign labware to robot
@@ -242,7 +243,7 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
     slot = deck.get_slot(tip_rack)
     assert slot is not None, "tip rack must be on deck"
 
-    ot_api.labware.add(
+    self._ot.labware.add(
       load_name=definition,
       namespace=namespace,
       ot_location=slot,
@@ -321,7 +322,7 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
 
     offset_z += op.tip.total_tip_length
 
-    ot_api.lh.pick_up_tip(
+    self._ot.lh.pick_up_tip(
       labware_id=self.get_ot_name(tip_rack.name),
       well_name=self.get_ot_name(op.resource.name),
       pipette_id=pipette_id,
@@ -361,15 +362,15 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
     offset_z += 10
 
     if use_fixed_trash:
-      ot_api.lh.move_to_addressable_area_for_drop_tip(
+      self._ot.lh.move_to_addressable_area_for_drop_tip(
         pipette_id=pipette_id,
         offset_x=offset_x,
         offset_y=offset_y,
         offset_z=offset_z,
       )
-      ot_api.lh.drop_tip_in_place(pipette_id=pipette_id)
+      self._ot.lh.drop_tip_in_place(pipette_id=pipette_id)
     else:
-      ot_api.lh.drop_tip(
+      self._ot.lh.drop_tip(
         labware_id,
         well_name=self.get_ot_name(op.resource.name),
         pipette_id=pipette_id,
@@ -461,18 +462,18 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
 
     if op.mix is not None:
       for _ in range(op.mix.repetitions):
-        ot_api.lh.aspirate_in_place(
+        self._ot.lh.aspirate_in_place(
           volume=op.mix.volume,
           flow_rate=op.mix.flow_rate,
           pipette_id=pipette_id,
         )
-        ot_api.lh.dispense_in_place(
+        self._ot.lh.dispense_in_place(
           volume=op.mix.volume,
           flow_rate=op.mix.flow_rate,
           pipette_id=pipette_id,
         )
 
-    ot_api.lh.aspirate_in_place(
+    self._ot.lh.aspirate_in_place(
       volume=volume,
       flow_rate=flow_rate,
       pipette_id=pipette_id,
@@ -533,7 +534,7 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
       pipette_id=pipette_id,
     )
 
-    ot_api.lh.dispense_in_place(
+    self._ot.lh.dispense_in_place(
       volume=volume,
       flow_rate=flow_rate,
       pipette_id=pipette_id,
@@ -541,12 +542,12 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
 
     if op.mix is not None:
       for _ in range(op.mix.repetitions):
-        ot_api.lh.aspirate_in_place(
+        self._ot.lh.aspirate_in_place(
           volume=op.mix.volume,
           flow_rate=op.mix.flow_rate,
           pipette_id=pipette_id,
         )
-        ot_api.lh.dispense_in_place(
+        self._ot.lh.dispense_in_place(
           volume=op.mix.volume,
           flow_rate=op.mix.flow_rate,
           pipette_id=pipette_id,
@@ -563,7 +564,7 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
     )
 
   async def home(self):
-    ot_api.health.home()
+    self._ot.health.home()
 
   async def pick_up_tips96(self, pickup: PickupTipRack):
     raise NotImplementedError("The Opentrons backend does not support the 96 head.")
@@ -590,7 +591,7 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
 
   async def list_connected_modules(self) -> List[dict]:
     """List all connected temperature modules."""
-    return cast(List[dict], ot_api.modules.list_connected_modules())
+    return cast(List[dict], self._ot.modules.list_connected_modules())
 
   def _pipette_id_for_channel(self, channel: int) -> str:
     pipettes = []
@@ -607,7 +608,7 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
 
     pipette_id = self._pipette_id_for_channel(channel)
     try:
-      res = ot_api.lh.save_position(pipette_id=pipette_id)
+      res = self._ot.lh.save_position(pipette_id=pipette_id)
       pos = res["data"]["result"]["position"]
       current = Coordinate(pos["x"], pos["y"], pos["z"])
     except Exception as exc:  # noqa: BLE001
@@ -676,7 +677,7 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
     if pipette_id is None:
       raise ValueError("No pipette id given or left/right pipette not available.")
 
-    ot_api.lh.move_arm(
+    self._ot.lh.move_arm(
       pipette_id=pipette_id,
       location_x=location.x,
       location_y=location.y,

--- a/pylabrobot/liquid_handling/backends/opentrons_backend.py
+++ b/pylabrobot/liquid_handling/backends/opentrons_backend.py
@@ -1,7 +1,10 @@
+import inspect
+import logging
 import uuid
-from typing import Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 from pylabrobot import utils
+from pylabrobot.io import LOG_LEVEL_IO
 from pylabrobot.liquid_handling.backends.backend import (
   LiquidHandlerBackend,
 )
@@ -41,6 +44,38 @@ except ImportError as e:
 # https://labautomation.io/t/connect-pylabrobot-to-ot2/2862/18
 _OT_DECK_IS_ADDRESSABLE_AREA_VERSION = "7.1.0"
 
+logger = logging.getLogger(__name__)
+
+
+class _IOLogger:
+  """Transparent proxy over the ``ot_api`` module that logs every call at
+  ``LOG_LEVEL_IO``.
+
+  The OT-2 talks HTTP through ``ot_api`` rather than a pylabrobot.io transport, so
+  this wrapper gives it the same wire-level logging every other backend gets from
+  its io object. Submodules (``lh``, ``health``, ...) are wrapped recursively;
+  plain attributes (e.g. ``run_id``) pass through untouched.
+  """
+
+  def __init__(self, target: Any, prefix: str = ""):
+    object.__setattr__(self, "_target", target)
+    object.__setattr__(self, "_prefix", prefix)
+
+  def __getattr__(self, name: str) -> Any:
+    attr = getattr(self._target, name)
+    qualified = f"{self._prefix}.{name}" if self._prefix else name
+    if inspect.ismodule(attr):
+      return _IOLogger(attr, qualified)
+    if callable(attr):
+
+      def _logged(*args, **kwargs):
+        parts = [repr(a) for a in args] + [f"{k}={v!r}" for k, v in kwargs.items()]
+        logger.log(LOG_LEVEL_IO, "%s(%s)", qualified, ", ".join(parts))
+        return attr(*args, **kwargs)
+
+      return _logged
+    return attr
+
 
 class OpentronsOT2Backend(LiquidHandlerBackend):
   """Backends for the Opentrons OT2 liquid handling robots."""
@@ -75,8 +110,9 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
     self.port = port
 
     # All hardware I/O goes through this handle so a subclass (e.g. the chatterbox)
-    # can dry-run the backend by swapping it for a recording stand-in.
-    self._ot = ot_api
+    # can dry-run the backend by swapping it for a recording stand-in. The real handle
+    # wraps ot_api to log every HTTP call at LOG_LEVEL_IO, like other backends' io.
+    self._ot: Any = _IOLogger(ot_api)
 
     self._ot.set_host(host)
     self._ot.set_port(port)

--- a/pylabrobot/liquid_handling/backends/opentrons_backend.py
+++ b/pylabrobot/liquid_handling/backends/opentrons_backend.py
@@ -58,8 +58,8 @@ class _IOLogger:
   """
 
   def __init__(self, target: Any, prefix: str = ""):
-    object.__setattr__(self, "_target", target)
-    object.__setattr__(self, "_prefix", prefix)
+    self._target = target
+    self._prefix = prefix
 
   def __getattr__(self, name: str) -> Any:
     attr = getattr(self._target, name)

--- a/pylabrobot/liquid_handling/backends/opentrons_backend_tests.py
+++ b/pylabrobot/liquid_handling/backends/opentrons_backend_tests.py
@@ -7,6 +7,7 @@ pytest.importorskip("ot_api")
 
 from pylabrobot.liquid_handling import LiquidHandler
 from pylabrobot.liquid_handling.backends.opentrons_backend import (
+  _OT_DECK_IS_ADDRESSABLE_AREA_VERSION,
   OpentronsOT2Backend,
 )
 from pylabrobot.liquid_handling.errors import NoChannelError
@@ -187,6 +188,59 @@ class OpentronsBackendCommandTests(unittest.IsolatedAsyncioTestCase):
     await self.test_aspirate()  # aspirate first
     with no_volume_tracking():
       await self.lh.dispense(self.plate["A1"], vols=[10])
+
+  # -- characterization of the remaining ot_api call sites (Phase 0 safety net) --
+
+  @patch("ot_api.health.home")
+  async def test_home_calls_health_home(self, mock_home):
+    """home() issues exactly one ot_api.health.home() call."""
+    await self.backend.home()
+    mock_home.assert_called_once_with()
+
+  @patch("ot_api.modules.list_connected_modules")
+  async def test_list_connected_modules_passthrough(self, mock_modules):
+    """list_connected_modules() returns ot_api.modules.list_connected_modules() verbatim."""
+    mock_modules.return_value = [{"id": "tempdeck"}]
+    result = await self.backend.list_connected_modules()
+    mock_modules.assert_called_once_with()
+    self.assertEqual(result, [{"id": "tempdeck"}])
+
+  @patch("ot_api.run_id", "run-id", create=True)
+  @patch("ot_api.requestor.post")
+  async def test_stop_cancels_active_run_and_clears_pipettes(self, mock_post):
+    """stop() cancels the active run through the requestor and clears mounted pipettes."""
+    await self.backend.stop()
+    mock_post.assert_called_once_with("/runs/run-id/cancel")
+    self.assertIsNone(self.backend.left_pipette)
+    self.assertIsNone(self.backend.right_pipette)
+
+  @patch("ot_api.lh.drop_tip_in_place")
+  @patch("ot_api.lh.move_to_addressable_area_for_drop_tip")
+  @patch("ot_api.lh.drop_tip")
+  @patch("ot_api.lh.pick_up_tip")
+  @patch("ot_api.labware.define")
+  @patch("ot_api.labware.add")
+  async def test_tip_drop_to_trash_uses_addressable_area(
+    self,
+    mock_add,
+    mock_define,
+    mock_pick_up_tip,
+    mock_drop_tip,
+    mock_to_trash,
+    mock_drop_in_place,
+  ):
+    """At api_version >= 7.1.0 a discard to the deck trash routes via the addressable
+    area (move_to_addressable_area_for_drop_tip + drop_tip_in_place), not drop_tip."""
+    mock_define.side_effect = _mock_define
+    mock_add.side_effect = _mock_add
+    self.backend.ot_api_version = _OT_DECK_IS_ADDRESSABLE_AREA_VERSION
+
+    await self.lh.pick_up_tips(self.tip_rack["A1"])
+    await self.lh.discard_tips()
+
+    mock_to_trash.assert_called_once()
+    mock_drop_in_place.assert_called_once()
+    mock_drop_tip.assert_not_called()
 
 
 def _make_backend_with_pipettes(left_name="p300_single_gen2", right_name="p20_single_gen2"):

--- a/pylabrobot/liquid_handling/backends/opentrons_chatterbox.py
+++ b/pylabrobot/liquid_handling/backends/opentrons_chatterbox.py
@@ -1,0 +1,173 @@
+"""A chatterbox backend for the Opentrons OT-2.
+
+Dry-runs the real OpentronsOT2Backend without hardware or the ``ot_api`` library
+by swapping the backend's transport handle (``self._ot``) for a recorder that
+logs every call and returns canned data for the few reads the backend makes back.
+
+This mirrors how ``STARChatterboxBackend`` dry-runs ``STARBackend``: only the
+transport is replaced, so all the real high-level logic (pipette selection, tip
+and volume bookkeeping, the per-operation wire calls) runs unchanged. Contrast
+with ``OpentronsOT2Simulator``, which overrides the high-level methods themselves.
+"""
+
+from typing import Dict, List, Optional, Tuple, cast
+
+from pylabrobot.liquid_handling.backends.backend import LiquidHandlerBackend
+from pylabrobot.liquid_handling.backends.opentrons_backend import (
+  _OT_DECK_IS_ADDRESSABLE_AREA_VERSION,
+  OpentronsOT2Backend,
+)
+
+
+class _RecordingNamespace:
+  """An ot_api sub-namespace (e.g. ``lh``, ``health``) that records every call.
+
+  Unknown attributes resolve to a function that appends ``(name, args, kwargs)``
+  to the shared recorder and returns the canned value registered in ``returns``
+  (``None`` if none is registered).
+  """
+
+  def __init__(self, recorder: "_OTChatterboxModule", prefix: str, returns=None):
+    self._recorder = recorder
+    self._prefix = prefix
+    self._returns = returns or {}
+
+  def __getattr__(self, name: str):
+    if name.startswith("_"):
+      raise AttributeError(name)
+    qualified = f"{self._prefix}.{name}"
+    returns = self._returns
+    recorder = self._recorder
+
+    def _record(*args, **kwargs):
+      recorder.log(qualified, args, kwargs)
+      canned = returns.get(name)
+      return canned() if callable(canned) else canned
+
+    return _record
+
+
+class _OTChatterboxModule:
+  """Stand-in for the ``ot_api`` module that records calls instead of issuing them.
+
+  Provides the sub-namespaces and reads the real backend touches: ``runs.create``,
+  ``lh.add_mounted_pipettes``, ``health.get``, ``labware.define``,
+  ``modules.list_connected_modules`` and ``lh.save_position`` return canned data;
+  everything else is recorded and returns ``None``. ``run_id`` stays ``None`` so
+  ``stop()`` skips the cancel request.
+  """
+
+  def __init__(self, left_pipette, right_pipette, api_version: str, verbose: bool = True):
+    self.calls: List[Tuple[str, tuple, dict]] = []
+    self.run_id: Optional[str] = None
+    self._verbose = verbose
+
+    self.runs = _RecordingNamespace(self, "runs", {"create": lambda: "chatterbox-run"})
+    self.health = _RecordingNamespace(self, "health", {"get": lambda: {"api_version": api_version}})
+    self.labware = _RecordingNamespace(
+      self, "labware", {"define": lambda: {"data": {"definitionUri": "pylabrobot/chatterbox/1"}}}
+    )
+    self.modules = _RecordingNamespace(self, "modules", {"list_connected_modules": lambda: []})
+    self.requestor = _RecordingNamespace(self, "requestor")
+    self.lh = _RecordingNamespace(
+      self,
+      "lh",
+      {
+        "add_mounted_pipettes": lambda: (left_pipette, right_pipette),
+        "save_position": lambda: {"data": {"result": {"position": {"x": 0, "y": 0, "z": 0}}}},
+      },
+    )
+
+  def log(self, qualified: str, args: tuple, kwargs: dict):
+    self.calls.append((qualified, args, kwargs))
+    if self._verbose:
+      parts = [repr(a) for a in args] + [f"{k}={v!r}" for k, v in kwargs.items()]
+      print(f"{qualified}({', '.join(parts)})")
+
+  def __getattr__(self, name: str):
+    # top-level functions the backend calls directly: set_host, set_port, set_run
+    if name.startswith("_"):
+      raise AttributeError(name)
+
+    def _record(*args, **kwargs):
+      self.log(name, args, kwargs)
+      return None
+
+    return _record
+
+
+class OpentronsOT2ChatterboxBackend(OpentronsOT2Backend):
+  """Chatterbox backend for the Opentrons OT-2.
+
+  Runs the real OpentronsOT2Backend logic with its transport replaced by a
+  recorder - no hardware and no ``ot_api`` library required. Every issued call is
+  printed and collected in :attr:`commands`.
+
+  Example:
+    >>> from pylabrobot.liquid_handling import LiquidHandler
+    >>> from pylabrobot.liquid_handling.backends import OpentronsOT2ChatterboxBackend
+    >>> from pylabrobot.resources.opentrons import OTDeck
+    >>> lh = LiquidHandler(backend=OpentronsOT2ChatterboxBackend(), deck=OTDeck())
+    >>> await lh.setup()
+  """
+
+  def __init__(
+    self,
+    left_pipette_name: Optional[str] = "p300_single_gen2",
+    right_pipette_name: Optional[str] = "p20_single_gen2",
+    host: str = "chatterbox",
+    port: int = 31950,
+    api_version: str = _OT_DECK_IS_ADDRESSABLE_AREA_VERSION,
+    verbose: bool = True,
+  ):
+    """Initialize the chatterbox.
+
+    Args:
+      left_pipette_name: pipette mounted on the left (``None`` for none).
+      right_pipette_name: pipette mounted on the right (``None`` for none).
+      api_version: reported Opentrons API version; defaults to the version at
+        which tip drops route through the addressable-area trash.
+      verbose: if True, print every recorded call.
+    """
+    # Skip OpentronsOT2Backend.__init__ (it requires ot_api); set up state directly.
+    LiquidHandlerBackend.__init__(self)
+
+    pv = OpentronsOT2Backend.pipette_name2volume
+    if left_pipette_name is not None and left_pipette_name not in pv:
+      raise ValueError(f"Unknown left pipette: {left_pipette_name}")
+    if right_pipette_name is not None and right_pipette_name not in pv:
+      raise ValueError(f"Unknown right pipette: {right_pipette_name}")
+
+    self._left_pipette_name = left_pipette_name
+    self._right_pipette_name = right_pipette_name
+    self.host = host
+    self.port = port
+
+    left = (
+      {"name": left_pipette_name, "pipetteId": "chatterbox-left"} if left_pipette_name else None
+    )
+    right = (
+      {"name": right_pipette_name, "pipetteId": "chatterbox-right"} if right_pipette_name else None
+    )
+    self._ot = _OTChatterboxModule(left, right, api_version, verbose=verbose)
+
+    self.ot_api_version: Optional[str] = None
+    self.left_pipette: Optional[Dict[str, str]] = None
+    self.right_pipette: Optional[Dict[str, str]] = None
+    self.traversal_height = 120
+    self._tip_racks: Dict[str, int] = {}
+    self._plr_name_to_load_name: Dict[str, str] = {}
+
+  @property
+  def commands(self) -> List[Tuple[str, tuple, dict]]:
+    """Recorded ``(qualified_name, args, kwargs)`` for every call issued so far."""
+    return cast(List[Tuple[str, tuple, dict]], self._ot.calls)
+
+  def serialize(self) -> dict:
+    return {
+      **LiquidHandlerBackend.serialize(self),
+      "left_pipette_name": self._left_pipette_name,
+      "right_pipette_name": self._right_pipette_name,
+      "host": self.host,
+      "port": self.port,
+    }

--- a/pylabrobot/liquid_handling/backends/opentrons_chatterbox.py
+++ b/pylabrobot/liquid_handling/backends/opentrons_chatterbox.py
@@ -10,13 +10,17 @@ and volume bookkeeping, the per-operation wire calls) runs unchanged. Contrast
 with ``OpentronsOT2Simulator``, which overrides the high-level methods themselves.
 """
 
+import logging
 from typing import Dict, List, Optional, Tuple, cast
 
+from pylabrobot.io import LOG_LEVEL_IO
 from pylabrobot.liquid_handling.backends.backend import LiquidHandlerBackend
 from pylabrobot.liquid_handling.backends.opentrons_backend import (
   _OT_DECK_IS_ADDRESSABLE_AREA_VERSION,
   OpentronsOT2Backend,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class _RecordingNamespace:
@@ -80,9 +84,12 @@ class _OTChatterboxModule:
 
   def log(self, qualified: str, args: tuple, kwargs: dict):
     self.calls.append((qualified, args, kwargs))
+    parts = [repr(a) for a in args] + [f"{k}={v!r}" for k, v in kwargs.items()]
+    rendered = f"{qualified}({', '.join(parts)})"
+    # log at LOG_LEVEL_IO so a dry run captures the same wire trace as a real run
+    logger.log(LOG_LEVEL_IO, "%s", rendered)
     if self._verbose:
-      parts = [repr(a) for a in args] + [f"{k}={v!r}" for k, v in kwargs.items()]
-      print(f"{qualified}({', '.join(parts)})")
+      print(rendered)
 
   def __getattr__(self, name: str):
     # top-level functions the backend calls directly: set_host, set_port, set_run

--- a/pylabrobot/liquid_handling/backends/opentrons_chatterbox_tests.py
+++ b/pylabrobot/liquid_handling/backends/opentrons_chatterbox_tests.py
@@ -1,0 +1,135 @@
+"""Tests for OpentronsOT2ChatterboxBackend.
+
+Deliberately does NOT importorskip("ot_api"): running the real backend logic with
+no hardware and no ot_api library is the whole point of the chatterbox.
+"""
+
+import unittest
+
+from pylabrobot.liquid_handling import LiquidHandler
+from pylabrobot.liquid_handling.backends import (
+  OpentronsOT2ChatterboxBackend,
+  OpentronsOT2Simulator,
+)
+from pylabrobot.resources import set_tip_tracking, set_volume_tracking
+from pylabrobot.resources.celltreat import CellTreat_96_wellplate_350ul_Fb
+from pylabrobot.resources.opentrons import OTDeck, opentrons_96_filtertiprack_20ul
+
+
+def _names(backend: OpentronsOT2ChatterboxBackend):
+  return [call[0] for call in backend.commands]
+
+
+class OpentronsChatterboxTests(unittest.IsolatedAsyncioTestCase):
+  """Direct tests: the chatterbox runs the real backend with no ot_api."""
+
+  async def asyncSetUp(self):
+    set_tip_tracking(True)
+    set_volume_tracking(True)
+    self.backend = OpentronsOT2ChatterboxBackend(
+      left_pipette_name="p20_single_gen2",
+      right_pipette_name="p20_single_gen2",
+      verbose=False,
+    )
+    self.deck = OTDeck()
+    self.lh = LiquidHandler(backend=self.backend, deck=self.deck)
+    await self.lh.setup()
+    self.tips = opentrons_96_filtertiprack_20ul(name="tips")
+    self.deck.assign_child_at_slot(self.tips, slot=1)
+    self.plate = CellTreat_96_wellplate_350ul_Fb(name="plate")
+    self.deck.assign_child_at_slot(self.plate, slot=2)
+
+  async def asyncTearDown(self):
+    set_tip_tracking(False)
+    set_volume_tracking(False)
+
+  async def test_setup_resolves_two_channels_without_ot_api(self):
+    """setup() runs through the recorder and resolves both mounted pipettes."""
+    self.assertEqual(self.backend.num_channels, 2)
+    assert self.backend.left_pipette is not None and self.backend.right_pipette is not None
+    self.assertEqual(self.backend.left_pipette["name"], "p20_single_gen2")
+
+  async def test_full_protocol_records_one_wire_call_per_operation(self):
+    """A pickup -> aspirate -> dispense -> trash-discard records exactly one
+    wire call each, via the real backend logic."""
+    self.plate.get_well("A1").tracker.set_volume(15)
+    await self.lh.pick_up_tips(self.tips["A1"])
+    await self.lh.aspirate(self.plate["A1"], vols=[10])
+    await self.lh.dispense(self.plate["B1"], vols=[10])
+    await self.lh.discard_tips()
+
+    names = _names(self.backend)
+    self.assertEqual(names.count("lh.pick_up_tip"), 1)
+    self.assertEqual(names.count("lh.aspirate_in_place"), 1)
+    self.assertEqual(names.count("lh.dispense_in_place"), 1)
+    # api_version defaults to 7.1.0, so the discard routes through the trash addressable area
+    self.assertEqual(names.count("lh.move_to_addressable_area_for_drop_tip"), 1)
+    self.assertEqual(names.count("lh.drop_tip_in_place"), 1)
+
+  def test_unknown_pipette_name_raises(self):
+    """An unrecognised pipette name is rejected at construction."""
+    with self.assertRaises(ValueError):
+      OpentronsOT2ChatterboxBackend(left_pipette_name="not_a_pipette")
+
+  def test_serialize_includes_pipettes(self):
+    """serialize() captures the mounted-pipette names (None for an empty mount)."""
+    backend = OpentronsOT2ChatterboxBackend(
+      left_pipette_name="p20_single_gen2", right_pipette_name=None, verbose=False
+    )
+    serialized = backend.serialize()
+    self.assertEqual(serialized["left_pipette_name"], "p20_single_gen2")
+    self.assertIsNone(serialized["right_pipette_name"])
+
+
+class OpentronsChatterboxVsSimulatorTests(unittest.IsolatedAsyncioTestCase):
+  """Differential audit: the chatterbox must produce the same tracked outcome as
+  the reference OpentronsOT2Simulator on the single-channel overlap. (The Simulator
+  is single-channel by construction, so the multi-channel head is out of scope here.)"""
+
+  async def asyncSetUp(self):
+    set_tip_tracking(True)
+    set_volume_tracking(True)
+
+  async def asyncTearDown(self):
+    set_tip_tracking(False)
+    set_volume_tracking(False)
+
+  async def _run_single_channel_protocol(self, backend):
+    deck = OTDeck()
+    lh = LiquidHandler(backend=backend, deck=deck)
+    await lh.setup()
+    tips = opentrons_96_filtertiprack_20ul(name="tips")
+    deck.assign_child_at_slot(tips, slot=1)
+    plate = CellTreat_96_wellplate_350ul_Fb(name="plate")
+    deck.assign_child_at_slot(plate, slot=2)
+    plate.get_well("A1").tracker.set_volume(15)
+
+    await lh.pick_up_tips(tips["A1"])
+    await lh.aspirate(plate["A1"], vols=[10])
+    await lh.dispense(plate["B1"], vols=[10])
+
+    outcome = (
+      lh.head[0].has_tip,
+      round(plate.get_well("A1").tracker.get_used_volume(), 3),
+      round(plate.get_well("B1").tracker.get_used_volume(), 3),
+    )
+    await lh.stop()
+    return outcome
+
+  async def test_chatterbox_matches_simulator_single_channel(self):
+    simulator_outcome = await self._run_single_channel_protocol(
+      OpentronsOT2Simulator(
+        left_pipette_name="p20_single_gen2", right_pipette_name="p20_single_gen2"
+      )
+    )
+    chatterbox_outcome = await self._run_single_channel_protocol(
+      OpentronsOT2ChatterboxBackend(
+        left_pipette_name="p20_single_gen2", right_pipette_name="p20_single_gen2", verbose=False
+      )
+    )
+    self.assertEqual(simulator_outcome, (True, 5.0, 10.0))
+    self.assertEqual(chatterbox_outcome, simulator_outcome)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Adds `OpentronsOT2ChatterboxBackend`, a dry-run backend for the OT-2 that runs the real backend logic with no hardware and no `ot_api` library, mirroring how `STARChatterboxBackend` dry-runs `STARBackend`. Unlike `OpentronsOT2Simulator` (which overrides the high-level methods with single-channel stubs), the chatterbox replaces only the transport, so pipette selection, tip/volume tracking, and the per-operation wire calls all run unchanged.

To enable that, the backend routes every `ot_api` call - including the run-cancel calls in `stop()` - through a single `self._ot` transport handle. The real handle wraps `ot_api` in a transparent `_IOLogger` proxy that logs every HTTP call at `LOG_LEVEL_IO`, like other backends get from their io object; the chatterbox swaps the handle for a recorder that logs the same way, so a dry run captures the same wire trace as a real run.

Characterization tests pin the existing wire calls (home / stop-cancel / list_connected_modules / addressable-area trash drop) so the seam refactor cannot change them silently; chatterbox tests run a full protocol with no `ot_api` installed and assert the recorded calls.

Foundation of the OT-2 series; depends on nothing else in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)