### PR TITLE
`Visualizer`: show a plate lid as its own tree node, exclude it from the well count

### DIFF
--- a/pylabrobot/visualizer/lib.js
+++ b/pylabrobot/visualizer/lib.js
@@ -3305,6 +3305,10 @@ function isTubeRackLike(resource) {
     (resource.children.length > 0 && resource.children[0] instanceof Tube);
 }
 
+function isLid(resource) {
+  return resource.category === "lid" || resource.resourceType === "Lid";
+}
+
 function isCarrierLike(resource) {
   return resource instanceof Carrier ||
     ["carrier", "tip_carrier", "plate_carrier", "trough_carrier", "tube_carrier"]
@@ -3324,13 +3328,13 @@ function getResourceSummary(resource) {
   }
 
   if (isPlateLike(resource)) {
-    const numChildren = resource.children.length;
-    return `${numChildren} wells`;
+    const numWells = resource.children.filter((c) => !isLid(c)).length;
+    return `${numWells} wells`;
   }
 
   if (isTubeRackLike(resource)) {
-    const numChildren = resource.children.length;
-    return `${numChildren} tubes`;
+    const numTubes = resource.children.filter((c) => !isLid(c)).length;
+    return `${numTubes} tubes`;
   }
 
   if (resource instanceof Container) {
@@ -3434,9 +3438,10 @@ function getDisplayChildren(resource) {
     return result;
   }
 
-  // Leaf containers: don't show individual wells/tips/tubes
+  // Leaf containers: hide the individual wells/tips/tubes, but still surface
+  // other children such as a lid so they appear as their own tree nodes.
   if (isTipRackLike(resource) || isPlateLike(resource) || isTubeRackLike(resource)) {
-    return [];
+    return (resource.children || []).filter(isLid);
   }
 
   return resource.children || [];


### PR DESCRIPTION
A plate's lid is a regular child resource, so the sidebar tree counted it toward the plate's item total - a lidded 96-well plate read "97 wells" - and the lid never appeared as its own node because plate-like resources return no display children. Confirmed on a real serialized culture_plate (with_lid=True): 97 children, the last one a Lid.

Both stem from the same assumption that every child of a plate is a well, which stopped being true once lids became child resources.

- Add an `isLid` predicate (`category === "lid"` or `resourceType === "Lid"`).
- Exclude lids from the plate and tube-rack counts, so a lidded 96-well plate reads "96 wells".
- Return the lid from `getDisplayChildren` so it renders as its own collapsible tree node, while the individual wells/tips/tubes stay hidden as before.

No behavior change for lid-less plates or for the canvas: the change only touches the sidebar tree and the count label. Tip racks are unaffected in practice - PLR has no lid concept for them - and stay consistent (the filter simply yields none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
