### PR TITLE
`STARBackend`: forward traverse-height and grouping knobs through `probe_liquid_volumes`

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -2910,10 +2910,14 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     containers: List[Container],
     use_channels: List[int],
     resource_offsets: Optional[List[Coordinate]] = None,
-    lld_mode: LLDMode = LLDMode.GAMMA,
+    lld_mode: Union[LLDMode, List[LLDMode], None] = None,
     search_speed: float = 10.0,
-    n_replicates: int = 3,
+    n_replicates: int = 1,
+    # Traverse height parameters (None = full Z safety, float = absolute Z position in mm)
+    min_traverse_height_at_beginning_of_command: Optional[float] = None,
+    min_traverse_height_during_command: Optional[float] = None,
     z_position_at_end_of_command: Optional[float] = None,
+    x_grouping_tolerance: Optional[float] = None,
     # Deprecated
     move_to_z_safety_after: Optional[bool] = None,
   ) -> List[float]:
@@ -2927,11 +2931,20 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       containers: List of Container objects to probe, one per channel. All must support height-to-volume conversion via compute_volume_from_height().
       use_channels: Channel indices to use for probing (0-indexed).
       resource_offsets: Optional XYZ offsets from container centers. Auto-calculated for single containers with odd channel counts. Defaults to container centers.
-      lld_mode: Detection mode - LLDMode(1) for capacitive, LLDMode(2) for pressure-based.  Defaults to capacitive.
+      lld_mode: Detection mode. Either a single ``LLDMode`` applied to all containers
+        (deprecated, removed in v1b1) or a list of ``LLDMode``s (one per container). ``None``
+        (default) applies GAMMA (capacitive cLLD) to all containers.
       search_speed: Z-axis search speed in mm/s. Default 10.0 mm/s.
-      n_replicates: Number of measurements per channel. Default 3.
+      n_replicates: Number of measurements per channel. Default 1.
+      min_traverse_height_at_beginning_of_command: Absolute Z height (mm) to move involved
+        channels to before the first batch. Must clear all deck obstacles since channels
+        travel laterally at this height. None (default) uses full Z safety.
+      min_traverse_height_during_command: Absolute Z height (mm) to move involved channels to
+        between batches. None (default) uses full Z safety.
       z_position_at_end_of_command: Absolute Z height (mm) to move involved channels to after
         probing. None (default) uses full Z safety.
+      x_grouping_tolerance: Containers within this X distance (mm) are grouped and probed
+        together. Defaults to ``_x_grouping_tolerance_mm`` (0.1 mm).
       move_to_z_safety_after: Deprecated. Use ``z_position_at_end_of_command`` instead.
 
     Returns:
@@ -2967,7 +2980,10 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
       lld_mode=lld_mode,
       search_speed=search_speed,
       n_replicates=n_replicates,
+      min_traverse_height_at_beginning_of_command=min_traverse_height_at_beginning_of_command,
+      min_traverse_height_during_command=min_traverse_height_during_command,
       z_position_at_end_of_command=z_position_at_end_of_command,
+      x_grouping_tolerance=x_grouping_tolerance,
     )
 
     return [

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -2908,7 +2908,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
   async def probe_liquid_volumes(
     self,
     containers: List[Container],
-    use_channels: List[int],
+    use_channels: Optional[List[int]] = None,
     resource_offsets: Optional[List[Coordinate]] = None,
     lld_mode: Union[LLDMode, List[LLDMode], None] = None,
     search_speed: float = 10.0,
@@ -2929,7 +2929,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
 
     Args:
       containers: List of Container objects to probe, one per channel. All must support height-to-volume conversion via compute_volume_from_height().
-      use_channels: Channel indices to use for probing (0-indexed).
+      use_channels: Channel indices to use for probing (0-indexed). None (default) uses channels [0, 1, ..., len(containers)-1].
       resource_offsets: Optional XYZ offsets from container centers. Auto-calculated for single containers with odd channel counts. Defaults to container centers.
       lld_mode: Detection mode. Either a single ``LLDMode`` applied to all containers
         (deprecated, removed in v1b1) or a list of ``LLDMode``s (one per container). ``None``


### PR DESCRIPTION
probe_liquid_volumes is a thin wrapper: it calls probe_liquid_heights and converts each returned height to a volume via compute_volume_from_height. But it forwarded only a subset of the inner method's knobs, so it silently overrode two probe behaviours that a direct probe_liquid_heights call can control, and it required an explicit use_channels the inner method makes optional.

probe_liquid_heights exposes min_traverse_height_at_beginning_of_command, min_traverse_height_during_command, and x_grouping_tolerance; probe_liquid_volumes did not, so its inner call always fell back to full Z safety between batches (channels fully retract each pass, slower) and default X grouping, with no way to request a low on-deck traverse.

- probe_liquid_volumes now accepts and forwards min_traverse_height_at_beginning_of_command, min_traverse_height_during_command, and x_grouping_tolerance, in the same order as probe_liquid_heights. Defaults stay None, which reproduces the previous full-Z-safety, default-grouping behaviour.
- lld_mode widens from LLDMode to Union[LLDMode, List[LLDMode], None], default None. None resolves to GAMMA (capacitive cLLD) inside probe_liquid_heights, so both methods default to the same detection mode, and a default call no longer trips the single-LLDMode deprecation warning the old LLDMode.GAMMA default emitted internally. A per-container list is now accepted too.
- n_replicates default changes from 3 to 1, matching probe_liquid_heights.
- use_channels widens from List[int] to Optional[List[int]] = None. None auto-selects channels [0, 1, ..., len(containers)-1] via validate_channel_selections, which the inner method already supported; the wrapper simply never inherited it. Required->optional, so existing callers are unaffected.

With these changes the two signatures are identical, and probe_liquid_volumes is a pure pass-through to probe_liquid_heights plus the compute_volume_from_height conversion.

Behaviour: the additive traverse/grouping params, the wider lld_mode, and the optional use_channels are all behaviour-preserving at their defaults. The one semantic change is n_replicates: a default call now takes a single measurement rather than averaging three, and the replicate-consistency check cannot fire at the default. The new traverse/grouping params are inserted mid-signature to mirror probe_liquid_heights, so a caller passing z_position_at_end_of_command or move_to_z_safety_after positionally would misbind; there are no such call sites in-tree, and these APIs are used with keyword arguments.

Tests: the probe_liquid_heights suite passes unchanged; ruff format, ruff check, ruff check --select I, and mypy --check-untyped-defs are clean on the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)