### PR TITLE
`io.ftdi`: skip logging and capturing empty reads (mirror io.serial)

### DIFF
--- a/pylabrobot/io/ftdi.py
+++ b/pylabrobot/io/ftdi.py
@@ -311,20 +311,22 @@ class FTDI(IOBase):
 
   async def read(self, num_bytes: int = 1) -> bytes:
     data = self.dev.read(num_bytes)
-    logger.log(LOG_LEVEL_IO, "[%s] read %s", self._device_id, data)
-    capturer.record(
-      FTDICommand(
-        device_id=self.device_id,
-        action="read",
-        data=data if isinstance(data, str) else data.hex(),
+    if len(data) != 0:
+      logger.log(LOG_LEVEL_IO, "[%s] read %s", self._device_id, data)
+      capturer.record(
+        FTDICommand(
+          device_id=self.device_id,
+          action="read",
+          data=data if isinstance(data, str) else data.hex(),
+        )
       )
-    )
     return cast(bytes, data)
 
   async def readline(self) -> bytes:  # type: ignore # very dumb it's reading from pyserial
     data = self.dev.readline()
-    logger.log(LOG_LEVEL_IO, "[%s] readline %s", self._device_id, data)
-    capturer.record(FTDICommand(device_id=self.device_id, action="readline", data=data.hex()))
+    if len(data) != 0:
+      logger.log(LOG_LEVEL_IO, "[%s] readline %s", self._device_id, data)
+      capturer.record(FTDICommand(device_id=self.device_id, action="readline", data=data.hex()))
     return cast(bytes, data)
 
   def serialize(self):

--- a/pylabrobot/io/ftdi_tests.py
+++ b/pylabrobot/io/ftdi_tests.py
@@ -1,0 +1,70 @@
+import logging
+import unittest
+from unittest import mock
+
+from pylabrobot.io import ftdi as ftdi_module
+from pylabrobot.io.ftdi import FTDI, HAS_PYLIBFTDI, HAS_PYUSB
+from pylabrobot.io.validation_utils import LOG_LEVEL_IO
+
+
+class _RecordingHandler(logging.Handler):
+  """Captures every record emitted to a logger, whatever method produced it - so the
+  test cannot be fooled by swapping logger.log for logger.debug/info."""
+
+  def __init__(self) -> None:
+    super().__init__(level=LOG_LEVEL_IO)
+    self.records: list[logging.LogRecord] = []
+
+  def emit(self, record: logging.LogRecord) -> None:
+    self.records.append(record)
+
+
+@unittest.skipUnless(HAS_PYLIBFTDI and HAS_PYUSB, "pylibftdi/pyusb not installed")
+class FTDIEmptyReadTests(unittest.IsolatedAsyncioTestCase):
+  """Empty reads must be neither logged nor captured (mirrors io.serial). Polling a quiet
+  device reads b'' repeatedly; logging/capturing each one floods the log and capture.
+  Locks the `if len(data) != 0:` guard on read()/readline() - asserting on real log
+  records (not a mocked method) so re-routing the log call can't fake a pass."""
+
+  def setUp(self) -> None:
+    self._handler = _RecordingHandler()
+    self._logger = logging.getLogger("pylabrobot.io.ftdi")
+    self._prev_level = self._logger.level
+    self._logger.setLevel(LOG_LEVEL_IO)
+    self._logger.addHandler(self._handler)
+    self.addCleanup(self._logger.setLevel, self._prev_level)
+    self.addCleanup(self._logger.removeHandler, self._handler)
+
+  def _ftdi(self, return_value: bytes) -> FTDI:
+    # Bypass setup() (no hardware) by driving the underlying device read directly.
+    dev = FTDI(human_readable_device_name="test", device_id="test")
+    dev._dev = mock.Mock()
+    dev._dev.read.return_value = return_value
+    dev._dev.readline.return_value = return_value
+    return dev
+
+  async def test_empty_read_is_not_logged_or_captured(self) -> None:
+    dev = self._ftdi(b"")
+    with mock.patch.object(ftdi_module.capturer, "record") as mock_record:
+      self.assertEqual(await dev.read(4), b"")
+    self.assertEqual(self._handler.records, [])
+    mock_record.assert_not_called()
+
+  async def test_empty_readline_is_not_logged_or_captured(self) -> None:
+    dev = self._ftdi(b"")
+    with mock.patch.object(ftdi_module.capturer, "record") as mock_record:
+      self.assertEqual(await dev.readline(), b"")
+    self.assertEqual(self._handler.records, [])
+    mock_record.assert_not_called()
+
+  async def test_nonempty_read_is_logged_and_captured(self) -> None:
+    dev = self._ftdi(b"\x01\x02")
+    with mock.patch.object(ftdi_module.capturer, "record") as mock_record:
+      self.assertEqual(await dev.read(2), b"\x01\x02")
+    self.assertEqual(len(self._handler.records), 1)
+    self.assertIn(str(b"\x01\x02"), self._handler.records[0].getMessage())
+    mock_record.assert_called_once()
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
FTDI `read()` / `readline()` logged and captured every read, including the empty `b''` polls returned while a quiet device is waiting to respond (e.g. a CLARIOstar between command and reply). This floods the log: on one plate-reader run the log was 30,999 lines, of which ~28,500 were `read b''` - a ~92% reduction once they are dropped (30,999 -> 2,515 lines).

`io.serial` already guards against exactly this with `if len(data) != 0:` around its log and capture (added alongside the Inheco incubator shaker); `io.ftdi` was simply never brought in line.

- `FTDI.read()` and `FTDI.readline()` now gate both the `logger.log(...)` and the `capturer.record(...)` on `len(data) != 0`, so an empty read emits no log line and no capture entry - identical to `io.serial`.
- Non-empty reads are unchanged: still logged and captured.
- Adds `pylabrobot/io/ftdi_tests.py` locking the behaviour: an empty `read`/`readline` produces no log record and no capture entry, while a real read still does both. It asserts on actual captured log records (a logging handler on the `pylabrobot.io.ftdi` logger), not a mocked logger, so re-routing the log call cannot fake a pass.

Behaviour: no change for non-empty reads or any other FTDI method; only the empty-read log/capture noise is removed.

Tests: the new `ftdi_tests.py` (3 cases, guarded by the `ftdi` extra); `ruff format`, `ruff check --select I`, `ruff check`, and `mypy --check-untyped-defs` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
