### PR TITLE
`Visualizer`: recolor liquid and tip shapes in place instead of rebuilding the Konva group

### DIFF
--- a/pylabrobot/visualizer/lib.js
+++ b/pylabrobot/visualizer/lib.js
@@ -1720,7 +1720,15 @@ class Container extends Resource {
 
   setVolume(volume) {
     this.volume = volume;
-    this.update();
+    // Fast path: recolor the existing liquid shape in place instead of destroying
+    // and rebuilding the entire Konva group (and re-registering every event
+    // handler) on each volume change. `_liquidShape` is captured in drawMainShape;
+    // fall back to a full draw() if the resource has not been drawn yet.
+    if (this._liquidShape !== undefined && this._liquidShape !== null) {
+      this._liquidShape.fill(Container.colorForVolume(volume, this.maxVolume));
+    } else {
+      this.update();
+    }
   }
 
   setState(state) {
@@ -1766,6 +1774,7 @@ class Well extends Container {
 
   drawMainShape() {
     const mainShape = new Konva.Group({});
+    let liquid;
     if (this.cross_section_type === "circle") {
       mainShape.add(new Konva.Circle({  // background
         radius: this.size_x / 2,
@@ -1773,28 +1782,31 @@ class Well extends Container {
         offsetX: -this.size_x / 2,
         offsetY: -this.size_y / 2,
       }));
-      mainShape.add(new Konva.Circle({ // liquid
+      liquid = new Konva.Circle({ // liquid
         radius: this.size_x / 2,
         fill: Well.colorForVolume(this.getVolume(), this.maxVolume),
         stroke: "black",
         strokeWidth: 1,
         offsetX: -this.size_x / 2,
         offsetY: -this.size_y / 2,
-      }));
+      });
+      mainShape.add(liquid);
     } else {
       mainShape.add(new Konva.Rect({  // background
         width: this.size_x,
         height: this.size_y,
         fill: RESOURCE_COLORS["ContainerBackground"],
       }));
-      mainShape.add(new Konva.Rect({ // liquid
+      liquid = new Konva.Rect({ // liquid
         width: this.size_x,
         height: this.size_y,
         fill: Well.colorForVolume(this.getVolume(), this.maxVolume),
         stroke: "black",
         strokeWidth: 1,
-      }));
+      });
+      mainShape.add(liquid);
     }
+    this._liquidShape = liquid;
     return mainShape;
   }
 }
@@ -1809,11 +1821,13 @@ class Trough extends Container {
       stroke: "black",
       strokeWidth: 1,
     }));
-    group.add(new Konva.Rect({  // liquid layer
+    const liquid = new Konva.Rect({  // liquid layer
       width: this.size_x,
       height: this.size_y,
       fill: Trough.colorForVolume(this.getVolume(), this.maxVolume),
-    }));
+    });
+    group.add(liquid);
+    this._liquidShape = liquid;
     return group;
   }
 }
@@ -1870,7 +1884,7 @@ class TipSpot extends Resource {
   get canDelete() { return false; }
 
   drawMainShape() {
-    return new Konva.Circle({
+    this._tipShape = new Konva.Circle({
       radius: this.size_x / 2,
       fill: this.has_tip ? "#40CDA1" : "white",
       stroke: "black",
@@ -1878,12 +1892,19 @@ class TipSpot extends Resource {
       offsetX: -this.size_x / 2,
       offsetY: -this.size_y / 2,
     });
+    return this._tipShape;
   }
 
   setState(state) {
     super.setState(state);
     this.has_tip = state.tip !== null;
-    this.update();
+    // Fast path: recolor the existing tip circle in place instead of rebuilding
+    // the whole group. Fall back to a full draw() if not yet drawn.
+    if (this._tipShape !== undefined && this._tipShape !== null) {
+      this._tipShape.fill(this.has_tip ? "#40CDA1" : "white");
+    } else {
+      this.update();
+    }
   }
 
   serialize() {
@@ -1925,14 +1946,16 @@ class Tube extends Container {
       offsetX: -this.size_x / 2,
       offsetY: -this.size_y / 2,
     }));
-    mainShape.add(new Konva.Circle({  // liquid
+    const liquid = new Konva.Circle({  // liquid
       radius: this.size_x / 2,
       fill: Tube.colorForVolume(this.getVolume(), this.maxVolume),
       stroke: "black",
       strokeWidth: 1,
       offsetX: -this.size_x / 2,
       offsetY: -this.size_y / 2,
-    }));
+    });
+    mainShape.add(liquid);
+    this._liquidShape = liquid;
     return mainShape;
   }
 }

--- a/pylabrobot/visualizer/vis.js
+++ b/pylabrobot/visualizer/vis.js
@@ -99,8 +99,20 @@ async function processCentralEvent(event, data) {
     case "set_state":
       let allStates = data;
       setState(allStates);
-      // Update only the affected sidepanel nodes instead of rebuilding the entire tree
+      // Update only the affected sidepanel nodes instead of rebuilding the entire
+      // tree. Wells/tip spots/tubes all refresh their parent's summary, so dedupe
+      // by target node to avoid recomputing the same plate/rack summary once per
+      // child (e.g. 96 identical refreshes for a single 96-channel operation).
+      let refreshedNodes = new Set();
       for (let resourceName in allStates) {
+        let target = resources[resourceName];
+        let targetName = resourceName;
+        if (target && (target instanceof TipSpot || target instanceof Well || target instanceof Tube)
+            && target.parent) {
+          targetName = target.parent.name;
+        }
+        if (refreshedNodes.has(targetName)) continue;
+        refreshedNodes.add(targetName);
         updateSidepanelState(resourceName);
       }
       break;
@@ -123,7 +135,7 @@ async function handleEvent(id, event, data) {
     return; // don't parse pongs.
   }
 
-  console.log("[event] " + event, data);
+  if (window.VIS_DEBUG) console.log("[event] " + event, data);
 
   const ret = {
     event: event,
@@ -192,7 +204,7 @@ function openSocket() {
       if (value == "-Infinity") return -Infinity;
       return value;
     });
-    console.log(`[message] Data received from server:`, data);
+    if (window.VIS_DEBUG) console.log(`[message] Data received from server:`, data);
     handleEvent(data.id, data.event, data.data);
   });
 }

--- a/pylabrobot/visualizer/visualizer.py
+++ b/pylabrobot/visualizer/visualizer.py
@@ -188,6 +188,11 @@ class Visualizer:
     self._flush_scheduled = False
 
     self.received: List[dict] = []
+    # Ids of commands whose responses a caller is actively awaiting. Only these
+    # responses are retained in ``self.received``; responses to fire-and-forget
+    # commands (every state update) are dropped so the list cannot grow without
+    # bound over a long-running session.
+    self._pending_response_ids: set = set()
 
   @property
   def websocket(
@@ -251,7 +256,8 @@ class Visualizer:
         return
 
       data = json.loads(message)
-      self.received.append(data)
+      if data.get("id") in self._pending_response_ids:
+        self.received.append(data)
 
       # If the event is "ready", then we can save the connection and send the saved messages.
       if data.get("event") == "ready":
@@ -320,12 +326,16 @@ class Visualizer:
       await self.websocket.send(serialized_data)
 
       if wait_for_response:
-        while True:
-          if len(self.received) > 0:
-            message = self.received.pop()
-            if "id" in message and message["id"] == id_:
-              break
-          await asyncio.sleep(0.1)
+        self._pending_response_ids.add(id_)
+        try:
+          while True:
+            if len(self.received) > 0:
+              message = self.received.pop()
+              if "id" in message and message["id"] == id_:
+                break
+            await asyncio.sleep(0.1)
+        finally:
+          self._pending_response_ids.discard(id_)
 
         if not message["success"]:
           error = message.get("error", "unknown error")
@@ -602,6 +612,7 @@ class Visualizer:
 
     # Clear all relevant attributes.
     self.received.clear()
+    self._pending_response_ids.clear()
     self._websocket = None
     self._loop = None
     self._t = None


### PR DESCRIPTION
## Motivation

Every well volume change and every tip pickup or drop went through `setState` to `update()` to `draw()`, and `draw()` destroys and recreates the resource's entire Konva group and re-registers its four event handlers, even when only a fill colour changed. During high-throughput operations such as 96-channel transfers this rebuild dominates the visualizer's cost, and it also churns a lot of short-lived Konva objects.

## Change

Wells, troughs, tubes and tip spots now keep a reference to their liquid or tip shape (captured in `drawMainShape`) and recolour it in place when their state updates. The full `draw()` path is retained as a fallback for first render, resource assignment and rotation, so what gets drawn is unchanged.

Three smaller cleanups are included in the same spirit:
- The backend no longer retains responses to fire-and-forget commands in `received`; only responses a caller is actively awaiting are kept, so the list can no longer grow for the whole lifetime of a session.
- The per-message `console.log` calls are gated behind a `window.VIS_DEBUG` flag so a long run does not accumulate logged object references.
- After a `set_state` batch, each affected sidebar summary node is refreshed once rather than once per child (a single 96-channel operation previously recomputed the same plate or tip-rack summary 96 times).

## Result

Driven through a headless browser on a 96-well plate, updating all 96 wells and forcing a synchronous repaint each round:

| metric | before | after |
| --- | --- | --- |
| well update, mean ms/round | 10.4 | 0.8 |
| well update, p95 ms/round | 12.1 | 1.0 |
| heap growth over 400 rounds (MB) | 37 | 6 |
| tip update, mean ms/round | 6.1 | 0.8 |
| Konva nodes in scene | 382 | 382 |

The rendered scene is identical (same node count), an end-to-end run driving real `LiquidHandler` aspirate/dispense/pickup through the websocket recolours wells and tip spots correctly, and the existing visualizer tests pass.
