### PR TITLE
v1: `OTDeck`: bring static geometry and holder-based slot rendering forward from main

### DIFF
--- a/pylabrobot/legacy/liquid_handling/backends/opentrons_backend.py
+++ b/pylabrobot/legacy/liquid_handling/backends/opentrons_backend.py
@@ -238,6 +238,8 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
     labware_uuid = self.get_ot_name(tip_rack.name)
 
     deck = tip_rack.parent
+    while deck is not None and not isinstance(deck, OTDeck):
+      deck = deck.parent  # labware sits in a slot holder, whose parent is the deck
     assert isinstance(deck, OTDeck)
     slot = deck.get_slot(tip_rack)
     assert slot is not None, "tip rack must be on deck"
@@ -437,6 +439,15 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
       "p20_multi_gen2": 7.6,
     }[pipette_name]
 
+  def _deck_to_robot_frame(self, location: Coordinate) -> Coordinate:
+    """Convert a deck-frame coordinate to the OT-2 robot frame.
+
+    pylabrobot positions OT deck slots from the deck plate corner, whereas the OT-2 motion API
+    expects coordinates in the robot frame whose origin is slot 1's corner. The two frames differ by
+    slot 1's position in the deck frame, so subtract it.
+    """
+    return location - cast(OTDeck, self.deck).slot_locations[0]
+
   async def aspirate(self, ops: List[SingleChannelAspiration], use_channels: List[int]):
     """Aspirate liquid from the specified resource using pip."""
 
@@ -447,7 +458,7 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
     pipette_name = self.get_pipette_name(pipette_id)
     flow_rate = op.flow_rate or self._get_default_aspiration_flow_rate(pipette_name)
 
-    location = (
+    location = self._deck_to_robot_frame(
       op.resource.get_location_wrt(self.deck, "c", "c", "cavity_bottom")
       + op.offset
       + Coordinate(z=op.liquid_height or 0)
@@ -478,7 +489,7 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
       pipette_id=pipette_id,
     )
 
-    traversal_location = (
+    traversal_location = self._deck_to_robot_frame(
       op.resource.get_location_wrt(self.deck, "c", "c", "cavity_bottom") + op.offset
     )
     traversal_location.z = self.traversal_height
@@ -522,7 +533,7 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
     pipette_name = self.get_pipette_name(pipette_id)
     flow_rate = op.flow_rate or self._get_default_dispense_flow_rate(pipette_name)
 
-    location = (
+    location = self._deck_to_robot_frame(
       op.resource.get_location_wrt(self.deck, "c", "c", "cavity_bottom")
       + op.offset
       + Coordinate(z=op.liquid_height or 0)
@@ -552,7 +563,7 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
           pipette_id=pipette_id,
         )
 
-    traversal_location = (
+    traversal_location = self._deck_to_robot_frame(
       op.resource.get_location_wrt(self.deck, "c", "c", "cavity_bottom") + op.offset
     )
     traversal_location.z = self.traversal_height

--- a/pylabrobot/legacy/liquid_handling/backends/opentrons_backend_tests.py
+++ b/pylabrobot/legacy/liquid_handling/backends/opentrons_backend_tests.py
@@ -239,6 +239,19 @@ class OpentronsSharedHelperTests(unittest.TestCase):
     with self.assertRaises(NoChannelError):
       self.backend._get_pickup_pipette(ops)
 
+  # -- _deck_to_robot_frame --
+
+  def test_deck_to_robot_frame_maps_slot1_corner_to_robot_origin(self):
+    """The deck->robot transform subtracts slot 1's corner, so a deck-frame point at slot 1's
+    corner becomes the robot origin and a point offset from it keeps that offset."""
+    self.backend.set_deck(self.deck)
+    corner = self.deck.slot_locations[0]
+    self.assertEqual(self.backend._deck_to_robot_frame(corner), Coordinate(0, 0, 0))
+    self.assertEqual(
+      self.backend._deck_to_robot_frame(corner + Coordinate(10, 20, 3)),
+      Coordinate(10, 20, 3),
+    )
+
   # -- _get_drop_pipette --
 
   def test_get_drop_pipette_selects_right_for_20ul(self):

--- a/pylabrobot/resources/opentrons/__init__.py
+++ b/pylabrobot/resources/opentrons/__init__.py
@@ -1,4 +1,5 @@
 from .deck import OTDeck
 from .load import load_ot_tip_rack
 from .module import OTModule
+from .ot2_geometry import OT2RobotGeometry
 from .tip_racks import *

--- a/pylabrobot/resources/opentrons/deck.py
+++ b/pylabrobot/resources/opentrons/deck.py
@@ -1,50 +1,90 @@
 import textwrap
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from pylabrobot.resources.coordinate import Coordinate
 from pylabrobot.resources.deck import Deck
 from pylabrobot.resources.resource import Resource
+from pylabrobot.resources.resource_holder import ResourceHolder
 from pylabrobot.resources.trash import Trash
+
+_SLOT_SIZE_X = 128.0
+_SLOT_SIZE_Y = 86.0
+
+# The fixed trash (opentrons_1_trash_1100ml_fixed) is larger than a standard slot and overhangs it,
+# so slot 12's holder takes the trash footprint instead of the standard slot size.
+_TRASH_SIZE_X = 172.86
+_TRASH_SIZE_Y = 165.86
+_TRASH_SIZE_Z = 82.0
+
+# Base OT-2 slot grid in the robot frame, where slot 1's corner is the origin.
+_BASE_SLOT_LOCATIONS = [
+  Coordinate(x=0.0, y=0.0, z=0.0),
+  Coordinate(x=132.5, y=0.0, z=0.0),
+  Coordinate(x=265.0, y=0.0, z=0.0),
+  Coordinate(x=0.0, y=90.5, z=0.0),
+  Coordinate(x=132.5, y=90.5, z=0.0),
+  Coordinate(x=265.0, y=90.5, z=0.0),
+  Coordinate(x=0.0, y=181.0, z=0.0),
+  Coordinate(x=132.5, y=181.0, z=0.0),
+  Coordinate(x=265.0, y=181.0, z=0.0),
+  Coordinate(x=0.0, y=271.5, z=0.0),
+  Coordinate(x=132.5, y=271.5, z=0.0),
+  Coordinate(x=265.0, y=271.5, z=0.0),
+]
+# The deck plate corner sits at (-115.65, -68.03) in the robot frame, which is this resource's
+# local origin, so each slot is re-based onto the plate corner by adding the offset.
+_SLOT_CORNER_OFFSET = Coordinate(x=115.65, y=68.03, z=0.0)
 
 
 class OTDeck(Deck):
-  """The OpenTron deck."""
+  """The Opentrons OT-2 deck.
+
+  The 12 slots are modeled as :class:`ResourceHolder` children, one per slot, so the deck geometry
+  has a single source of truth and renders directly from the serialized resource tree. Labware is
+  placed into a slot's holder with :meth:`assign_child_at_slot`.
+  """
 
   def __init__(
     self,
     size_x: float = 624.3,
     size_y: float = 565.2,
-    size_z: float = 900,
+    size_z: float = 0,
     origin: Coordinate = Coordinate(0, 0, 0),
     with_trash: bool = True,
-    name: str = "deck",
+    name: str = "ot2_deck",
+    category: str = "deck",
   ):
-    # size_z is probably wrong
+    super().__init__(
+      size_x=size_x, size_y=size_y, size_z=size_z, name=name, origin=origin, category=category
+    )
 
-    super().__init__(size_x=size_x, size_y=size_y, size_z=size_z, origin=origin)
-
-    self.slots: List[Optional[Resource]] = [None] * 12
-
-    self.slot_locations = [
-      Coordinate(x=0.0, y=0.0, z=0.0),
-      Coordinate(x=132.5, y=0.0, z=0.0),
-      Coordinate(x=265.0, y=0.0, z=0.0),
-      Coordinate(x=0.0, y=90.5, z=0.0),
-      Coordinate(x=132.5, y=90.5, z=0.0),
-      Coordinate(x=265.0, y=90.5, z=0.0),
-      Coordinate(x=0.0, y=181.0, z=0.0),
-      Coordinate(x=132.5, y=181.0, z=0.0),
-      Coordinate(x=265.0, y=181.0, z=0.0),
-      Coordinate(x=0.0, y=271.5, z=0.0),
-      Coordinate(x=132.5, y=271.5, z=0.0),
-      Coordinate(x=265.0, y=271.5, z=0.0),
-    ]
+    self._slot_holders: List[ResourceHolder] = []
+    for i, base in enumerate(_BASE_SLOT_LOCATIONS):
+      is_trash_slot = i == 11 and with_trash
+      holder = ResourceHolder(
+        name=f"{self.name}_slot_{i + 1}",
+        size_x=_TRASH_SIZE_X if is_trash_slot else _SLOT_SIZE_X,
+        size_y=_TRASH_SIZE_Y if is_trash_slot else _SLOT_SIZE_Y,
+        size_z=_TRASH_SIZE_Z if is_trash_slot else 0,
+      )
+      self._slot_holders.append(holder)
+      super().assign_child_resource(holder, location=base + _SLOT_CORNER_OFFSET)
 
     if with_trash:
       self._assign_trash()
 
+  @property
+  def slots(self) -> List[Optional[Resource]]:
+    """The labware in each slot, or ``None`` for empty slots (slot 1 first)."""
+    return [holder.resource for holder in self._slot_holders]
+
+  @property
+  def slot_locations(self) -> List[Coordinate]:
+    """The location of each slot, re-based onto the deck plate corner (slot 1 first)."""
+    return [cast(Coordinate, holder.location) for holder in self._slot_holders]
+
   def _assign_trash(self):
-    """Assign the trash area to the deck.
+    """Assign the trash area to slot 12.
 
     Because all opentrons operations require that the resource passed references a parent, we need
     to create a dummy resource to represent the container of the actual trash area.
@@ -52,16 +92,16 @@ class OTDeck(Deck):
 
     trash_container = Trash(
       name="trash_container",
-      size_x=172.86,
-      size_y=165.86,
-      size_z=82,
+      size_x=_TRASH_SIZE_X,
+      size_y=_TRASH_SIZE_Y,
+      size_z=_TRASH_SIZE_Z,
     )
 
     actual_trash = Trash(
       name="trash",
-      size_x=172.86,
-      size_y=165.86,
-      size_z=82,
+      size_x=_TRASH_SIZE_X,
+      size_y=_TRASH_SIZE_Y,
+      size_z=_TRASH_SIZE_Z,
     )
 
     # Trash location used to be Coordinate(x=86.43, y=82.93, z=0),
@@ -75,47 +115,57 @@ class OTDeck(Deck):
   def assign_child_resource(
     self,
     resource: Resource,
-    location: Optional[Coordinate],
+    location: Optional[Coordinate] = None,
     reassign: bool = True,
   ):
-    """Assign a resource to a slot.
+    """Assign a slot holder to the deck.
 
-    ..warning:: This method exists only for deserialization. You should use
-    :meth:`assign_child_at_slot` instead.
+    The deck's direct children are the 12 slot holders created in ``__init__``. Deserialization
+    re-assigns those holders by name, replacing the placeholder with the loaded one (which carries
+    its labware). Labware itself is placed with :meth:`assign_child_at_slot`, not here.
     """
 
-    if location is None:
-      raise ValueError("location must be provided for resources on the deck")
+    existing = next((child for child in self.children if child.name == resource.name), None)
+    if existing is not None:
+      if not reassign:
+        raise ValueError(f"Resource '{resource.name}' already assigned to deck")
+      super().unassign_child_resource(existing)
+      for i, holder in enumerate(self._slot_holders):
+        if holder is existing:
+          self._slot_holders[i] = cast(ResourceHolder, resource)
+          break
+    elif not isinstance(resource, ResourceHolder):
+      raise ValueError(
+        f"Cannot assign '{resource.name}' directly to the deck. Use assign_child_at_slot to place "
+        "labware into a slot. A deck serialized before slots became resource holders stores labware "
+        "as direct children and will not load."
+      )
 
-    if location not in self.slot_locations:
-      super().assign_child_resource(resource, location=location)
-    else:
-      slot = self.slot_locations.index(location) + 1
-      self.assign_child_at_slot(resource, slot)
+    super().assign_child_resource(resource, location=location, reassign=reassign)
 
   def assign_child_at_slot(self, resource: Resource, slot: int):
     if slot not in range(1, 13):
       raise ValueError("slot must be between 1 and 12")
 
-    if self.slots[slot - 1] is not None:
+    holder = self._slot_holders[slot - 1]
+    if holder.resource is not None:
       raise ValueError(f"Spot {slot} is already occupied")
 
-    self.slots[slot - 1] = resource
-    super().assign_child_resource(resource, location=self.slot_locations[slot - 1])
+    holder.assign_child_resource(resource)
 
   def unassign_child_resource(self, resource: Resource):
-    if resource not in self.slots:
-      raise ValueError(f"Resource {resource.name} is not assigned to this deck")
-
-    slot = self.slots.index(resource)
-    self.slots[slot] = None
+    for holder in self._slot_holders:
+      if holder.resource is resource:
+        holder.unassign_child_resource(resource)
+        return
     super().unassign_child_resource(resource)
 
   def get_slot(self, resource: Resource) -> Optional[int]:
     """Get the slot number of a resource."""
-    if resource not in self.slots:
-      return None
-    return self.slots.index(resource) + 1
+    for i, holder in enumerate(self._slot_holders):
+      if holder.resource is resource:
+        return i + 1
+    return None
 
   def summary(self) -> str:
     """Get a summary of the deck.

--- a/pylabrobot/resources/opentrons/deck_tests.py
+++ b/pylabrobot/resources/opentrons/deck_tests.py
@@ -1,6 +1,7 @@
 import textwrap
 import unittest
 
+from pylabrobot.resources.coordinate import Coordinate
 from pylabrobot.resources.corning.plates import (
   Cor_96_wellplate_360ul_Fb,
 )
@@ -8,6 +9,8 @@ from pylabrobot.resources.opentrons.deck import OTDeck
 from pylabrobot.resources.opentrons.tip_racks import (
   opentrons_96_tiprack_300ul,
 )
+from pylabrobot.resources.resource import Resource
+from pylabrobot.resources.resource_holder import ResourceHolder
 
 
 class TestOTDeck(unittest.TestCase):
@@ -22,6 +25,41 @@ class TestOTDeck(unittest.TestCase):
     self.deck.assign_child_at_slot(opentrons_96_tiprack_300ul("tip_rack_3"), 9)
     self.deck.assign_child_at_slot(Cor_96_wellplate_360ul_Fb("my_plate"), 4)
     self.deck.assign_child_at_slot(Cor_96_wellplate_360ul_Fb("my_other_plate"), 5)
+
+  def test_slot_locations_inset_from_plate_corner(self):
+    """Slots are re-based onto the deck plate corner, so slot 1 sits at the corner offset
+    (115.65, 68.03) rather than the deck origin, and every other slot shifts by the same amount."""
+    self.assertEqual(self.deck.slot_locations[0], Coordinate(115.65, 68.03, 0))
+    self.assertEqual(self.deck.slot_locations[11], Coordinate(380.65, 339.53, 0))
+
+  def test_slots_are_resource_holders_at_inset_positions(self):
+    """The 12 slots are ResourceHolder children at the inset slot locations, and a slot's labware
+    is that holder's child."""
+    holders = self.deck._slot_holders
+    self.assertEqual(len(holders), 12)
+    self.assertTrue(all(isinstance(h, ResourceHolder) for h in holders))
+    self.assertEqual(holders[0].location, Coordinate(115.65, 68.03, 0))
+    self.assertIs(holders[6].resource, self.deck.slots[6])  # tip_rack_1 lives in slot 7's holder
+
+  def test_assign_child_resource_rejects_direct_labware(self):
+    """Labware must enter a slot via assign_child_at_slot; assigning it directly to the deck (as a
+    deck serialized before slots became holders would) is rejected rather than misplaced."""
+    deck = OTDeck()
+    plate = Cor_96_wellplate_360ul_Fb("p")
+    with self.assertRaises(ValueError):
+      deck.assign_child_resource(plate, location=Coordinate(115.65, 68.03, 0))
+
+  def test_serialize_deserialize_round_trip(self):
+    """A deck with labware survives serialize -> deserialize, with slots resolving to the same
+    labware (validates replacing the placeholder holders with the loaded ones)."""
+    loaded = Resource.deserialize(self.deck.serialize())
+    assert isinstance(loaded, OTDeck)
+    slot_6, slot_3 = loaded.slots[6], loaded.slots[3]
+    assert slot_6 is not None and slot_3 is not None
+    self.assertEqual(slot_6.name, "tip_rack_1")
+    self.assertEqual(loaded.get_slot(slot_6), 7)
+    self.assertEqual(slot_3.name, "my_plate")
+    self.assertEqual(loaded.slot_locations[0], Coordinate(115.65, 68.03, 0))
 
   def test_summary(self):
     self.assertEqual(

--- a/pylabrobot/resources/opentrons/ot2_geometry.py
+++ b/pylabrobot/resources/opentrons/ot2_geometry.py
@@ -1,0 +1,86 @@
+import dataclasses
+from typing import List, Tuple
+
+from pylabrobot.resources.coordinate import Coordinate
+
+
+@dataclasses.dataclass(frozen=True)
+class OT2RobotGeometry:
+  """Static geometry of an Opentrons OT-2, expressed in the robot frame.
+
+  Every OT-2 Standard shares this geometry, so it is a constant rather than something probed from
+  the device. The only OT-2 data worth discovering at runtime is which pipettes are mounted, not
+  where the deck is.
+
+  The robot frame has its origin at the front-left corner of slot 1, with +x to the right, +y to
+  the back, and +z up. All distances are in mm.
+  """
+
+  # Gantry working area reachable by the reference (right) mount.
+  extents: Coordinate = dataclasses.field(default_factory=lambda: Coordinate(446.75, 347.5, 0.0))
+
+  # Partial-tip body clearance: how far a pipette's bounding box may sit beyond the deck extents at
+  # each edge. These bound the pipette body in partial nozzle configurations only; they do not
+  # constrain a fully-configured single or multi-channel pipette and are not used by the
+  # single-channel reach check below.
+  padding_front: float = 31.89
+  padding_rear: float = -35.91
+  padding_left: float = 0.0
+  padding_right: float = 0.0
+
+  # Nozzle offset of each mount from the gantry carriage; the right mount is the reference.
+  left_mount_offset: Coordinate = dataclasses.field(
+    default_factory=lambda: Coordinate(-34.0, 0.0, 0.0)
+  )
+  right_mount_offset: Coordinate = dataclasses.field(
+    default_factory=lambda: Coordinate(0.0, 0.0, 0.0)
+  )
+
+  def mount_offset(self, mount: str) -> Coordinate:
+    """Nozzle offset of ``mount`` ("left" or "right") from the gantry carriage."""
+    if mount == "left":
+      return self.left_mount_offset
+    if mount == "right":
+      return self.right_mount_offset
+    raise ValueError(f"mount must be 'left' or 'right', got {mount!r}")
+
+  def single_channel_reach(self, mount: str) -> Tuple[float, float, float, float]:
+    """Reachable nozzle region for a fully-configured pipette on ``mount``.
+
+    Returns ``(x_min, x_max, y_min, y_max)`` in the robot frame: the gantry working area
+    (``extents``) translated by the mount offset. This mirrors how the OT-2 motion system bounds a
+    fully-configured pipette - the deck extents per mount, running from the front-left corner to
+    ``extents`` plus the mount offset. It is independent of ``padding_*``, which govern partial-tip
+    nozzle configurations only. The mount offset has no y component, so both mounts share the same
+    front/back reach and differ only in x.
+    """
+    off = self.mount_offset(mount)
+    return (off.x, self.extents.x + off.x, 0.0, self.extents.y)
+
+  @staticmethod
+  def channel_y_offsets() -> List[float]:
+    """Y offset of each head8 channel from the head center, in mm.
+
+    Indexed back-to-front to match the Opentrons nozzle map: index 0 is the back-most nozzle (row
+    A, the primary/critical point) at the largest +y, descending to the front-most nozzle at -y.
+    The head8's 8 channels at 9 mm pitch span the head center by +-31.5 mm.
+    """
+    half = (8 - 1) / 2
+    return [(half - i) * 9.0 for i in range(8)]
+
+  def can_reach_position(
+    self, mount: str, position: Coordinate, channel_offset: float = 0.0
+  ) -> bool:
+    """Whether a nozzle displaced ``channel_offset`` mm in y from the head center can reach
+    ``position`` in x and y on ``mount``.
+
+    A pure predicate over the reachable region, here the single-channel deck extents for the
+    mount. For a single channel use the default
+    ``channel_offset=0``. For a head8, pass each channel's offset from :meth:`channel_y_offsets`; the
+    center must land within the extents, so near the front/back limits only a subset of channels can
+    reach, which is why an edge column is picked up partially rather than all 8. Z is not bounded by
+    deck extents and is checked separately by the motion layer.
+    """
+    x_min, x_max, y_min, y_max = self.single_channel_reach(mount)
+    center_y = position.y - channel_offset
+    return x_min <= position.x <= x_max and y_min <= center_y <= y_max

--- a/pylabrobot/resources/opentrons/ot2_geometry_tests.py
+++ b/pylabrobot/resources/opentrons/ot2_geometry_tests.py
@@ -1,0 +1,54 @@
+import unittest
+
+from pylabrobot.resources.coordinate import Coordinate
+from pylabrobot.resources.opentrons.ot2_geometry import OT2RobotGeometry
+
+
+class TestOT2RobotGeometry(unittest.TestCase):
+  """Tests for the static OT-2 robot geometry."""
+
+  def assert_bounds_almost_equal(self, actual, expected):
+    for a, e in zip(actual, expected):
+      self.assertAlmostEqual(a, e, places=4)
+
+  def test_single_channel_reach_right_mount_is_full_extents(self):
+    """Right mount (reference): reach is the full gantry extents anchored at the origin."""
+    self.assert_bounds_almost_equal(
+      OT2RobotGeometry().single_channel_reach("right"), (0.0, 446.75, 0.0, 347.5)
+    )
+
+  def test_single_channel_reach_left_mount_shifted_by_mount_offset(self):
+    """Left mount sits 34 mm left of the reference, so its x window shifts by -34 while y is
+    unchanged (the mount offset has no y component)."""
+    self.assert_bounds_almost_equal(
+      OT2RobotGeometry().single_channel_reach("left"), (-34.0, 412.75, 0.0, 347.5)
+    )
+
+  def test_can_reach_position_inside_and_outside(self):
+    """A point inside the mount's extents reaches; one past the front edge (y<0) does not."""
+    geo = OT2RobotGeometry()
+    self.assertTrue(geo.can_reach_position("right", Coordinate(265.0, 271.5, 0)))  # slot 12 corner
+    self.assertFalse(
+      geo.can_reach_position("right", Coordinate(265.0, -5.0, 0))
+    )  # in front of deck
+
+  def test_channel_y_offsets_head8_matches_opentrons_nozzle_map(self):
+    """8 channels at 9 mm pitch, indexed back-to-front: index 0 is A1 at +31.5 (the back-most,
+    primary nozzle), descending to the front-most at -31.5, matching the Opentrons nozzle map."""
+    offsets = OT2RobotGeometry().channel_y_offsets()
+    self.assertEqual(len(offsets), 8)
+    self.assertAlmostEqual(offsets[0], 31.5)
+    self.assertAlmostEqual(offsets[-1], -31.5)
+
+  def test_can_reach_position_channel_offset_partial_at_back_edge(self):
+    """Near the back limit a back-displaced channel reaches but a front-displaced one does not, so
+    a head8 engages only a subset of channels there."""
+    geo = OT2RobotGeometry()
+    target = Coordinate(265.0, 340.0, 0)
+    self.assertTrue(geo.can_reach_position("right", target, channel_offset=31.5))
+    self.assertFalse(geo.can_reach_position("right", target, channel_offset=-31.5))
+
+  def test_mount_offset_rejects_unknown_mount(self):
+    """Only 'left' and 'right' are valid mounts."""
+    with self.assertRaises(ValueError):
+      OT2RobotGeometry().mount_offset("middle")

--- a/pylabrobot/visualizer/lib.js
+++ b/pylabrobot/visualizer/lib.js
@@ -497,6 +497,12 @@ var resourceSnapshots = {}; // name -> serialized resource data
 
 var rootResource = null; // the root resource for fit-to-viewport
 
+// Find the deck by type rather than a hardcoded "deck" key: robust to the deck's name and to the
+// resource not yet being registered (returns undefined instead of throwing).
+function getDeck() {
+  return Object.values(resources).find((r) => r instanceof Deck);
+}
+
 function fitToViewport() {
   if (!rootResource || !stage) return;
   const padding = 40;
@@ -564,7 +570,7 @@ function getSnappingResourceAndLocationAndSnappingBox(resourceToSnap, x, y) {
   }
 
   // Check if the resource is in a ResourceHolder.
-  let deck = resources["deck"];
+  let deck = getDeck();
   for (let resource_name in deck.children) {
     const resource = deck.children[resource_name];
 
@@ -647,7 +653,7 @@ function getSnappingGrid(x, y, width, height) {
 
   let snappingLines = {};
 
-  const deck = resources["deck"];
+  const deck = getDeck();
   if (
     deck.constructor.name === "HamiltonSTARDeck" ||
     deck.constructor.name === "VantageDeck"
@@ -1238,45 +1244,13 @@ const otDeckSiteLocations = [
 
 class OTDeck extends Deck {
   constructor(resourceData) {
-    resourceData.location = { x: 115.65, y: 68.03 };
     super(resourceData, undefined);
   }
 
   drawMainShape() {
-    let group = new Konva.Group({});
-    const width = 128.0;
-    const height = 86.0;
-    // Draw the sites
-    for (let i = 0; i < otDeckSiteLocations.length; i++) {
-      const siteLocation = otDeckSiteLocations[i];
-      const site = new Konva.Rect({
-        x: siteLocation.x,
-        y: siteLocation.y,
-        width: width,
-        height: height,
-        fill: "white",
-        stroke: "black",
-        strokeWidth: 1,
-      });
-      group.add(site);
-
-      // Add a text label in the site
-      const siteLabel = new Konva.Text({
-        x: siteLocation.x,
-        y: siteLocation.y + height,
-        text: i + 1,
-        width: width,
-        height: height,
-        fontSize: 16,
-        fill: "black",
-        align: "center",
-        verticalAlign: "middle",
-        scaleY: -1, // Flip the text vertically
-      });
-      group.add(siteLabel);
-    }
-
-    // draw border around the deck
+    // The slot rectangles are drawn by the ResourceHolder children; the main shape is just the deck
+    // border. The slot-number labels are added in draw() so they sit on top of the holders.
+    const group = new Konva.Group({});
     group.add(
       new Konva.Rect({
         width: this.size_x,
@@ -1285,8 +1259,41 @@ class OTDeck extends Deck {
         strokeWidth: 1,
       })
     );
-
     return group;
+  }
+
+  draw(layer) {
+    super.draw(layer);
+    // Holder children are drawn after the main shape, so a slot number placed in the main shape is
+    // hidden. Add the number to the deck group last (on top) but only for empty slots, so the
+    // labware in an occupied slot is shown instead of being covered by the number.
+    for (const holder of this.children) {
+      if (!holder.location || (holder.children && holder.children.length > 0)) {
+        continue; // skip non-slot children and occupied slots
+      }
+      const match = holder.name ? holder.name.match(/slot_(\d+)$/) : null;
+      if (match === null) {
+        continue;
+      }
+      const siteLabel = new Konva.Text({
+        x: holder.location.x,
+        y: holder.location.y + holder.size_y,
+        text: match[1],
+        width: holder.size_x,
+        height: holder.size_y,
+        fontSize: 16,
+        fill: "white",
+        stroke: "black",
+        strokeWidth: 0.5,
+        fillAfterStrokeEnabled: true,
+        align: "center",
+        verticalAlign: "middle",
+        scaleY: -1, // Flip the text vertically
+        listening: false,
+      });
+      this.group.add(siteLabel);
+      siteLabel.moveToTop();
+    }
   }
 
   serialize() {
@@ -1598,7 +1605,7 @@ class Tube extends Container {
 // Nothing special.
 class Trash extends Resource {
   drawMainShape() {
-    if (resources["deck"].constructor.name) {
+    if (getDeck()) {
       return undefined;
     }
     return super.drawMainShape();


### PR DESCRIPTION
v1b1's OT-2 resources predate #1130 and #1131 on main: there is no `OT2RobotGeometry`, and the deck is still the original slots-list `OTDeck` rather than the holder-based one. This brings the resource layer forward so v1b1's OT-2 deck matches main, and ports the matching visualizer rendering and backend coordinate handling.

Adds `OT2RobotGeometry`, a frozen dataclass of the OT-2's fixed gantry extents, per-mount nozzle offsets, and head8 channel offsets, and replaces the deck with the version whose 12 slots are `ResourceHolder` children. The base classes this depends on - `Coordinate`, `ResourceHolder`, `Trash`, `OTModule` - are byte-identical on v1b1, so the carry-over is near-verbatim; the one adaptation is the deck round-trip test, which uses v1b1's `Cor_96_wellplate_360ul_Fb` since that factory predates the main naming rename.

The holder-based deck positions labware from the deck plate corner rather than slot 1's corner, so the legacy OT-2 backend is updated to match: tip pickup and drop walk up to the deck through the slot holder, and a new `_deck_to_robot_frame` subtracts slot 1's corner from the aspirate and dispense coordinates so the wire commands stay in the robot frame the motion API expects. Without this the deck change shifts every generated coordinate by slot 1's inset.

The visualizer draws each slot from its holder and labels empty slots with their number, and looks the deck up by type via `getDeck()` instead of the hardcoded `resources["deck"]` key. The type lookup is required, not cosmetic: v1b1's `Trash` renderer reads the deck through that key and throws when it is absent, so without it the OT-2 scene fails to draw. The main-only deck-surface gradient is left out because v1b1 does not define its colour constants.

Validated by running a standard single-channel OT-2 protocol against the simulator on this branch - pick up, aspirate, dispense, return - by the legacy backend command tests, and by rendering the deck in a headless browser: slots, slot numbers, labware, and the trash all draw with no console errors, and the deck border and selection highlight bound the slots correctly.

One item is left out of scope: the browser drag-to-slot snapping still uses the old fixed site coordinates rather than the holders, so it is untouched here and interactive placement is unchanged for Python-assigned protocols. The workcell tree lists slots in column order because a deck's children are sorted by x; this is identical to main (verified by rendering the same scene on both) and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
