### PR TITLE
`Visualizer`: add a per-item visibility toggle to the workcell tree

### DIFF
--- a/pylabrobot/visualizer/lib.js
+++ b/pylabrobot/visualizer/lib.js
@@ -858,6 +858,9 @@ class Resource {
       rotation: this.rotation ? this.rotation.z : 0,
       draggable: this.draggable,
     });
+    // Re-apply the tree eye-toggle state; draw() runs on every redraw (volume
+    // change, tip pickup, re-assign) and would otherwise resurrect a hidden item.
+    this.group.visible(!hiddenResourceNames.has(this.name));
     this.mainShape = this.drawMainShape();
     if (this.mainShape !== undefined) {
       this.group.add(this.mainShape);
@@ -3285,6 +3288,130 @@ var sidepanelHighlightRect = null;
 var sidepanelHoverRect = null;
 var sidepanelHoverGlow = null;
 
+// Names of resources currently hidden via the tree eye toggle. Keyed by name
+// rather than by JS instance so the state survives the destroy/redraw and
+// unassign/re-assign cycles that recreate a resource's Konva group.
+var hiddenResourceNames = new Set();
+
+// Blender-outliner-style eye. Shown: open almond outline with a filled pupil.
+// Hidden: a closed eyelid (downward arc), matching Blender's hide toggle.
+function treeEyeSvg(hidden) {
+  if (hidden) {
+    return '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">' +
+      '<path d="M3 10.5c2.6 3.3 5.9 5 9 5s6.4-1.7 9-5" stroke-width="2.2"/></svg>';
+  }
+  return '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">' +
+    '<path d="M3.07 12C5.23 8.2 8.43 6 12 6s6.77 2.2 8.93 6c-2.16 3.8-5.36 6-8.93 6s-6.77-2.2-8.93-6Z" stroke-width="2.2"/>' +
+    '<circle cx="12" cy="12" r="3.8" fill="currentColor" stroke="none"/></svg>';
+}
+
+// The Set stores only *explicitly* hidden resources (a resource's own state).
+// A resource's effective visibility is its own state AND every ancestor being
+// visible; the ancestor half is enforced for free by Konva group nesting, so we
+// never copy hidden-ness onto descendants. This keeps "hidden because I was
+// toggled off" distinct from "hidden because a parent is off".
+
+// True if any ancestor (not the resource itself) is explicitly hidden, so the
+// resource is clipped on the canvas no matter its own state.
+function isHiddenByAncestor(resource) {
+  var p = resource ? resource.parent : undefined;
+  while (p) {
+    if (hiddenResourceNames.has(p.name)) return true;
+    p = p.parent;
+  }
+  return false;
+}
+
+// Push a resource's own hidden flag onto its Konva group. Descendants are
+// clipped automatically because their groups are nested inside this one, and
+// the resource keeps its slot in the parent's child list so re-showing
+// preserves stacking order (a destroy/redraw would re-append it last).
+function applyOwnVisibility(resource) {
+  if (resource && resource.group !== undefined) {
+    resource.group.visible(!hiddenResourceNames.has(resource.name));
+  }
+}
+
+function setResourceHidden(resourceName, hidden) {
+  if (hidden) {
+    hiddenResourceNames.add(resourceName);
+  } else {
+    hiddenResourceNames.delete(resourceName);
+  }
+  applyOwnVisibility(resources[resourceName]);
+  resourceLayer.draw();
+  refreshTreeVisibilityState();
+}
+
+// Opt-in gesture (alt-click) for a row clipped by a hidden ancestor: clear this
+// resource's own flag and every hidden ancestor so it actually becomes visible.
+function revealResourceAndAncestors(resource) {
+  if (!resource) return;
+  hiddenResourceNames.delete(resource.name);
+  applyOwnVisibility(resource);
+  var p = resource.parent;
+  while (p) {
+    hiddenResourceNames.delete(p.name);
+    applyOwnVisibility(p);
+    p = p.parent;
+  }
+  resourceLayer.draw();
+  refreshTreeVisibilityState();
+}
+
+// Sync one tree row from current state. Eye *shape* follows the resource's own
+// flag (closed eyelid iff explicitly hidden). The `inherited` styling marks
+// rows clipped by a hidden ancestor: their own toggle can't take effect, so the
+// eye is shown disabled with a tooltip rather than letting a click lie about
+// what happened on the canvas.
+function updateRowVisibility(row, resource) {
+  var ownHidden = hiddenResourceNames.has(resource.name);
+  var inherited = isHiddenByAncestor(resource);
+  var eye = row.querySelector(":scope > .tree-node-eye");
+  if (eye) {
+    eye.classList.toggle("hidden", ownHidden);
+    eye.classList.toggle("inherited", inherited);
+    eye.innerHTML = treeEyeSvg(ownHidden);
+    eye.title = inherited
+      ? "Hidden by a parent - alt-click to reveal it"
+      : (ownHidden ? "Show" : "Hide");
+  }
+  row.classList.toggle("resource-hidden", ownHidden || inherited);
+}
+
+// Re-sync every tree row's eye/dim state. Cheap: only rows present in the DOM
+// are walked (leaf wells/tips are not surfaced as tree nodes).
+function refreshTreeVisibilityState() {
+  var tree = document.getElementById("resource-tree");
+  if (!tree) return;
+  var nodes = tree.querySelectorAll(".tree-node[data-resource-name]");
+  for (var i = 0; i < nodes.length; i++) {
+    var resource = resources[nodes[i].dataset.resourceName];
+    var row = nodes[i].querySelector(":scope > .tree-node-row");
+    if (resource && row) updateRowVisibility(row, resource);
+  }
+}
+
+// Build the per-row eye button. State is read from the Set (not a local flag)
+// so it stays correct when a subtree is rebuilt via replaceWith.
+function createVisibilityToggle(resourceName) {
+  var btn = document.createElement("span");
+  btn.className = "tree-node-eye";
+  btn.innerHTML = treeEyeSvg(false);
+  btn.addEventListener("click", function (e) {
+    e.stopPropagation();
+    var resource = resources[resourceName];
+    if (resource && isHiddenByAncestor(resource)) {
+      // Clipped by a hidden ancestor: a plain click can't take effect, so it is
+      // a no-op. Alt-click reveals the ancestor chain to force it visible.
+      if (e.altKey) revealResourceAndAncestors(resource);
+      return;
+    }
+    setResourceHidden(resourceName, !hiddenResourceNames.has(resourceName));
+  });
+  return btn;
+}
+
 function getResourceTypeName(resource) {
   return resource.constructor.name;
 }
@@ -3548,6 +3675,8 @@ function buildTreeNodeDOM(resource, depth, slotIndex) {
   row.appendChild(nameSpan);
   row.appendChild(typeSpan);
   row.appendChild(info);
+  row.appendChild(createVisibilityToggle(resource.name));
+  updateRowVisibility(row, resource);
   node.appendChild(row);
 
   // Hover row to show yellow highlight on canvas
@@ -3646,6 +3775,8 @@ function buildResourceTree(rootResource, { rebuildNavbar = true } = {}) {
   rootRow.appendChild(rootDot);
   rootRow.appendChild(rootName);
   rootRow.appendChild(rootType);
+  rootRow.appendChild(createVisibilityToggle(rootResource.name));
+  updateRowVisibility(rootRow, rootResource);
   rootNode.appendChild(rootRow);
 
   rootRow.addEventListener("mouseenter", function () {

--- a/pylabrobot/visualizer/main.css
+++ b/pylabrobot/visualizer/main.css
@@ -728,6 +728,58 @@ main {
   font-weight: 600;
 }
 
+/* Blender-outliner-style eye: a neutral grey icon that is always visible on
+   every row (not hover-revealed), brightening slightly on hover. */
+.tree-node-eye {
+  margin-left: 8px;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: #7a7f87;
+  cursor: pointer;
+  border-radius: 4px;
+  opacity: 0.85;
+  transition: background 0.12s, color 0.12s, opacity 0.12s;
+}
+
+.tree-node-eye:hover {
+  opacity: 1;
+  background: #dee2e6;
+  color: #333;
+}
+
+/* Hidden item: keep the same grey (Blender does not recolour it), the closed
+   eyelid shape conveys the state; a touch lighter to read as "off". */
+.tree-node-eye.hidden {
+  color: #9aa0a8;
+}
+
+/* Clipped by a hidden ancestor: the eye is disabled (its own toggle can't take
+   effect), shown muted with a not-allowed cursor. Alt-click still reveals the
+   ancestor chain. */
+.tree-node-eye.inherited {
+  color: #c3c7cd;
+  cursor: not-allowed;
+}
+
+.tree-node-eye.inherited:hover {
+  background: transparent;
+  color: #c3c7cd;
+}
+
+.tree-node-row.resource-hidden .tree-node-name {
+  color: #aaa;
+  font-style: italic;
+}
+
+.tree-node-row.resource-hidden .tree-node-type,
+.tree-node-row.resource-hidden .tree-node-info {
+  opacity: 0.5;
+}
+
 .tree-node-children {
   display: block;
 }


### PR DESCRIPTION
The visualizer's workcell tree lists every resource in the workcell - the liquid handler, carriers, plates, tip racks, and lids - but offered no way to hide an individual item from the canvas. On a dense deck, resources overlap and a carrier or lid occludes whatever sits beneath it, with no way to declutter the view or look underneath short of editing the layout.

- Add an eye toggle to every row of the workcell tree (including the root); clicking it hides or shows that resource on the canvas.
- Hiding flips the resource's Konva group visibility instead of destroying and redrawing it, so the item keeps its exact location and stacking order when shown again.
- Hiding a container hides everything on it: the canvas scene graph mirrors the resource tree, so a hidden group clips all of its descendants - hide a carrier and its racks and plates go with it.
- The hidden set is keyed by resource name and re-applied on every redraw, so an item stays hidden across the volume changes, tip pickups, and re-assignments that rebuild its canvas group.
- A row whose parent is hidden is shown disabled and greyed with an explanatory tooltip, because its own toggle cannot take effect while an ancestor hides it; alt-clicking such a row reveals it by clearing the hidden flag on it and every hidden ancestor.

Behavior: nothing changes until an eye is clicked - the default view, canvas rendering, and tree counts are untouched. The toggle is view-only; it never alters the deck layout or any resource state, only what the canvas draws, so it is a safe way to declutter a busy deck and inspect occluded or nested resources. Frontend only (lib.js and main.css); no Python or API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
