### PR TITLE
feat(kbiosystems): add Ultraseal XT Pro driver and share a base sealer class

### DIFF
--- a/docs/api/pylabrobot.kbiosystems.rst
+++ b/docs/api/pylabrobot.kbiosystems.rst
@@ -3,6 +3,16 @@
 pylabrobot.kbiosystems package
 ==============================
 
+.. currentmodule:: pylabrobot.kbiosystems.sealer
+
+.. autosummary::
+  :toctree: _autosummary
+  :nosignatures:
+  :recursive:
+
+    KBiosystemsSealer
+    KBiosystemsError
+
 .. currentmodule:: pylabrobot.kbiosystems.ultraseal_epro
 
 .. autosummary::
@@ -12,4 +22,13 @@ pylabrobot.kbiosystems package
 
     KBiosystemsUltrasealEPRO
     UltrasealEPROStatus
-    KBiosystemsError
+
+.. currentmodule:: pylabrobot.kbiosystems.ultraseal_xt_pro
+
+.. autosummary::
+  :toctree: _autosummary
+  :nosignatures:
+  :recursive:
+
+    KBiosystemsUltrasealXTPro
+    UltrasealXTProStatus

--- a/docs/user_guide/kbiosystems/index.md
+++ b/docs/user_guide/kbiosystems/index.md
@@ -4,4 +4,5 @@
 :maxdepth: 1
 
 ultraseal-epro/hello-world
+ultraseal-xt-pro/hello-world
 ```

--- a/docs/user_guide/kbiosystems/ultraseal-xt-pro/hello-world.ipynb
+++ b/docs/user_guide/kbiosystems/ultraseal-xt-pro/hello-world.ipynb
@@ -1,0 +1,112 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ultraseal-xt-pro-intro",
+   "source": "# KBiosystems Ultraseal XT Pro\n\nThe Ultraseal XT Pro is an inline, pneumatically driven heat sealer for microplates from KBiosystems, controlled over an RS-232 serial interface. It advances and cuts its own film internally and has no foil-length, force, or distance parameters. It requires a compressed air supply.\n\n| Property | Value |\n|---|---|\n| [OEM link](https://www.kbiosystems.com/product/ultraseal-xt-pro) | |\n| Communication | Serial / RS-232, ASCII command protocol |\n| Serial settings | 9600 baud, 8 data bits, no parity, 1 stop bit, no handshake |\n| Terminator | CR (`\\r`) |\n| Temperature | 25-199 °C |\n| Sealing time | 0.5-9.9 s |\n\n```{warning}\nThis driver has NOT been tested against hardware in PyLabRobot. If you verify\nit on a sealer, please open a PR to remove the not-tested warning.\n```",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ultraseal-xt-pro-setup-md",
+   "source": "## Physical setup\n\nConnect the sealer's RS-232 port to your computer, typically through a USB-to-serial adapter, and connect the compressed air supply. Make sure the sealer's serial parameters match the driver defaults (9600 baud, 8 data bits, no parity, 1 stop bit, no handshake).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ultraseal-xt-pro-connect-md",
+   "source": "## Connect\n\n`setup()` opens the serial port, waits for the device to be ready, and pre-heats to the preheating temperature. It also logs the not-tested warning.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "ultraseal-xt-pro-connect-code",
+   "source": "from pylabrobot.kbiosystems import KBiosystemsUltrasealXTPro\n\nsealer = KBiosystemsUltrasealXTPro(port=\"/dev/ttyUSB0\")  # replace with your port\nawait sealer.setup()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ultraseal-xt-pro-shuttle-md",
+   "source": "## Present and retract a plate\n\nThe XT Pro seals a plate held on its shuttle. Move the shuttle out to let a mover place a plate, then move it back in before sealing.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "ultraseal-xt-pro-shuttle-code",
+   "source": "await sealer.move_shuttle_out()  # present the nest for loading\n# ... a mover places a plate ...\nawait sealer.move_shuttle_in()   # retract for sealing",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ultraseal-xt-pro-seal-md",
+   "source": "## Seal a plate\n\n`seal()` applies the time and temperature, waits for the heater to reach the setpoint, seals the plate, then returns to the idle temperature. Sealing time is 0.5-9.9 s; temperature is 25-199 °C.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "ultraseal-xt-pro-seal-code",
+   "source": "await sealer.seal(temperature=170, duration=2.5)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ultraseal-xt-pro-temp-md",
+   "source": "## Temperature\n\nSet the sealing temperature setpoint and read the current heater temperature.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "ultraseal-xt-pro-temp-code",
+   "source": "await sealer.set_temperature(160)\nprint(\"Current temperature:\", await sealer.request_temperature(), \"C\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ultraseal-xt-pro-status-md",
+   "source": "## Status\n\nRead the status byte as a set of flags. On the XT Pro this includes `LowAir`, which indicates the compressed air supply is insufficient.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "ultraseal-xt-pro-status-code",
+   "source": "print(\"Status:\", await sealer.request_status())",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ultraseal-xt-pro-teardown-md",
+   "source": "## Teardown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "ultraseal-xt-pro-teardown-code",
+   "source": "await sealer.stop()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pylabrobot/kbiosystems/__init__.py
+++ b/pylabrobot/kbiosystems/__init__.py
@@ -1,5 +1,3 @@
-from .ultraseal_epro import (
-  KBiosystemsError,
-  KBiosystemsUltrasealEPRO,
-  UltrasealEPROStatus,
-)
+from .sealer import KBiosystemsError, KBiosystemsSealer
+from .ultraseal_epro import KBiosystemsUltrasealEPRO, UltrasealEPROStatus
+from .ultraseal_xt_pro import KBiosystemsUltrasealXTPro, UltrasealXTProStatus

--- a/pylabrobot/kbiosystems/sealer.py
+++ b/pylabrobot/kbiosystems/sealer.py
@@ -1,0 +1,274 @@
+import asyncio
+import enum
+import logging
+import time
+from typing import Dict, Optional, Type
+
+from pylabrobot.io.serial import Serial
+
+logger = logging.getLogger(__name__)
+
+
+class KBiosystemsError(Exception):
+  """Error raised by a KBiosystems heat sealer."""
+
+  def __init__(
+    self,
+    title: str,
+    message: Optional[str] = None,
+    status: Optional[enum.IntFlag] = None,
+    error_code: Optional[int] = None,
+  ) -> None:
+    self.title = title
+    self.message = message
+    self.status = status
+    self.error_code = error_code
+
+  def __str__(self) -> str:
+    return f"{self.title}: {self.message}" if self.message else self.title
+
+
+class KBiosystemsSealer:
+  """Shared base for KBiosystems serial heat sealers (Ultraseal ePRO / XT Pro).
+
+  Every model speaks the same ASCII-over-RS-232 core: a command is written with
+  a CR terminator, the device echoes the command in front of its reply, and the
+  echo is stripped before the reply is parsed (e.g. ``A160`` -> ``A160ok`` ->
+  ``ok``; ``?`` -> ``?3f`` -> ``3f``). A reply containing ``syntax`` means the
+  command was rejected. This base implements the transport, the status/error
+  polling state machine, and the temperature and time commands shared by all
+  models. Subclasses supply the model-specific status flags, error table,
+  temperature limits, human-readable name, ``setup``, ``seal``, and any extra
+  commands.
+
+  Serial settings: 9600 baud, 8 data bits, no parity, 1 stop bit, no handshake,
+  CR (``\\r``) terminator.
+  """
+
+  # Human-readable device name, used for the serial handle. Overridden per model.
+  _HUMAN_READABLE_NAME: str = "KBiosystems Heat Sealer"
+
+  # Status flag enum returned by ``?``. Overridden per model.
+  STATUS: Type[enum.IntFlag]
+  # Description for each status bit, used to explain a not-ready condition.
+  STATUS_MESSAGES: Dict[enum.IntFlag, str]
+  # Text for each numeric error code returned by ``E``.
+  ERRORS: Dict[int, str]
+
+  # The low status bits are identical across every model, so the state machine
+  # below works against them directly rather than the per-model enum.
+  _READY = 0x00
+  _ERROR = 0x02
+  _BUSY = 0x04
+  _NOT_AT_SEAL_TEMPERATURE = 0x08
+
+  MIN_SEALING_TEMPERATURE: int
+  MAX_SEALING_TEMPERATURE: int
+  MIN_SEALING_DURATION: float = 0.5
+  MAX_SEALING_DURATION: float = 9.9
+
+  def __init__(
+    self,
+    port: str,
+    timeout: float = 5.0,
+    settle_time: float = 5.0,
+    preheating_temperature: int = 100,
+    offline_temperature: int = 20,
+  ) -> None:
+    self.timeout = timeout
+    self.settle_time = settle_time
+    self.preheating_temperature = preheating_temperature
+    self.offline_temperature = offline_temperature
+    self.io = Serial(
+      human_readable_device_name=self._HUMAN_READABLE_NAME,
+      port=port,
+      baudrate=9600,
+      bytesize=8,
+      parity="N",
+      stopbits=1,
+      timeout=0.2,
+    )
+
+  async def _open(self) -> None:
+    """Open the port, wait out the post-open settling, and clear the buffer.
+
+    Emits the not-tested warning: no KBiosystems sealer driver has been verified
+    against hardware in PyLabRobot yet.
+    """
+    logger.warning(
+      "%s has NOT been tested against hardware in PyLabRobot. Please make a PR "
+      "to remove this message if you have verified it on your hardware.",
+      type(self).__name__,
+    )
+    await self.io.setup()
+    # The device drops characters for a few seconds after the port opens.
+    await asyncio.sleep(self.settle_time)
+    await self.io.reset_input_buffer()
+
+  async def stop(self) -> None:
+    """Return the heater to the offline temperature and close the port."""
+    try:
+      await self.set_temperature(self.offline_temperature)
+    except (KBiosystemsError, TimeoutError) as e:
+      logger.warning("[%s] could not set offline temperature: %s", self.io.port, e)
+    await self.io.stop()
+
+  # === Command layer ===
+
+  async def _read_line(self) -> str:
+    """Read bytes until a CR terminator, skipping stray LF."""
+    start = time.time()
+    buf = bytearray()
+    while True:
+      b = await self.io.read(1)
+      if b == b"":
+        if time.time() - start > self.timeout:
+          raise TimeoutError("Timeout while waiting for response from sealer.")
+        continue
+      if b == b"\r":
+        break
+      if b == b"\n":
+        continue
+      buf += b
+    return buf.decode("ascii", errors="replace")
+
+  async def send_command(self, command: str, read_reply: bool = True) -> str:
+    """Send a command and return the reply with the echoed command stripped.
+
+    Args:
+      command: command string without the CR terminator, e.g. "A160", "?".
+      read_reply: if False, do not read a reply (used for commands that send none).
+    """
+    await self.io.reset_input_buffer()
+    await self.io.write((command + "\r").encode("ascii"))
+    await asyncio.sleep(0.2)
+    if not read_reply:
+      return ""
+    text = await self._read_line()
+    if "syntax" in text:
+      return text
+    # The device echoes the command; an empty command trims whitespace only.
+    return text.lstrip(command) if command else text.strip()
+
+  def _check(self, reply: str, allowed: set, command: str) -> str:
+    if reply not in allowed or "syntax" in reply:
+      raise KBiosystemsError(
+        title="Unexpected response", message=f"command {command!r} returned {reply!r}"
+      )
+    return reply
+
+  # === State ===
+
+  async def request_status(self) -> enum.IntFlag:
+    """Read the status byte (``?``)."""
+    reply = await self.send_command("?")
+    try:
+      return self.STATUS(int(reply, 16))
+    except ValueError as e:
+      raise KBiosystemsError(title="Unexpected status reply", message=repr(reply)) from e
+
+  async def request_error_code(self) -> int:
+    """Read the current error code (``E``)."""
+    reply = await self.send_command("E")
+    try:
+      return int(reply)
+    except ValueError as e:
+      raise KBiosystemsError(title="Unexpected error reply", message=repr(reply)) from e
+
+  async def wait_for_idle(self, ignore_mask: Optional[enum.IntFlag] = None) -> enum.IntFlag:
+    """Wait until the device is Ready, tolerating the bits set in ``ignore_mask``.
+
+    Raises KBiosystemsError if any bit outside ``ignore_mask`` is set; if the
+    Error bit is set, the error code and text are attached.
+    """
+    mask = self._READY if ignore_mask is None else int(ignore_mask)
+
+    status = await self.request_status()
+    while status != self._READY:
+      if status & self._BUSY:
+        await asyncio.sleep(0.5)
+        status = await self._wait_for_busy_cleared()
+        continue
+
+      # While heating, the device also reports Busy; ignore it alongside
+      # NotAtSealTemperature so waiting for temperature does not raise.
+      if mask & self._NOT_AT_SEAL_TEMPERATURE and status & self._NOT_AT_SEAL_TEMPERATURE:
+        mask = mask | self._BUSY
+
+      remaining = status & ~mask
+      if remaining == self._READY:
+        break
+
+      description = ", ".join(m for bit, m in self.STATUS_MESSAGES.items() if remaining & bit)
+      if remaining & self._ERROR:
+        code = await self.request_error_code()
+        raise KBiosystemsError(
+          title=f"Sealer error: {description}",
+          message=self.ERRORS.get(code),
+          status=remaining,
+          error_code=code,
+        )
+      raise KBiosystemsError(title=f"Sealer not ready: {description}", status=remaining)
+    return status
+
+  async def _wait_for_busy_cleared(self, timeout: float = 60.0) -> enum.IntFlag:
+    start = time.time()
+    status = await self.request_status()
+    while status & self._BUSY:
+      if time.time() - start > timeout:
+        raise KBiosystemsError(title="Timeout while waiting for busy flag to clear")
+      await asyncio.sleep(0.5)
+      status = await self.request_status()
+    return status
+
+  async def wait_for_sealing_temperature(self, timeout: float = 300.0) -> None:
+    """Block until the heater reaches the setpoint (NotAtSealTemperature clears)."""
+    start = time.time()
+    while await self.request_status() & self._NOT_AT_SEAL_TEMPERATURE:
+      if time.time() - start > timeout:
+        raise TimeoutError("Timeout while waiting for sealing temperature.")
+      await asyncio.sleep(5.0)
+
+  # === Parameters ===
+
+  async def set_temperature(self, temperature: int) -> None:
+    """Set the sealing temperature in degrees C (``A``)."""
+    if not self.MIN_SEALING_TEMPERATURE <= temperature <= self.MAX_SEALING_TEMPERATURE:
+      raise ValueError(
+        f"temperature must be {self.MIN_SEALING_TEMPERATURE}..{self.MAX_SEALING_TEMPERATURE} C"
+      )
+    command = f"A{temperature:03d}"
+    self._check(await self.send_command(command), {"ok"}, command)
+    # The firmware needs a moment to accept the new setpoint.
+    await asyncio.sleep(3.0)
+
+  async def set_sealing_time(self, seconds: float) -> None:
+    """Set the sealing time in seconds (``B``)."""
+    if not self.MIN_SEALING_DURATION <= seconds <= self.MAX_SEALING_DURATION:
+      raise ValueError(f"time must be {self.MIN_SEALING_DURATION}..{self.MAX_SEALING_DURATION} s")
+    command = f"B{int(seconds * 10):02d}"
+    self._check(await self.send_command(command), {"ok"}, command)
+
+  async def request_sealing_temperature(self) -> int:
+    """Read the sealing temperature setpoint in degrees C (``C``)."""
+    reply = await self.send_command("C")
+    try:
+      return int(reply)
+    except ValueError as e:
+      raise KBiosystemsError(title="Unexpected temperature reply", message=repr(reply)) from e
+
+  async def request_sealing_time(self) -> float:
+    """Read the sealing time setpoint in seconds (``D``)."""
+    reply = await self.send_command("D")
+    try:
+      return int(reply) / 10.0
+    except ValueError as e:
+      raise KBiosystemsError(title="Unexpected time reply", message=repr(reply)) from e
+
+  async def request_temperature(self) -> int:
+    """Read the current heater temperature in degrees C (``F``)."""
+    reply = await self.send_command("F")
+    try:
+      return int(reply)
+    except ValueError as e:
+      raise KBiosystemsError(title="Unexpected temperature reply", message=repr(reply)) from e

--- a/pylabrobot/kbiosystems/sealer.py
+++ b/pylabrobot/kbiosystems/sealer.py
@@ -1,3 +1,4 @@
+import abc
 import asyncio
 import enum
 import logging
@@ -28,7 +29,7 @@ class KBiosystemsError(Exception):
     return f"{self.title}: {self.message}" if self.message else self.title
 
 
-class KBiosystemsSealer:
+class KBiosystemsSealer(abc.ABC):
   """Shared base for KBiosystems serial heat sealers (Ultraseal ePRO / XT Pro).
 
   Every model speaks the same ASCII-over-RS-232 core: a command is written with
@@ -88,6 +89,16 @@ class KBiosystemsSealer:
       stopbits=1,
       timeout=0.2,
     )
+
+  # === Subclass contract ===
+
+  @abc.abstractmethod
+  async def setup(self) -> None:
+    """Open the connection and bring the sealer to a ready, pre-heated state."""
+
+  @abc.abstractmethod
+  async def seal(self, temperature: int, duration: float) -> None:
+    """Seal a plate at the given sealing temperature (C) and duration (s)."""
 
   async def _open(self) -> None:
     """Open the port, wait out the post-open settling, and clear the buffer.

--- a/pylabrobot/kbiosystems/sealer_tests.py
+++ b/pylabrobot/kbiosystems/sealer_tests.py
@@ -176,6 +176,10 @@ class TestSharedBase(unittest.TestCase):
     self.assertTrue(issubclass(KBiosystemsUltrasealEPRO, KBiosystemsSealer))
     self.assertTrue(issubclass(KBiosystemsUltrasealXTPro, KBiosystemsSealer))
 
+  def test_base_is_abstract(self):
+    with self.assertRaises(TypeError):
+      KBiosystemsSealer(port="FAKE")  # setup/seal are abstract
+
   def test_shared_low_status_bits(self):
     # The state machine in the base relies on these being identical.
     for bit in ("Ready", "NoFoil", "Error", "Busy", "NotAtSealTemperature", "PlateNotPresent"):

--- a/pylabrobot/kbiosystems/sealer_tests.py
+++ b/pylabrobot/kbiosystems/sealer_tests.py
@@ -1,0 +1,188 @@
+import unittest
+from typing import Dict, List
+from unittest.mock import AsyncMock, patch
+
+from pylabrobot.kbiosystems import (
+  KBiosystemsError,
+  KBiosystemsSealer,
+  KBiosystemsUltrasealEPRO,
+  KBiosystemsUltrasealXTPro,
+  UltrasealEPROStatus,
+  UltrasealXTProStatus,
+)
+
+
+class FakeSealerSerial:
+  """In-memory serial stand-in that mimics the sealer's echo protocol.
+
+  On ``write(command + "\\r")`` it records the command and, if a reply body is
+  configured for it, queues ``command + body + "\\r"`` to be read back - exactly
+  like the device, which echoes the command in front of its reply.
+  """
+
+  def __init__(self, responses: Dict[str, str]) -> None:
+    self.responses = responses
+    self.port = "FAKE"
+    self.written: List[str] = []
+    self._rx = bytearray()
+
+  async def setup(self) -> None:
+    pass
+
+  async def stop(self) -> None:
+    pass
+
+  async def reset_input_buffer(self) -> None:
+    self._rx.clear()
+
+  async def write(self, data: bytes) -> None:
+    command = data.decode("ascii").rstrip("\r")
+    self.written.append(command)
+    if command in self.responses:
+      self._rx += (command + self.responses[command] + "\r").encode("ascii")
+
+  async def read(self, num_bytes: int = 1) -> bytes:
+    if not self._rx:
+      return b""
+    out = bytes(self._rx[:num_bytes])
+    del self._rx[:num_bytes]
+    return out
+
+
+class KBiosystemsSealerTestBase(unittest.IsolatedAsyncioTestCase):
+  async def asyncSetUp(self) -> None:
+    # Skip the firmware's real settle/setpoint sleeps so tests run instantly.
+    patcher = patch("pylabrobot.kbiosystems.sealer.asyncio.sleep", new_callable=AsyncMock)
+    patcher.start()
+    self.addCleanup(patcher.stop)
+
+
+class TestUltrasealEPRO(KBiosystemsSealerTestBase):
+  def _make(self, responses: Dict[str, str]) -> KBiosystemsUltrasealEPRO:
+    sealer = KBiosystemsUltrasealEPRO(port="FAKE")
+    sealer.io = FakeSealerSerial(responses)  # type: ignore[assignment]
+    return sealer
+
+  async def test_setup_sequence(self):
+    sealer = self._make({"I": "ok", "?": "00", "V": "1.2\rboardA", "A100": "ok"})
+    await sealer.setup()
+    self.assertEqual(sealer.firmware_version, "1.2 | boardA")
+    self.assertIn("I", sealer.io.written)  # type: ignore[attr-defined]
+    self.assertIn("V", sealer.io.written)  # type: ignore[attr-defined]
+    self.assertIn("A100", sealer.io.written)  # type: ignore[attr-defined]
+
+  async def test_seal_distance_mode_wire_bytes(self):
+    sealer = self._make(
+      {
+        "ECO_OFF": "ok",
+        "?": "00",
+        "B25": "ok",
+        "A170": "ok",
+        "A100": "ok",
+        "L=120": "ok",
+        "FS=0": "ok",
+        "DO=25": "ok",
+        "S": "ok",
+      }
+    )
+    await sealer.seal(temperature=170, duration=2.5)
+    written = sealer.io.written  # type: ignore[attr-defined]
+    for expected in ["ECO_OFF", "B25", "A170", "L=120", "FS=0", "DO=25", "S", "A100"]:
+      self.assertIn(expected, written)
+    # Distance mode must not touch the force commands.
+    self.assertFalse(any(w.startswith("PS=") or w == "FS=1" for w in written))
+
+  async def test_seal_force_mode_wire_bytes(self):
+    sealer = self._make(
+      {
+        "ECO_OFF": "ok",
+        "?": "00",
+        "B25": "ok",
+        "A170": "ok",
+        "A100": "ok",
+        "L=120": "ok",
+        "FS=1": "ok",
+        "S": "ok",
+      }
+    )
+    await sealer.seal(temperature=170, duration=2.5, force_mode=True, sealing_force=30)
+    written = sealer.io.written  # type: ignore[attr-defined]
+    self.assertIn("FS=1", written)
+    self.assertIn("PS=30", written)  # sent with no reply
+    self.assertFalse(any(w.startswith("DO=") for w in written))
+
+  async def test_status_decode(self):
+    sealer = self._make({"?": "a4"})
+    status = await sealer.request_status()
+    self.assertEqual(
+      status,
+      UltrasealEPROStatus.ParkMode | UltrasealEPROStatus.NotInitialised | UltrasealEPROStatus.Busy,
+    )
+
+  async def test_temperature_floor_is_5(self):
+    sealer = self._make({"A005": "ok"})
+    await sealer.set_temperature(5)  # allowed on the ePRO
+    with self.assertRaises(ValueError):
+      await sealer.set_temperature(4)
+
+
+class TestUltrasealXTPro(KBiosystemsSealerTestBase):
+  def _make(self, responses: Dict[str, str]) -> KBiosystemsUltrasealXTPro:
+    sealer = KBiosystemsUltrasealXTPro(port="FAKE")
+    sealer.io = FakeSealerSerial(responses)  # type: ignore[assignment]
+    return sealer
+
+  async def test_setup_sequence(self):
+    sealer = self._make({"?": "00", "A100": "ok"})
+    await sealer.setup()
+    self.assertEqual(sealer.io.written, ["?", "A100"])  # type: ignore[attr-defined]
+
+  async def test_seal_wire_bytes(self):
+    sealer = self._make({"?": "00", "B30": "ok", "A180": "ok", "A100": "ok", "S": "ok"})
+    await sealer.seal(temperature=180, duration=3.0)
+    written = sealer.io.written  # type: ignore[attr-defined]
+    for expected in ["B30", "A180", "S", "A100"]:
+      self.assertIn(expected, written)
+    # The XT Pro has no foil/force/distance/eco commands.
+    self.assertFalse(any(w.startswith(("L=", "DO=", "PS=", "FS=", "ECO_")) for w in written))
+
+  async def test_shuttle_commands(self):
+    sealer = self._make({"P": "ok", "U": "ok", "R": "ok"})
+    self.assertTrue(await sealer.park())
+    self.assertTrue(await sealer.unpark())
+    self.assertTrue(await sealer.reset())
+
+  async def test_status_decode_lowair(self):
+    sealer = self._make({"?": "24"})
+    status = await sealer.request_status()
+    self.assertEqual(status, UltrasealXTProStatus.LowAir | UltrasealXTProStatus.Busy)
+
+  async def test_temperature_floor_is_25(self):
+    sealer = self._make({"A025": "ok"})
+    await sealer.set_temperature(25)
+    with self.assertRaises(ValueError):
+      await sealer.set_temperature(20)  # allowed on the ePRO, not the XT Pro
+
+  async def test_error_status_raises_with_code(self):
+    sealer = self._make({"?": "02", "E": "12"})
+    with self.assertRaises(KBiosystemsError) as ctx:
+      await sealer.wait_for_idle()
+    self.assertEqual(ctx.exception.error_code, 12)
+    self.assertEqual(ctx.exception.message, "Low air pressure.")
+
+
+class TestSharedBase(unittest.TestCase):
+  def test_both_drivers_subclass_base(self):
+    self.assertTrue(issubclass(KBiosystemsUltrasealEPRO, KBiosystemsSealer))
+    self.assertTrue(issubclass(KBiosystemsUltrasealXTPro, KBiosystemsSealer))
+
+  def test_shared_low_status_bits(self):
+    # The state machine in the base relies on these being identical.
+    for bit in ("Ready", "NoFoil", "Error", "Busy", "NotAtSealTemperature", "PlateNotPresent"):
+      self.assertEqual(
+        int(getattr(UltrasealEPROStatus, bit)), int(getattr(UltrasealXTProStatus, bit))
+      )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/pylabrobot/kbiosystems/ultraseal_epro.py
+++ b/pylabrobot/kbiosystems/ultraseal_epro.py
@@ -1,12 +1,12 @@
-import asyncio
 import enum
 import logging
-import time
-from typing import Optional
+from typing import Dict, Optional
 
-from pylabrobot.io.serial import Serial
+from pylabrobot.kbiosystems.sealer import KBiosystemsError, KBiosystemsSealer
 
 logger = logging.getLogger(__name__)
+
+__all__ = ["KBiosystemsUltrasealEPRO", "UltrasealEPROStatus", "KBiosystemsError"]
 
 
 class UltrasealEPROStatus(enum.IntFlag):
@@ -28,7 +28,7 @@ class UltrasealEPROStatus(enum.IntFlag):
 
 
 # Text for each status bit, used to describe a not-ready condition.
-STATUS_MESSAGES = {
+STATUS_MESSAGES: Dict[enum.IntFlag, str] = {
   UltrasealEPROStatus.NoFoil: "No foil detected.",
   UltrasealEPROStatus.Error: "Error",
   UltrasealEPROStatus.Busy: (
@@ -67,55 +67,34 @@ MIN_FOIL_LENGTH = 117
 MAX_FOIL_LENGTH = 128
 
 
-class KBiosystemsError(Exception):
-  """Exceptions raised by a KBiosystems Ultraseal ePRO heat sealer."""
+class KBiosystemsUltrasealEPRO(KBiosystemsSealer):
+  """KBiosystems Ultraseal ePRO heat sealer (formerly the eSeal).
 
-  def __init__(
-    self,
-    title: str,
-    message: Optional[str] = None,
-    status: Optional[UltrasealEPROStatus] = None,
-    error_code: Optional[int] = None,
-  ) -> None:
-    self.title = title
-    self.message = message
-    self.status = status
-    self.error_code = error_code
+  A benchtop heat sealer that presses a heated head onto foil over a plate. In
+  addition to the shared temperature/time commands it exposes foil length,
+  distance- vs force-controlled sealing, eco mode, and an initialize/home step.
 
-  def __str__(self) -> str:
-    return f"{self.title}: {self.message}" if self.message else self.title
-
-
-class KBiosystemsUltrasealEPRO:
-  """KBiosystems Ultraseal ePRO heat sealer.
-
-  Serial settings:
-    9600 baud, 8 data bits, no parity, 1 stop bit, no handshake, "\\r"
-    terminator.
-
-  Commands (ASCII, terminated with CR). The device echoes the command in front
-  of its reply, so the leading command characters are stripped before the reply
-  is read (e.g. ``A160`` -> ``A160ok`` -> ``ok``; ``?`` -> ``?3f`` -> ``3f``). A
-  reply containing ``syntax`` means the command was rejected.
-    ?            read status byte, two hex digits (see UltrasealEPROStatus)
-    E            read error code, two decimal digits (see DEVICE_ERRORS)
-    S            seal the plate; replies ok or err
+  Commands (in addition to the shared ``?``/``E``/``S``/``A``/``B``/``C``/
+  ``D``/``F``, see :class:`KBiosystemsSealer`):
     I            initialize/home; replies ok or err
-    A{t:03d}     set sealing temperature, degrees C (5..199)
-    B{t:02d}     set sealing time, deciseconds (05..99 = 0.5..9.9 s)
     L={l:03d}    set foil length (117..128)
     DO={d:02d}   set sealing distance (10..50), distance mode
     PS={f:02d}   set sealing force (10..50), force mode; no reply
     FS={0|1}     set force mode off/on
     ECO_{ON|OFF} set eco mode
-    C            read sealing temperature setpoint, three digits
-    D            read sealing time setpoint, two digits (deciseconds)
-    F            read current heater temperature, three digits
     V            read firmware version (two lines)
 
-  Not verified: has NOT been tested against hardware in PyLabRobot. A warning
-  is emitted at setup.
+  Not verified: has NOT been tested against hardware in PyLabRobot. A warning is
+  emitted at setup.
   """
+
+  _HUMAN_READABLE_NAME = "KBiosystems Ultraseal ePRO Heat Sealer"
+
+  STATUS = UltrasealEPROStatus
+  STATUS_MESSAGES = STATUS_MESSAGES
+  ERRORS = DEVICE_ERRORS
+  MIN_SEALING_TEMPERATURE = MIN_SEALING_TEMPERATURE
+  MAX_SEALING_TEMPERATURE = MAX_SEALING_TEMPERATURE
 
   def __init__(
     self,
@@ -125,30 +104,17 @@ class KBiosystemsUltrasealEPRO:
     preheating_temperature: int = 100,
     offline_temperature: int = 20,
   ) -> None:
-    self.timeout = timeout
-    self.settle_time = settle_time
-    self.preheating_temperature = preheating_temperature
-    self.offline_temperature = offline_temperature
-    self.firmware_version: Optional[str] = None
-    self.io = Serial(
-      human_readable_device_name="KBiosystems Ultraseal ePRO Heat Sealer",
-      port=port,
-      baudrate=9600,
-      bytesize=8,
-      parity="N",
-      stopbits=1,
-      timeout=0.2,
+    super().__init__(
+      port,
+      timeout=timeout,
+      settle_time=settle_time,
+      preheating_temperature=preheating_temperature,
+      offline_temperature=offline_temperature,
     )
+    self.firmware_version: Optional[str] = None
 
   async def setup(self) -> None:
-    logger.warning(
-      "KBiosystemsUltrasealEPRO has NOT been tested against hardware in PyLabRobot. "
-      "Please make a PR to remove this message if you have verified it on your hardware."
-    )
-    await self.io.setup()
-    # The device drops characters for a few seconds after the port opens.
-    await asyncio.sleep(self.settle_time)
-    await self.io.reset_input_buffer()
+    await self._open()
     # Initialize/home the sealer (``I``).
     if self._check(await self.send_command("I"), {"ok", "err"}, "I") != "ok":
       raise KBiosystemsError(title="Initializing the Ultraseal ePRO failed")
@@ -162,153 +128,7 @@ class KBiosystemsUltrasealEPRO:
     await self.set_temperature(self.preheating_temperature)
     logger.info("[Ultraseal ePRO %s] connected: firmware=%s", self.io.port, self.firmware_version)
 
-  async def stop(self) -> None:
-    try:
-      await self.set_temperature(self.offline_temperature)
-    except (KBiosystemsError, TimeoutError) as e:
-      logger.warning("[Ultraseal ePRO %s] could not set offline temperature: %s", self.io.port, e)
-    await self.io.stop()
-
-  # === Command layer ===
-
-  async def _read_line(self) -> str:
-    """Read bytes until a CR terminator, skipping stray LF."""
-    start = time.time()
-    buf = bytearray()
-    while True:
-      b = await self.io.read(1)
-      if b == b"":
-        if time.time() - start > self.timeout:
-          raise TimeoutError("Timeout while waiting for response from sealer.")
-        continue
-      if b == b"\r":
-        break
-      if b == b"\n":
-        continue
-      buf += b
-    return buf.decode("ascii", errors="replace")
-
-  async def send_command(self, command: str, read_reply: bool = True) -> str:
-    """Send a command and return the reply with the echoed command stripped.
-
-    Args:
-      command: command string without the CR terminator, e.g. "A160", "?".
-      read_reply: if False, do not read a reply (used for PS=, which sends none).
-    """
-    await self.io.reset_input_buffer()
-    await self.io.write((command + "\r").encode("ascii"))
-    await asyncio.sleep(0.2)
-    if not read_reply:
-      return ""
-    text = await self._read_line()
-    if command == "V":
-      text = text + " | " + await self._read_line()
-    if "syntax" in text:
-      return text
-    # The device echoes the command; an empty command trims whitespace only.
-    return text.lstrip(command) if command else text.strip()
-
-  def _check(self, reply: str, allowed: set, command: str) -> str:
-    if reply not in allowed or "syntax" in reply:
-      raise KBiosystemsError(
-        title="Unexpected response", message=f"command {command!r} returned {reply!r}"
-      )
-    return reply
-
-  # === State ===
-
-  async def request_status(self) -> UltrasealEPROStatus:
-    """Read the status byte (``?``)."""
-    reply = await self.send_command("?")
-    try:
-      return UltrasealEPROStatus(int(reply, 16))
-    except ValueError as e:
-      raise KBiosystemsError(title="Unexpected status reply", message=repr(reply)) from e
-
-  async def request_error_code(self) -> int:
-    """Read the current error code (``E``)."""
-    reply = await self.send_command("E")
-    try:
-      return int(reply)
-    except ValueError as e:
-      raise KBiosystemsError(title="Unexpected error reply", message=repr(reply)) from e
-
-  async def wait_for_idle(
-    self, ignore_mask: UltrasealEPROStatus = UltrasealEPROStatus.Ready
-  ) -> UltrasealEPROStatus:
-    """Wait until the device is Ready, tolerating the bits set in ``ignore_mask``.
-
-    Raises KBiosystemsError if any bit outside ``ignore_mask`` is set; if the
-    Error bit is set, the error code and text are attached.
-    """
-    status = await self.request_status()
-    while status != UltrasealEPROStatus.Ready:
-      if status & UltrasealEPROStatus.Busy:
-        await asyncio.sleep(0.5)
-        status = await self._wait_for_busy_cleared()
-        continue
-
-      # While heating, the device also reports Busy; ignore it alongside
-      # NotAtSealTemperature so waiting for temperature does not raise.
-      if (
-        ignore_mask & UltrasealEPROStatus.NotAtSealTemperature
-        and status & UltrasealEPROStatus.NotAtSealTemperature
-      ):
-        ignore_mask = ignore_mask | UltrasealEPROStatus.Busy
-
-      remaining = status & ~ignore_mask
-      if remaining == UltrasealEPROStatus.Ready:
-        break
-
-      description = ", ".join(m for bit, m in STATUS_MESSAGES.items() if remaining & bit)
-      if remaining & UltrasealEPROStatus.Error:
-        code = await self.request_error_code()
-        raise KBiosystemsError(
-          title=f"Sealer error: {description}",
-          message=DEVICE_ERRORS.get(code),
-          status=remaining,
-          error_code=code,
-        )
-      raise KBiosystemsError(title=f"Sealer not ready: {description}", status=remaining)
-    return status
-
-  async def _wait_for_busy_cleared(self, timeout: float = 60.0) -> UltrasealEPROStatus:
-    start = time.time()
-    status = await self.request_status()
-    while status & UltrasealEPROStatus.Busy:
-      if time.time() - start > timeout:
-        raise KBiosystemsError(title="Timeout while waiting for busy flag to clear")
-      await asyncio.sleep(0.5)
-      status = await self.request_status()
-    return status
-
-  async def wait_for_sealing_temperature(self, timeout: float = 300.0) -> None:
-    """Block until the heater reaches the setpoint (NotAtSealTemperature clears)."""
-    start = time.time()
-    while await self.request_status() & UltrasealEPROStatus.NotAtSealTemperature:
-      if time.time() - start > timeout:
-        raise TimeoutError("Timeout while waiting for sealing temperature.")
-      await asyncio.sleep(5.0)
-
   # === Parameters ===
-
-  async def set_temperature(self, temperature: int) -> None:
-    """Set the sealing temperature in degrees C (``A``, 5..199)."""
-    if not MIN_SEALING_TEMPERATURE <= temperature <= MAX_SEALING_TEMPERATURE:
-      raise ValueError(
-        f"temperature must be {MIN_SEALING_TEMPERATURE}..{MAX_SEALING_TEMPERATURE} C"
-      )
-    command = f"A{temperature:03d}"
-    self._check(await self.send_command(command), {"ok"}, command)
-    # The firmware needs a moment to accept the new setpoint.
-    await asyncio.sleep(3.0)
-
-  async def set_sealing_time(self, seconds: float) -> None:
-    """Set the sealing time in seconds (``B``, 0.5..9.9)."""
-    if not MIN_SEALING_DURATION <= seconds <= MAX_SEALING_DURATION:
-      raise ValueError(f"time must be {MIN_SEALING_DURATION}..{MAX_SEALING_DURATION} s")
-    command = f"B{int(seconds * 10):02d}"
-    self._check(await self.send_command(command), {"ok"}, command)
 
   async def set_foil_length(self, length: int) -> None:
     """Set the foil length (``L=``, 117..128)."""
@@ -345,33 +165,11 @@ class KBiosystemsUltrasealEPRO:
     if reply == "err" or "syntax" in reply:
       raise KBiosystemsError(title="Setting eco mode failed", message=reply)
 
-  async def request_sealing_temperature(self) -> int:
-    """Read the sealing temperature setpoint in degrees C (``C``)."""
-    reply = await self.send_command("C")
-    try:
-      return int(reply)
-    except ValueError as e:
-      raise KBiosystemsError(title="Unexpected temperature reply", message=repr(reply)) from e
-
-  async def request_sealing_time(self) -> float:
-    """Read the sealing time setpoint in seconds (``D``)."""
-    reply = await self.send_command("D")
-    try:
-      return int(reply) / 10.0
-    except ValueError as e:
-      raise KBiosystemsError(title="Unexpected time reply", message=repr(reply)) from e
-
-  async def request_temperature(self) -> int:
-    """Read the current heater temperature in degrees C (``F``)."""
-    reply = await self.send_command("F")
-    try:
-      return int(reply)
-    except ValueError as e:
-      raise KBiosystemsError(title="Unexpected temperature reply", message=repr(reply)) from e
-
   async def request_firmware_version(self) -> str:
-    """Read the firmware version (``V``)."""
-    return await self.send_command("V")
+    """Read the firmware version (``V``). This device replies with two lines."""
+    line1 = await self.send_command("V")
+    line2 = await self._read_line()
+    return f"{line1} | {line2}"
 
   # === Operations ===
 

--- a/pylabrobot/kbiosystems/ultraseal_xt_pro.py
+++ b/pylabrobot/kbiosystems/ultraseal_xt_pro.py
@@ -1,0 +1,189 @@
+import enum
+import logging
+from typing import Dict
+
+from pylabrobot.kbiosystems.sealer import KBiosystemsError, KBiosystemsSealer
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["KBiosystemsUltrasealXTPro", "UltrasealXTProStatus", "KBiosystemsError"]
+
+
+class UltrasealXTProStatus(enum.IntFlag):
+  """Status byte returned by the ``?`` command (two hex digits).
+
+  ``Ready`` (0x00) is the all-clear value; any other bit is a condition that
+  must be cleared, or masked when ignorable, before an operation runs. The low
+  bits (Ready/Error/Busy/NotAtSealTemperature) are the shared set
+  :class:`KBiosystemsSealer` acts on; ``LowAir`` and ``ParkMode`` are specific to
+  this model.
+  """
+
+  Ready = 0x00
+  NoFoil = 0x01
+  Error = 0x02
+  Busy = 0x04
+  NotAtSealTemperature = 0x08
+  PlateNotPresent = 0x10
+  LowAir = 0x20
+  ParkMode = 0x40
+
+
+# Text for each status bit, used to describe a not-ready condition.
+STATUS_MESSAGES: Dict[enum.IntFlag, str] = {
+  UltrasealXTProStatus.NoFoil: "No foil detected.",
+  UltrasealXTProStatus.Error: "Error.",
+  UltrasealXTProStatus.Busy: "Device busy.",
+  UltrasealXTProStatus.NotAtSealTemperature: "Waiting for seal temperature.",
+  UltrasealXTProStatus.PlateNotPresent: "No plate detected.",
+  UltrasealXTProStatus.LowAir: "Low air pressure - check the compressed air supply.",
+  UltrasealXTProStatus.ParkMode: "Shuttle parked (inside).",
+}
+
+# Error codes returned by the ``E`` command (two decimal digits).
+DEVICE_ERRORS = {
+  1: "Vertical shuttle down.",
+  2: "Heater up.",
+  3: "Shuttle in.",
+  4: "Shuttle out.",
+  7: "Thermocouple error.",
+  8: "Heater failure.",
+  9: "The sealer is overheating.",
+  10: "No foil detected.",
+  11: "No plate detected.",
+  12: "Low air pressure.",
+  13: "Door error.",
+}
+
+MIN_SEALING_TEMPERATURE = 25
+MAX_SEALING_TEMPERATURE = 199
+MIN_SEALING_DURATION = 0.5
+MAX_SEALING_DURATION = 9.9
+
+
+class KBiosystemsUltrasealXTPro(KBiosystemsSealer):
+  """KBiosystems Ultraseal XT Pro heat sealer.
+
+  An inline, pneumatically driven heat sealer that advances and cuts its own
+  film internally, so it exposes no foil-length/force/distance parameters. A
+  plate is presented by moving the shuttle out (unparking); after the plate is
+  loaded, the shuttle is moved in (parked) and the plate is sealed.
+
+  Commands (in addition to the shared ``?``/``E``/``S``/``A``/``B``/``C``/
+  ``D``/``F``, see :class:`KBiosystemsSealer`):
+    P            park the shuttle (move in); replies ok or err
+    U            unpark the shuttle (move out); replies ok or err
+    R            reset the sealer; replies ok
+
+  Requires a compressed air supply (see the ``LowAir`` status bit).
+
+  Not verified: has NOT been tested against hardware in PyLabRobot. A warning is
+  emitted at setup.
+  """
+
+  _HUMAN_READABLE_NAME = "KBiosystems Ultraseal XT Pro Heat Sealer"
+
+  STATUS = UltrasealXTProStatus
+  STATUS_MESSAGES = STATUS_MESSAGES
+  ERRORS = DEVICE_ERRORS
+  MIN_SEALING_TEMPERATURE = MIN_SEALING_TEMPERATURE
+  MAX_SEALING_TEMPERATURE = MAX_SEALING_TEMPERATURE
+
+  def __init__(
+    self,
+    port: str,
+    timeout: float = 5.0,
+    settle_time: float = 5.0,
+    preheating_temperature: int = 100,
+    offline_temperature: int = 25,
+  ) -> None:
+    super().__init__(
+      port,
+      timeout=timeout,
+      settle_time=settle_time,
+      preheating_temperature=preheating_temperature,
+      offline_temperature=offline_temperature,
+    )
+
+  async def setup(self) -> None:
+    await self._open()
+    await self.wait_for_idle(
+      UltrasealXTProStatus.NoFoil
+      | UltrasealXTProStatus.NotAtSealTemperature
+      | UltrasealXTProStatus.ParkMode
+    )
+    await self.set_temperature(self.preheating_temperature)
+    logger.info("[Ultraseal XT Pro %s] connected", self.io.port)
+
+  # === Shuttle ===
+
+  async def park(self) -> bool:
+    """Park the shuttle / move it in (``P``). Returns True on ``ok``."""
+    return self._check(await self.send_command("P"), {"ok", "err"}, "P") == "ok"
+
+  async def unpark(self) -> bool:
+    """Unpark the shuttle / move it out (``U``). Returns True on ``ok``."""
+    return self._check(await self.send_command("U"), {"ok", "err"}, "U") == "ok"
+
+  async def reset(self) -> bool:
+    """Reset the sealer (``R``). Returns True on ``ok``."""
+    return await self.send_command("R") == "ok"
+
+  async def move_shuttle_out(self) -> None:
+    """Present a plate: unpark the shuttle if needed, then wait until ready.
+
+    ``NoFoil`` and ``NotAtSealTemperature`` are tolerated so a plate can be
+    loaded while the film is being advanced or the heater is warming.
+    """
+    status = await self._wait_for_busy_cleared(timeout=30.0)
+    if status & UltrasealXTProStatus.ParkMode and not status & UltrasealXTProStatus.Busy:
+      await self.unpark()
+    await self.wait_for_idle(
+      UltrasealXTProStatus.NoFoil | UltrasealXTProStatus.NotAtSealTemperature
+    )
+
+  async def move_shuttle_in(self) -> None:
+    """Retract a plate for sealing: park the shuttle if needed, then wait."""
+    status = await self._wait_for_busy_cleared(timeout=30.0)
+    if not status & UltrasealXTProStatus.ParkMode and not status & UltrasealXTProStatus.Busy:
+      await self.park()
+    await self.wait_for_idle(
+      UltrasealXTProStatus.NoFoil
+      | UltrasealXTProStatus.NotAtSealTemperature
+      | UltrasealXTProStatus.ParkMode
+    )
+
+  # === Operations ===
+
+  async def seal(
+    self,
+    temperature: int,
+    duration: float,
+    idle_temperature: int = 100,
+  ) -> None:
+    """Seal the plate currently in the sealer.
+
+    Waits for the device to be ready, applies the time and temperature, waits
+    for the heater to reach the setpoint, seals, then returns to
+    ``idle_temperature``. The shuttle must already be in (see
+    :meth:`move_shuttle_in`); film advance and cutting are handled by the device.
+
+    Args:
+      temperature: sealing temperature in degrees C (25..199).
+      duration: sealing time in seconds (0.5..9.9).
+      idle_temperature: temperature to hold after sealing (25..199).
+    """
+    logger.info(
+      "[Ultraseal XT Pro %s] sealing at %d C for %.1fs", self.io.port, temperature, duration
+    )
+    ignore = UltrasealXTProStatus.NotAtSealTemperature | UltrasealXTProStatus.ParkMode
+
+    await self.wait_for_idle(ignore)
+    await self.set_sealing_time(duration)
+    await self.set_temperature(temperature)
+    await self.wait_for_sealing_temperature()
+    if self._check(await self.send_command("S"), {"ok", "err"}, "S") != "ok":
+      raise KBiosystemsError(title="Seal command returned 'err'")
+    await self.wait_for_idle(ignore)
+
+    await self.set_temperature(idle_temperature)


### PR DESCRIPTION
## What

Adds a driver for the KBiosystems Ultraseal XT Pro heat sealer and extracts a shared base class for the KBiosystems sealers.

- **`KBiosystemsSealer`** (new base): serial transport, command-echo stripping, the `?`/`E` status and error state machine (`wait_for_idle`, busy/temperature waits), and the `A`/`B`/`C`/`D`/`F` temperature and time commands.
- **`KBiosystemsUltrasealXTPro`** (new): the inline, pneumatically actuated model. Adds `park`/`unpark`/`reset`, `move_shuttle_in`/`move_shuttle_out`, a `LowAir` status bit, its own error table, a 25 °C temperature floor, and a `seal()` with no foil/force/distance/eco parameters (the device advances and cuts its film internally).
- **`KBiosystemsUltrasealEPRO`**: now subclasses `KBiosystemsSealer`. Public API unchanged; keeps its foil/force/distance/eco/init/firmware commands.

Serial protocol for both: 9600 8-N-1, no handshake, CR terminator; ASCII commands with the command echoed in front of the reply.

## Tests

`sealer_tests.py` (13 tests) covers wire bytes for both models via a fake echoing serial, status decoding, the error path, temperature floors, and the shared-base contract. `mypy`, `ruff check`, and `ruff format` are clean.

## Status

Not tested against hardware. `setup()` logs a warning asking for a follow-up PR to remove it once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
