### PR TITLE
`Container`: forward volume-tracker changes to state updates; format Visualizer volume readouts

### DIFF
--- a/pylabrobot/resources/container.py
+++ b/pylabrobot/resources/container.py
@@ -79,6 +79,9 @@ class Container(Resource):
 
     self.max_volume = max_volume or (size_x * size_y * size_z)
     self.tracker = VolumeTracker(thing=f"{self.name}_volume_tracker", max_volume=self.max_volume)
+    # Notify state-update subscribers (e.g. the Visualizer) on volume changes; without this
+    # a bare Container like a Trough updates its volume internally but never broadcasts it.
+    self.tracker.register_callback(self._state_updated)
     self._compute_volume_from_height = compute_volume_from_height
     self._compute_height_from_volume = compute_height_from_volume
     self.no_go_zones: List[Tuple[Coordinate, Coordinate]] = self._validate_no_go_zones(

--- a/pylabrobot/resources/container_tests.py
+++ b/pylabrobot/resources/container_tests.py
@@ -203,6 +203,19 @@ class TestContainer(unittest.TestCase):
     c = Container(name="c", size_x=10, size_y=142, size_z=10, no_go_zones=zones)
     self.assertEqual(len(c.no_go_zones), 3)
 
+  def test_tracker_change_notifies_state_update_callbacks(self):
+    """A bare Container (e.g. a Trough) must forward volume-tracker changes to its
+    state-update callbacks, so subscribers like the Visualizer see the level change and do
+    not show a frozen volume."""
+    c = Container(name="c", size_x=10, size_y=10, size_z=10, max_volume=1000)
+    received: list = []
+    c.register_state_update_callback(received.append)
+    c.tracker.set_volume(500)
+    c.tracker.remove_liquid(100)
+    c.tracker.commit()
+    self.assertGreaterEqual(len(received), 2)  # at least set_volume and remove_liquid fired
+    self.assertEqual(c.tracker.get_used_volume(), 400)
+
 
 class TestNoGoZoneCollision(unittest.TestCase):
   def _make_container(self, size_y, no_go_zones=None):

--- a/pylabrobot/resources/tube.py
+++ b/pylabrobot/resources/tube.py
@@ -70,7 +70,6 @@ class Tube(Container):
       height_volume_data=height_volume_data,
       no_go_zones=no_go_zones,
     )
-    self.tracker.register_callback(self._state_updated)
 
   def serialize(self) -> dict:
     return {**super().serialize(), "max_volume": self.max_volume}

--- a/pylabrobot/resources/well.py
+++ b/pylabrobot/resources/well.py
@@ -105,8 +105,6 @@ class Well(Container):
     self.bottom_type = bottom_type
     self.cross_section_type = cross_section_type
 
-    self.tracker.register_callback(self._state_updated)
-
   def serialize(self):
     return {
       **super().serialize(),

--- a/pylabrobot/visualizer/lib.js
+++ b/pylabrobot/visualizer/lib.js
@@ -4492,6 +4492,14 @@ window.addEventListener("load", function () {
 var umlPanelResourceName = null;
 var _umlPanelOpenedAt = 0;
 
+// Format a volume for display: at most 2 decimals (no trailing zeros, so 327.2 not
+// 327.20) and thousands separators, so values above 1000 read as e.g. 1,000. Passes
+// null/undefined through unchanged.
+function formatVolume(v) {
+  if (v == null) return v;
+  return Number(v).toLocaleString("en-US", { maximumFractionDigits: 2 });
+}
+
 function getUmlAttributes(resource) {
   var attrs = [];
   attrs.push({ key: "name", value: JSON.stringify(resource.name) });
@@ -4537,8 +4545,8 @@ function getUmlAttributes(resource) {
       attrs.push({ key: "material_z_thickness", value: resource.material_z_thickness });
     }
     attrs.push({ key: "height_volume_data", value: resource.has_height_volume_data ? "exists" : "None" });
-    attrs.push({ key: "max_volume", value: resource.maxVolume });
-    attrs.push({ key: "volume", value: resource.volume });
+    attrs.push({ key: "max_volume", value: formatVolume(resource.maxVolume) });
+    attrs.push({ key: "volume", value: formatVolume(resource.volume) });
   }
   // TipSpot
   if (resource instanceof TipSpot) {


### PR DESCRIPTION
A `Container`'s `VolumeTracker` changes were applied internally but never broadcast. `Container.__init__` creates the tracker but never calls `tracker.register_callback(self._state_updated)`, so a bare container such as a `Trough` updates its own volume yet notifies no subscribers.

`Well` and `Tube` each register that callback in their own `__init__`, so plates and tube racks already update live; every other direct `Container` subclass was missed. The most visible symptom is in the Visualizer: a `Trough`'s liquid level stays frozen at its seeded volume even as it drains, because the tracker's `_callback` is never set. The tracking math was always correct - only the notification was missing.

- `Container.__init__` now calls `self.tracker.register_callback(self._state_updated)` right after creating the tracker. `super().__init__()` runs first, so `_state_updated` is already bound, and this wires every `Container` subclass in one place.
- `Well` and `Tube` drop their now-redundant `register_callback` calls and inherit the wiring through `super().__init__()`. `register_callback` is a plain setter, so the registered callback is identical and behaviour is unchanged.
- The Visualizer formats volume readouts through a shared `formatVolume` helper: at most 2 decimals with no trailing zeros (so a draining `Trough` reads `327.2`, not `327.20000000004626`) and thousands separators on `volume` and `max_volume`, so values above 1000 read as e.g. `60,000`.

Behaviour: no change for `Well`, `Tube`, or plates (the same callback, now set one level up); `Trough` and other bare containers emit state updates on volume change for the first time, and the Visualizer renders their level live and cleanly formatted.

Tests: adds a regression test asserting a `Container` forwards tracker changes to its state-update callbacks; the container, well, and visualizer suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
