### PR TITLE
`Visualizer`: cache idle plates and send method signatures once per class

### DIFF
--- a/pylabrobot/visualizer/lib.js
+++ b/pylabrobot/visualizer/lib.js
@@ -741,6 +741,7 @@ function getResourceWorldReferencePoint(resource, xRefStr, yRefStr, zRefStr) {
 var scaleX, scaleY;
 
 var resources = {}; // name -> Resource object
+var methodRegistry = {}; // resource type name -> public method signatures (sent once per class)
 // Serialized resource data saved before resources are destroyed (e.g. picked up by arm).
 // Used by the arm panel to re-instantiate the resource and draw it on a live Konva stage
 // using the exact same draw() code as the main canvas — guaranteeing visual consistency.
@@ -962,7 +963,10 @@ class Resource {
     this.parent = parent;
     this.resourceType = resourceData.type || this.constructor.name;
     this.category = resourceData.category || "";
-    this.methods = resourceData.methods || [];
+    // Methods are sent once per class in methodRegistry (keyed by serialized type);
+    // fall back to an inline list for backward compatibility.
+    this.methods =
+      resourceData.methods || methodRegistry[resourceData.type] || [];
     this.model = resourceData.model || null;
     this.rotation = resourceData.rotation || null;
     this.barcode = resourceData.barcode || null;

--- a/pylabrobot/visualizer/lib.js
+++ b/pylabrobot/visualizer/lib.js
@@ -297,6 +297,7 @@ function refreshScaleOverlays() {
   updateWrtBullseyeScale();
   updateTooltipScale();
   updateDeltaLinesScale();
+  requestZoomRecache();
 }
 
 function drawDeltaLines(resource) {
@@ -3577,6 +3578,9 @@ function setResourceHidden(resourceName, hidden) {
     hiddenResourceNames.delete(resourceName);
   }
   applyOwnVisibility(resources[resourceName]);
+  // A visibility change on a plate's descendant (or the plate itself) must rebuild
+  // the cached bitmap, otherwise the change would not show until the next update.
+  touchCacheOwner(resources[resourceName]);
   resourceLayer.draw();
   refreshTreeVisibilityState();
 }
@@ -3593,6 +3597,7 @@ function revealResourceAndAncestors(resource) {
     applyOwnVisibility(p);
     p = p.parent;
   }
+  touchCacheOwner(resource);
   resourceLayer.draw();
   refreshTreeVisibilityState();
 }
@@ -4165,6 +4170,9 @@ function showHoverHighlight(resourceName) {
   clearHoverHighlight();
   const resource = resources[resourceName];
   if (!resource || !resource.group) return;
+  // The highlight rects are added inside the group; if that group (or its plate)
+  // is cached the rects would not render, so uncache the owner while highlighted.
+  suspendCacheForHighlight(resource);
   // Draw both highlight rects inside the resource's Konva.Group so they inherit
   // its transform (location + rotation, chained through any rotated parents).
   // Drawing on resourceLayer with the un-rotated absolute location leaves them
@@ -4206,6 +4214,7 @@ function clearHoverHighlight() {
     sidepanelHoverRect.destroy();
     sidepanelHoverRect = null;
   }
+  resumeCacheAfterHighlight();
   resourceLayer.draw();
 }
 
@@ -5705,4 +5714,136 @@ function openAllMachineToolPanels() {
       }
     }
   }
+}
+
+// ===========================================================================
+// Idle-plate caching (performance)
+// ---------------------------------------------------------------------------
+// A whole-layer Konva redraw costs proportionally to the number of shapes on the
+// layer, so on a busy deck a single well update repaints every other plate too.
+// While a plate/tip rack is idle we cache its group to an offscreen bitmap so it
+// blits in one operation instead of re-rendering all its wells/tips. When an
+// update arrives for a plate we clear its cache (so the new fill renders live),
+// then re-cache it after a short idle. The group hierarchy is untouched, so
+// transforms, rotation, moves, and hit detection are unaffected.
+// ===========================================================================
+const CACHE_IDLE_MS = 250;              // re-cache a plate this long after its last update
+const MAX_CACHE_PIXEL_RATIO = 4;        // cap so a zoomed-in cache bitmap stays bounded in memory
+const ZOOM_RECACHE_FACTOR = 1.5;        // re-cache when we can get this much sharper than the current cache
+const _recacheTimers = new Map();       // resourceName -> idle re-cache timeout handle
+let _cachePixelRatio = null;            // pixel ratio at which current caches were built
+let _highlightCacheOwner = null;        // owner uncached to show a sidebar hover highlight
+let _zoomRecacheRAF = null;             // coalesces zoom-driven re-cache to one per frame
+
+function isCacheOwnerType(resource) {
+  return resource instanceof Plate || resource instanceof TipRack;
+}
+
+// Nearest ancestor (or self) whose group we cache as a unit.
+function getCacheOwner(resource) {
+  let r = resource;
+  while (r) {
+    if (isCacheOwnerType(r)) return r;
+    r = r.parent;
+  }
+  return null;
+}
+
+// Cache bitmap resolution tracks the on-screen device pixels per mm (stage scale times
+// the display's device pixel ratio) so an idle cached plate stays as sharp as a live one,
+// capped to bound bitmap memory (matters most on low-RAM hosts such as a Raspberry Pi).
+function currentCachePixelRatio() {
+  const scale = (typeof stage !== "undefined" && stage) ? Math.abs(stage.scaleX()) : 1;
+  const dpr = (typeof window !== "undefined" && window.devicePixelRatio) || 1;
+  return Math.min(MAX_CACHE_PIXEL_RATIO, Math.max(1, scale * dpr));
+}
+
+function cacheResourceGroup(resource) {
+  if (!resource || !resource.group) return;
+  if (hiddenResourceNames.has(resource.name)) return; // don't freeze a hidden item visible
+  try {
+    if (!resource.group.isCached()) {
+      resource.group.cache({ pixelRatio: currentCachePixelRatio() });
+    }
+  } catch (e) {
+    // group may not be renderable yet (zero size); skip silently
+  }
+}
+
+function uncacheResourceGroup(resource) {
+  if (resource && resource.group && resource.group.isCached()) {
+    resource.group.clearCache();
+  }
+}
+
+// Clear the cache now (so a pending update renders live), then re-cache after idle.
+function markCacheOwnerActive(resource) {
+  if (!resource || !resource.group) return;
+  uncacheResourceGroup(resource);
+  const name = resource.name;
+  if (_recacheTimers.has(name)) clearTimeout(_recacheTimers.get(name));
+  _recacheTimers.set(name, setTimeout(() => {
+    _recacheTimers.delete(name);
+    if (resources[name] === resource) {
+      cacheResourceGroup(resource);
+      resourceLayer.batchDraw();
+    }
+  }, CACHE_IDLE_MS));
+}
+
+// Uncache the owner of `resource` and schedule its re-cache. Used by callers that
+// mutate a plate's contents outside the set_state path (e.g. per-item visibility).
+function touchCacheOwner(resource) {
+  markCacheOwnerActive(getCacheOwner(resource));
+}
+
+function cacheAllIdleOwners() {
+  for (const name in resources) {
+    const r = resources[name];
+    if (isCacheOwnerType(r) && !_recacheTimers.has(name)) cacheResourceGroup(r);
+  }
+  _cachePixelRatio = currentCachePixelRatio();
+  resourceLayer.batchDraw();
+}
+
+// Uncache the owner of a hovered resource so a sidebar highlight (drawn inside the
+// group) is visible; the owner is re-cached when the highlight clears.
+function suspendCacheForHighlight(resource) {
+  const owner = getCacheOwner(resource);
+  if (!owner || !owner.group) return;
+  if (_recacheTimers.has(owner.name)) { clearTimeout(_recacheTimers.get(owner.name)); _recacheTimers.delete(owner.name); }
+  uncacheResourceGroup(owner);
+  _highlightCacheOwner = owner;
+}
+
+function resumeCacheAfterHighlight() {
+  if (_highlightCacheOwner) {
+    const owner = _highlightCacheOwner;
+    _highlightCacheOwner = null;
+    if (resources[owner.name] === owner) markCacheOwnerActive(owner);
+  }
+}
+
+// On zoom-in past the resolution the caches were built at, rebuild them sharper.
+// Coalesced to one pass per frame; skips owners that are actively updating or highlighted.
+function requestZoomRecache() {
+  if (_zoomRecacheRAF !== null || typeof stage === "undefined" || !stage) return;
+  _zoomRecacheRAF = requestAnimationFrame(function () {
+    _zoomRecacheRAF = null;
+    if (_cachePixelRatio === null) return;
+    const target = currentCachePixelRatio();
+    // Only rebuild when we can get meaningfully sharper; this also no-ops once the
+    // pixel ratio is capped (target stops growing), so zooming further in is free.
+    if (target <= _cachePixelRatio * ZOOM_RECACHE_FACTOR) return;
+    const highlightedName = _highlightCacheOwner && _highlightCacheOwner.name;
+    for (const name in resources) {
+      const r = resources[name];
+      if (isCacheOwnerType(r) && !_recacheTimers.has(name) && name !== highlightedName) {
+        uncacheResourceGroup(r);
+        cacheResourceGroup(r);
+      }
+    }
+    _cachePixelRatio = target;
+    resourceLayer.batchDraw();
+  });
 }

--- a/pylabrobot/visualizer/vis.js
+++ b/pylabrobot/visualizer/vis.js
@@ -25,6 +25,9 @@ function updateStatusLabel(status) {
 }
 
 function setRootResource(data) {
+  // Method signatures arrive once per class; make them available before the tree is
+  // built so each Resource can attach its methods by type.
+  methodRegistry = data.method_registry || {};
   resource = loadResource(data.resource);
 
   resource.location = { x: 0, y: 0, z: 0 };
@@ -84,6 +87,7 @@ async function processCentralEvent(event, data) {
       break;
 
     case "resource_assigned":
+      Object.assign(methodRegistry, data.method_registry || {});
       resource = loadResource(data.resource);
       resource.draw(resourceLayer);
       setState(data.state);

--- a/pylabrobot/visualizer/vis.js
+++ b/pylabrobot/visualizer/vis.js
@@ -36,6 +36,9 @@ function setRootResource(data) {
   fitToViewport();
 
   buildResourceTree(resource);
+
+  // Cache idle plates/tip racks so subsequent updates don't repaint them.
+  cacheAllIdleOwners();
 }
 
 // Save the full serialized resource data before it is destroyed.
@@ -85,6 +88,8 @@ async function processCentralEvent(event, data) {
       resource.draw(resourceLayer);
       setState(data.state);
       addResourceToTree(resource);
+      // Cache the newly-assigned plate/tip rack (or the owner it landed in).
+      cacheResourceGroup(getCacheOwner(resource));
       break;
 
     case "resource_unassigned":
@@ -98,7 +103,16 @@ async function processCentralEvent(event, data) {
 
     case "set_state":
       let allStates = data;
+      // Clear the cache on each affected plate/tip rack so the update renders live,
+      // then re-cache it once it goes idle (handled by markCacheOwnerActive).
+      let activeOwners = new Set();
+      for (let resourceName in allStates) {
+        let owner = getCacheOwner(resources[resourceName]);
+        if (owner) activeOwners.add(owner);
+      }
+      activeOwners.forEach(uncacheResourceGroup);
       setState(allStates);
+      activeOwners.forEach(markCacheOwnerActive);
       // Update only the affected sidepanel nodes instead of rebuilding the entire
       // tree. Wells/tip spots/tubes all refresh their parent's summary, so dedupe
       // by target node to avoid recomputing the same plate/rack summary once per

--- a/pylabrobot/visualizer/visualizer.py
+++ b/pylabrobot/visualizer/visualizer.py
@@ -50,12 +50,32 @@ def _get_public_methods(cls: type) -> list:
   return sorted(methods)
 
 
-def _serialize_with_methods(resource: Resource) -> dict:
-  """Serialize a resource and enrich with Python method signatures for the visualizer."""
+def _serialize_resource_tree(resource: Resource) -> dict:
+  """Serialize a resource and its children for the visualizer.
+
+  Method signatures are not embedded per node; identical for every instance of a class,
+  they are sent once per class via :func:`_build_method_registry` and attached by type in
+  the browser. On a full deck this avoids repeating the same signature list on every well.
+  """
   data = resource.serialize()
-  data["methods"] = _get_public_methods(type(resource))  # type: ignore[arg-type]
-  data["children"] = [_serialize_with_methods(child) for child in resource.children]
+  data["children"] = [_serialize_resource_tree(child) for child in resource.children]
   return data
+
+
+def _build_method_registry(resource: Resource, registry: Optional[dict] = None) -> dict:
+  """Map each resource class name in the tree to its public method signatures.
+
+  The serialized ``type`` of a resource is its class name, so the browser can look up a
+  node's methods by ``type`` instead of receiving the same list on every node.
+  """
+  if registry is None:
+    registry = {}
+  type_name = type(resource).__name__
+  if type_name not in registry:
+    registry[type_name] = _get_public_methods(type(resource))  # type: ignore[arg-type]
+  for child in resource.children:
+    _build_method_registry(child, registry)
+  return registry
 
 
 def _sanitize_floats(obj):
@@ -627,7 +647,10 @@ class Visualizer:
     # send the serialized root resource (including all children) to the browser
     await self.send_command(
       "set_root_resource",
-      {"resource": _serialize_with_methods(self._root_resource)},
+      {
+        "resource": _serialize_resource_tree(self._root_resource),
+        "method_registry": _build_method_registry(self._root_resource),
+      },
       wait_for_response=False,
     )
 
@@ -666,7 +689,8 @@ class Visualizer:
 
     # Send a `resource_assigned` event to the browser.
     data = {
-      "resource": _serialize_with_methods(resource),
+      "resource": _serialize_resource_tree(resource),
+      "method_registry": _build_method_registry(resource),
       "state": resource.serialize_all_state(),
       "parent_name": (resource.parent.name if resource.parent else None),
     }

--- a/pylabrobot/visualizer/visualizer_tests.py
+++ b/pylabrobot/visualizer/visualizer_tests.py
@@ -14,7 +14,11 @@ from pylabrobot.resources import (
   cor_96_wellplate_360uL_Fb,
 )
 from pylabrobot.visualizer import Visualizer
-from pylabrobot.visualizer.visualizer import _sanitize_floats, _serialize_with_methods
+from pylabrobot.visualizer.visualizer import (
+  _build_method_registry,
+  _sanitize_floats,
+  _serialize_resource_tree,
+)
 
 
 class SanitizeFloatsTests(unittest.TestCase):
@@ -150,7 +154,8 @@ class VisualizerServerTests(unittest.IsolatedAsyncioTestCase):
       {
         "event": "set_root_resource",
         "data": {
-          "resource": _serialize_with_methods(self.r),
+          "resource": _serialize_resource_tree(self.r),
+          "method_registry": _build_method_registry(self.r),
         },
         "id": "0001",
         "version": STANDARD_FORM_JSON_VERSION,
@@ -215,7 +220,8 @@ class VisualizerCommandTests(unittest.IsolatedAsyncioTestCase):
     self.vis.send_command.assert_called_once_with(  # type: ignore[attr-defined]
       event="resource_assigned",
       data={
-        "resource": _serialize_with_methods(child),
+        "resource": _serialize_resource_tree(child),
+        "method_registry": _build_method_registry(child),
         "state": child.serialize_all_state(),
         "parent_name": "root",
       },


### PR DESCRIPTION
## Motivation

On a busy deck the visualizer became expensive in two places, both of which are felt most on low-power hosts such as a Raspberry Pi: a live update stutters during a run, and the first connect is slow. This PR addresses both, with no change to what the user sees.

## Idle-plate caching (runtime cost)

A whole-layer Konva redraw costs in proportion to the number of shapes on the layer, so after the recent change that forwards volume updates to the visualizer, a single well update repaints every other plate and tip rack on the deck. On a six-plate deck, updating one plate's 96 wells measured about 4.6 ms per frame.

While a plate or tip rack is idle its group is cached to an offscreen bitmap, so it blits in one operation instead of re-rendering all its wells or tips. When a state update arrives for a plate its cache is cleared so the change renders live, and it is re-cached once it has been idle briefly. The group hierarchy is untouched, so transforms, rotation, moves, and hit detection are unaffected. The same six-plate update drops to about 0.55 ms and, more importantly, stays flat as the deck grows.

The cache resolution tracks the on-screen device pixels so an idle plate stays as sharp as a live one, and is rebuilt sharper when the user zooms in. Sidebar hover highlights and per-item visibility toggles clear the affected plate's cache so their changes show immediately, then re-cache when idle.

## Method signatures once per class (startup cost)

The initial resource message attached the full list of Python method signatures to every resource, so a plate repeated the same list on all 96 of its wells. This is the largest single cost at connect, and the browser must parse the whole blob before the first paint.

Signatures are identical for every instance of a class, so they are now sent once in a registry keyed by resource type; the browser attaches the matching signatures by type when it builds the tree. On a six-plate, six-tip-rack deck this shrinks the payload from about 2.7 MB to 0.77 MB (roughly 3.5x smaller). The UML method panel is populated exactly as before.

## Testing

Existing visualizer tests pass (updated for the new message shape). Verified through a headless browser driving the real websocket: the cache lifecycle is correct (idle plates cached, active plate live, re-cached after idle, no stale bitmap); hit detection still works over cached plates; zoom, hover-highlight, and per-item visibility behave correctly; a real liquid-handling flow (tip pickup, aspirate, dispense) renders correctly with both changes active; and method signatures attach in the browser via the registry.
