### PR TITLE
`STARBackend`: reject aspirations whose pre-wetting or transport-air peak overfills the tip

### DIFF
--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_backend.py
@@ -3479,6 +3479,27 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
         f"Well bottom: {well_bottoms}, liquid height: {liquid_heights}, surface_following_distance: {surface_following_distance}, minimum_height: {minimum_height}"
       )
 
+    # A tip fills to one of two transient peaks that never coexist: volume + pre_wetting
+    # (pre-wet over-aspiration) and volume + transport_air (air gap drawn above the liquid);
+    # blow-out air counts toward neither.
+    over_capacity = []
+    for i, op in enumerate(ops):
+      for label, extra in (
+        ("pre-wetting", pre_wetting_volume[i]),
+        ("transport-air", transport_air_volume[i]),
+      ):
+        peak = volumes[i] + extra
+        if peak > op.tip.maximal_volume:
+          over_capacity.append((i, label, peak, op.tip.maximal_volume))
+    if over_capacity:
+      raise ValueError(
+        "Aspiration would exceed tip capacity: "
+        + "; ".join(
+          f"channel {i} {label} peak {peak:.1f} uL > tip maximal volume {tip_max:.1f} uL"
+          for i, label, peak, tip_max in over_capacity
+        )
+      )
+
     try:
       return await self.aspirate_pip(
         aspiration_type=[0 for _ in range(n)],

--- a/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
+++ b/pylabrobot/liquid_handling/backends/hamilton/STAR_tests.py
@@ -988,6 +988,41 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
       ]
     )
 
+  async def test_aspirate_rejects_over_tip_capacity(self):
+    self.lh.update_head_state({0: self.tip_rack.get_tip("A1")})  # 300 uL filter tip, max 360
+    assert self.plate.lid is not None
+    self.plate.lid.unassign()
+    well = self.plate.get_item("A1")
+    # pre-wetting peak (volume + pre_wetting) exceeds the tip max
+    well.tracker.set_volume(300)
+    with self.assertRaises(ValueError):
+      await self.lh.aspirate([well], vols=[100], pre_wetting_volume=[300])
+    # transport-air peak (volume + transport_air) exceeds the tip max
+    well.tracker.set_volume(300)
+    with self.assertRaises(ValueError):
+      await self.lh.aspirate([well], vols=[100], transport_air_volume=[300])
+
+  async def test_aspirate_capacity_ignores_blow_out(self):
+    self.lh.update_head_state({0: self.tip_rack.get_tip("A1")})  # 300 uL filter tip, max 360
+    assert self.plate.lid is not None
+    self.plate.lid.unassign()
+    well = self.plate.get_item("A1")
+    well.tracker.set_volume(200)
+    # blow-out counts toward neither peak, so a large blow-out stays within capacity
+    await self.lh.aspirate([well], vols=[100], blow_out_air_volume=[300])
+
+  async def test_aspirate_capacity_boundary_is_exclusive(self):
+    self.lh.update_head_state({0: self.tip_rack.get_tip("A1")})  # 300 uL filter tip, max 360
+    assert self.plate.lid is not None
+    self.plate.lid.unassign()
+    well = self.plate.get_item("A1")
+    # a peak exactly at the tip's maximal volume is allowed; just above it is rejected (>)
+    well.tracker.set_volume(400)
+    await self.lh.aspirate([well], vols=[360], disable_volume_correction=[True])
+    well.tracker.set_volume(400)
+    with self.assertRaises(ValueError):
+      await self.lh.aspirate([well], vols=[361], disable_volume_correction=[True])
+
   async def test_single_channel_aspiration_liquid_height(self):
     self.lh.update_head_state({0: self.tip_rack.get_tip("A1")})
     # TODO: Hamilton liquid classes


### PR DESCRIPTION
An aspiration whose transient tip fill reaches the tip's maximal volume is caught only by the firmware, with the opaque `Maximum volume in tip reached` error, and only after the channel has already travelled to the well. `STARBackend.aspirate` builds and sends the command with no client-side capacity check, so a caller gets a cryptic wire error at run time on hardware instead of a clear, actionable one.

It turns out that there are actually at least 2 _different_ types of volume in tip overflow that can cause the same firmware error:

1. `volume + pre_wetting` (pre-wet over-aspiration) 
2. `volume + transport_air` (the air gap drawn above the liquid after the tip leaves it).
 
The firmware rejects when either reaches the tip max -> interestingly, blow-out air sits at the top throughout and counts toward neither peak!

- `STARBackend.aspirate` now checks each channel's two peak volumes against `tip.maximal_volume` before assembling the firmware command, and raises `ValueError` naming every peak on every channel that reaches it - so a caller sees all offending peaks at once, not just the first channel or the larger of a channel's two peaks.
- Blow-out air volume is excluded, matching the firmware.
The bound is exclusive (`>`): a peak equal to the tip's maximal volume is allowed.

Behaviour:
purely additive for in-capacity aspirations, which is the common case since callers keep within the tip - no wire change, no new default.
Over-capacity aspirations now raise a clear `ValueError` client-side instead of surfacing the firmware error after the channel has moved.
The guard is on the channel `aspirate` path only; `aspirate96` is unchanged.

Tests: adds `test_aspirate_rejects_over_tip_capacity` (pre-wet and transport peaks each trip the guard), `test_aspirate_capacity_ignores_blow_out` (a large blow-out stays within capacity), and `test_aspirate_capacity_boundary_is_exclusive` (a peak exactly at the tip max is allowed, just above is rejected); the existing STAR command suite passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

