### PR TITLE
feat(thermo_fisher): add Thermo Scientific ALPS 300/3000/5000 heat sealer drivers

### DIFF
--- a/docs/api/pylabrobot.thermo_fisher.rst
+++ b/docs/api/pylabrobot.thermo_fisher.rst
@@ -3,6 +3,49 @@
 pylabrobot.thermo_fisher package
 ================================
 
+ALPS Heat Sealers
+-----------------
+
+.. currentmodule:: pylabrobot.thermo_fisher.alps.sealer
+
+.. autosummary::
+  :toctree: _autosummary
+  :nosignatures:
+  :recursive:
+
+    ThermoScientificALPSSealer
+    ThermoScientificALPSError
+
+.. currentmodule:: pylabrobot.thermo_fisher.alps.alps300
+
+.. autosummary::
+  :toctree: _autosummary
+  :nosignatures:
+  :recursive:
+
+    ThermoScientificALPS300
+    ALPS300Status
+
+.. currentmodule:: pylabrobot.thermo_fisher.alps.alps3000
+
+.. autosummary::
+  :toctree: _autosummary
+  :nosignatures:
+  :recursive:
+
+    ThermoScientificALPS3000
+    ALPS3000Status
+
+.. currentmodule:: pylabrobot.thermo_fisher.alps.alps5000
+
+.. autosummary::
+  :toctree: _autosummary
+  :nosignatures:
+  :recursive:
+
+    ThermoScientificALPS5000
+    ALPS5000Status
+
 Multidrop Combi
 ---------------
 

--- a/docs/user_guide/thermo_fisher/alps/alps300/hello-world.ipynb
+++ b/docs/user_guide/thermo_fisher/alps/alps300/hello-world.ipynb
@@ -1,0 +1,99 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "alps300-intro",
+   "source": "# Thermo Scientific ALPS 300\n\nThe ALPS 300 is a heat sealer for microplates from Thermo Scientific, controlled over an RS-232 serial interface.\n\n| Property | Value |\n|---|---|\n| Communication | Serial / RS-232, ASCII command protocol |\n| Serial settings | 9600 baud, 8 data bits, no parity, 1 stop bit, no handshake |\n| Terminator | CR (`\\r`) |\n\nThe ALPS 300, 3000, and 5000 share a command core but use different status flags and error codes, so each has its own driver class.\n\n```{warning}\nThis driver has NOT been tested against hardware in PyLabRobot. If you verify\nit on a sealer, please open a PR to remove the not-tested warning.\n```",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps300-setup-md",
+   "source": "## Physical setup\n\nConnect the sealer's RS-232 port to your computer, typically through a USB-to-serial adapter. Make sure the sealer's serial parameters match the driver defaults (9600 baud, 8 data bits, no parity, 1 stop bit, no handshake).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps300-connect-md",
+   "source": "## Connect\n\n`setup()` opens the serial port, waits for the device to be ready, and pre-heats to the preheating temperature. It also logs the not-tested warning.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps300-connect-code",
+   "source": "from pylabrobot.thermo_fisher.alps import ThermoScientificALPS300\n\nsealer = ThermoScientificALPS300(port=\"/dev/ttyUSB0\")  # replace with your port\nawait sealer.setup()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps300-seal-md",
+   "source": "## Seal a plate\n\n`seal()` applies the time and temperature, waits for the heater to reach the setpoint, then seals the plate. Sealing time is 0.5–9.9 s; temperature is 5–199 °C.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps300-seal-code",
+   "source": "await sealer.seal(temperature=170, duration=2.5)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps300-temp-md",
+   "source": "## Temperature\n\nSet the sealing temperature setpoint and read the current heater temperature.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps300-temp-code",
+   "source": "await sealer.set_temperature(160)\nprint(\"Current temperature:\", await sealer.request_temperature(), \"C\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps300-status-md",
+   "source": "## Status\n\nRead the status byte as a set of flags.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps300-status-code",
+   "source": "print(\"Status:\", await sealer.request_status())",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps300-teardown-md",
+   "source": "## Teardown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps300-teardown-code",
+   "source": "await sealer.stop()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/user_guide/thermo_fisher/alps/alps3000/hello-world.ipynb
+++ b/docs/user_guide/thermo_fisher/alps/alps3000/hello-world.ipynb
@@ -1,0 +1,99 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "alps3000-intro",
+   "source": "# Thermo Scientific ALPS 3000\n\nThe ALPS 3000 is a heat sealer for microplates from Thermo Scientific, controlled over an RS-232 serial interface.\n\nProduct page: <https://www.thermofisher.com/order/catalog/product/AB-3000>\n\n| Property | Value |\n|---|---|\n| Communication | Serial / RS-232, ASCII command protocol |\n| Serial settings | 9600 baud, 8 data bits, no parity, 1 stop bit, no handshake |\n| Terminator | CR (`\\r`) |\n\nThe ALPS 300, 3000, and 5000 share a command core but use different status flags and error codes, so each has its own driver class.\n\n```{warning}\nThis driver has NOT been tested against hardware in PyLabRobot. If you verify\nit on a sealer, please open a PR to remove the not-tested warning.\n```",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps3000-setup-md",
+   "source": "## Physical setup\n\nConnect the sealer's RS-232 port to your computer, typically through a USB-to-serial adapter. Make sure the sealer's serial parameters match the driver defaults (9600 baud, 8 data bits, no parity, 1 stop bit, no handshake).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps3000-connect-md",
+   "source": "## Connect\n\n`setup()` opens the serial port, waits for the device to be ready, and pre-heats to the preheating temperature. It also logs the not-tested warning.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps3000-connect-code",
+   "source": "from pylabrobot.thermo_fisher.alps import ThermoScientificALPS3000\n\nsealer = ThermoScientificALPS3000(port=\"/dev/ttyUSB0\")  # replace with your port\nawait sealer.setup()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps3000-seal-md",
+   "source": "## Seal a plate\n\n`seal()` applies the time and temperature, waits for the heater to reach the setpoint, then seals the plate. Sealing time is 0.5–9.9 s; temperature is 5–199 °C.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps3000-seal-code",
+   "source": "await sealer.seal(temperature=170, duration=2.5)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps3000-temp-md",
+   "source": "## Temperature\n\nSet the sealing temperature setpoint and read the current heater temperature.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps3000-temp-code",
+   "source": "await sealer.set_temperature(160)\nprint(\"Current temperature:\", await sealer.request_temperature(), \"C\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps3000-status-md",
+   "source": "## Status\n\nRead the status byte as a set of flags.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps3000-status-code",
+   "source": "print(\"Status:\", await sealer.request_status())",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps3000-teardown-md",
+   "source": "## Teardown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps3000-teardown-code",
+   "source": "await sealer.stop()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/user_guide/thermo_fisher/alps/alps5000/hello-world.ipynb
+++ b/docs/user_guide/thermo_fisher/alps/alps5000/hello-world.ipynb
@@ -1,0 +1,141 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "alps5000-intro",
+   "source": "# Thermo Scientific ALPS 5000\n\nThe ALPS 5000 is a heat sealer for microplates from Thermo Scientific, controlled over an RS-232 serial interface. It extends the shared ALPS protocol with initialisation, force-sensor control, foil length, sealing distance, and shuttle movement.\n\nProduct page: <https://www.thermofisher.com/order/catalog/product/AB-5000>\n\n| Property | Value |\n|---|---|\n| Communication | Serial / RS-232, ASCII command protocol |\n| Serial settings | 9600 baud, 8 data bits, no parity, 1 stop bit, no handshake |\n| Terminator | CR (`\\r`) |\n\nThe ALPS 300, 3000, and 5000 share a command core but use different status flags and error codes, so each has its own driver class.\n\n```{warning}\nThis driver has NOT been tested against hardware in PyLabRobot. If you verify\nit on a sealer, please open a PR to remove the not-tested warning.\n```",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps5000-setup-md",
+   "source": "## Physical setup\n\nConnect the sealer's RS-232 port to your computer, typically through a USB-to-serial adapter. Make sure the sealer's serial parameters match the driver defaults (9600 baud, 8 data bits, no parity, 1 stop bit, no handshake).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps5000-connect-md",
+   "source": "## Connect\n\n`setup()` opens the serial port, runs the instrument initialisation routine, waits for the device to be ready, and pre-heats to the preheating temperature. It also logs the not-tested warning.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps5000-connect-code",
+   "source": "from pylabrobot.thermo_fisher.alps import ThermoScientificALPS5000\n\nsealer = ThermoScientificALPS5000(port=\"/dev/ttyUSB0\")  # replace with your port\nawait sealer.setup()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps5000-seal-md",
+   "source": "## Seal a plate\n\n`seal()` applies the time and temperature, optionally enables the force sensor, waits for the heater to reach the setpoint, then seals the plate. Sealing time is 0.5–9.9 s; temperature is 5–199 °C.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps5000-seal-code",
+   "source": "await sealer.seal(temperature=170, duration=2.5, use_force_sensor=True)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps5000-force-md",
+   "source": "## Force and force sensor\n\nSet the sealing force (5–50) and enable or disable the force sensor independently of a seal.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps5000-force-code",
+   "source": "await sealer.set_force(30)\nawait sealer.enable_force_sensor(True)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps5000-foil-md",
+   "source": "## Foil length and sealing distance\n\nSet the foil length (119–128) and the sealing distance (10–50).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps5000-foil-code",
+   "source": "await sealer.set_foil_length(124)\nawait sealer.set_sealing_distance(20)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps5000-shuttle-md",
+   "source": "## Shuttle\n\nMove the shuttle in and out.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps5000-shuttle-code",
+   "source": "await sealer.shuttle_out()\nawait sealer.shuttle_in()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps5000-temp-md",
+   "source": "## Temperature\n\nSet the sealing temperature setpoint and read the current heater temperature.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps5000-temp-code",
+   "source": "await sealer.set_temperature(160)\nprint(\"Current temperature:\", await sealer.request_temperature(), \"C\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps5000-status-md",
+   "source": "## Status\n\nRead the status byte as a set of flags.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps5000-status-code",
+   "source": "print(\"Status:\", await sealer.request_status())",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "alps5000-teardown-md",
+   "source": "## Teardown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "alps5000-teardown-code",
+   "source": "await sealer.stop()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/user_guide/thermo_fisher/alps/index.md
+++ b/docs/user_guide/thermo_fisher/alps/index.md
@@ -1,0 +1,13 @@
+# ALPS Heat Sealers
+
+The Thermo Scientific ALPS family of heat sealers share a common serial command
+core but differ in their status flags, error tables, and available commands. Each
+model has its own driver.
+
+```{toctree}
+:maxdepth: 1
+
+alps300/hello-world
+alps3000/hello-world
+alps5000/hello-world
+```

--- a/docs/user_guide/thermo_fisher/index.md
+++ b/docs/user_guide/thermo_fisher/index.md
@@ -5,4 +5,5 @@
 
 cytomat/hello-world
 multidrop_combi/hello-world
+alps/index
 ```

--- a/pylabrobot/kbioscience/kube.py
+++ b/pylabrobot/kbioscience/kube.py
@@ -117,8 +117,10 @@ class KBioscienceKUBE:
     F            read current heater temperature, three digits
     V            read firmware version
     @            read product name / model description
-    <empty>      protocol probe; a unit replying ``ALPS300`` speaks the older,
-                 incompatible protocol and is rejected at setup
+    <empty>      protocol probe; a unit replying ``ALPS300`` speaks the older
+                 ALPS protocol and is rejected at setup. Use
+                 ``pylabrobot.thermo_fisher.alps.ThermoScientificALPS300`` for a
+                 unit running that protocol.
 
   Not verified: has NOT been tested against hardware in PyLabRobot. A warning
   is emitted at setup.
@@ -160,13 +162,16 @@ class KBioscienceKUBE:
     await asyncio.sleep(self.settle_time)
     await self.io.reset_input_buffer()
     # A unit that answers the empty-command probe with "ALPS300" speaks the
-    # older protocol this driver does not support.
+    # older ALPS protocol; pylabrobot.thermo_fisher.alps.ThermoScientificALPS300
+    # handles that protocol.
     if await self._is_alps300():
       raise KBioscienceError(
         title="Incompatible communication protocol",
         message=(
-          "Please uncheck ALPS Compatibility from instrument software menu "
-          "[Menu->Supervisor options->Remote control settings->ALPS Compatibility]"
+          "This unit is running the ALPS protocol. Either use "
+          "ThermoScientificALPS300, or uncheck ALPS Compatibility from the "
+          "instrument software menu [Menu->Supervisor options->Remote control "
+          "settings->ALPS Compatibility]."
         ),
       )
     await self.wait_for_idle(

--- a/pylabrobot/thermo_fisher/alps/__init__.py
+++ b/pylabrobot/thermo_fisher/alps/__init__.py
@@ -1,0 +1,7 @@
+from pylabrobot.thermo_fisher.alps.alps300 import ALPS300Status, ThermoScientificALPS300
+from pylabrobot.thermo_fisher.alps.alps3000 import ALPS3000Status, ThermoScientificALPS3000
+from pylabrobot.thermo_fisher.alps.alps5000 import ALPS5000Status, ThermoScientificALPS5000
+from pylabrobot.thermo_fisher.alps.sealer import (
+  ThermoScientificALPSError,
+  ThermoScientificALPSSealer,
+)

--- a/pylabrobot/thermo_fisher/alps/alps300.py
+++ b/pylabrobot/thermo_fisher/alps/alps300.py
@@ -1,0 +1,78 @@
+import enum
+from typing import Dict
+
+from pylabrobot.thermo_fisher.alps.sealer import ThermoScientificALPSSealer
+
+
+class ALPS300Status(enum.IntFlag):
+  """Status byte returned by the ``?`` command (two hex digits).
+
+  ``Ready`` (0x00) is the all-clear value; any other bit is a condition that
+  must be cleared, or masked when ignorable, before an operation runs.
+  """
+
+  Ready = 0x00
+  Busy = 0x01
+  Error = 0x02
+  Sealing = 0x04
+  NotAtSealTemperature = 0x08
+  NotAssigned = 0x10
+  FoilLow = 0x20
+  DoorOpen = 0x40
+  ProceedOverridden = 0x80
+
+
+STATUS_MESSAGES: Dict[enum.IntFlag, str] = {
+  ALPS300Status.Busy: "Busy",
+  ALPS300Status.Error: "Error",
+  ALPS300Status.Sealing: "Sealing",
+  ALPS300Status.NotAtSealTemperature: "Waiting for seal temperature",
+  ALPS300Status.NotAssigned: "Status not assigned",
+  ALPS300Status.FoilLow: "No foil detected or foil low.",
+  ALPS300Status.DoorOpen: "Door open",
+  ALPS300Status.ProceedOverridden: "Proceed overriden",
+}
+
+# Error codes returned by the ``E`` command. The firmware leaves gaps in the
+# numbering (there is no code 2).
+ERRORS = {
+  1: "Low air pressure detected. Check air pressure.",
+  3: "Shuttle not out.",
+  4: "No foil or low foil error. Check foil and foil sensor.",
+  5: "Seal transfer error.",
+  6: "Placement error (can be caused of low air pressure).",
+  7: "Thermocouple error - ambient temperature may be too low.",
+}
+
+# Status bits tolerated while waiting for the sealer to accept an operation.
+_READY_MASK = (
+  ALPS300Status.NotAtSealTemperature | ALPS300Status.FoilLow | ALPS300Status.ProceedOverridden
+)
+_SETUP_MASK = ALPS300Status.NotAtSealTemperature | ALPS300Status.ProceedOverridden
+
+
+class ThermoScientificALPS300(ThermoScientificALPSSealer):
+  """Thermo Scientific ALPS 300 heat sealer.
+
+  Not verified: has NOT been tested against hardware in PyLabRobot. A warning
+  is emitted at setup.
+  """
+
+  _HUMAN_READABLE_NAME = "Thermo Scientific ALPS 300 Heat Sealer"
+  STATUS = ALPS300Status
+  STATUS_MESSAGES = STATUS_MESSAGES
+  ERRORS = ERRORS
+
+  async def setup(self) -> None:
+    await self._open()
+    await self.wait_for_idle(_SETUP_MASK)
+    await self.set_temperature(self.preheating_temperature)
+
+  async def seal(self, temperature: int = 160, duration: float = 2.5) -> None:
+    """Seal a plate.
+
+    Args:
+      temperature: sealing temperature in degrees C (5..199).
+      duration: sealing time in seconds (0.5..9.9).
+    """
+    await self._seal(temperature, duration, _READY_MASK)

--- a/pylabrobot/thermo_fisher/alps/alps3000.py
+++ b/pylabrobot/thermo_fisher/alps/alps3000.py
@@ -1,0 +1,77 @@
+import enum
+from typing import Dict
+
+from pylabrobot.thermo_fisher.alps.sealer import ThermoScientificALPSSealer
+
+
+class ALPS3000Status(enum.IntFlag):
+  """Status byte returned by the ``?`` command (two hex digits).
+
+  ``Ready`` (0x00) is the all-clear value; any other bit is a condition that
+  must be cleared, or masked when ignorable, before an operation runs.
+  """
+
+  Ready = 0x00
+  NoFoil = 0x01
+  Error = 0x02
+  Busy = 0x04
+  WaitingForSealTemperature = 0x08
+  PlateNotPresent = 0x10
+  LowAir = 0x20
+  FoilLoadModeAfterPark = 0x40
+  ParkMode = 0x80
+
+
+STATUS_MESSAGES: Dict[enum.IntFlag, str] = {
+  ALPS3000Status.NoFoil: "No foil detected",
+  ALPS3000Status.Error: "Error",
+  ALPS3000Status.Busy: "Busy",
+  ALPS3000Status.WaitingForSealTemperature: "Waiting for seal temperature",
+  ALPS3000Status.PlateNotPresent: "Plate not present in shuttle",
+  ALPS3000Status.LowAir: "Low air pressure detected",
+  ALPS3000Status.FoilLoadModeAfterPark: "Waiting for foil to be loaded",
+  ALPS3000Status.ParkMode: "Park mode",
+}
+
+# Error codes returned by the ``E`` command. The firmware leaves gaps in the
+# numbering.
+ERRORS = {
+  1: "Down error",
+  2: "Up error",
+  3: "Shuttle not in",
+  4: "Shuttle not out",
+  7: "Thermocouple error - ambient temperature may be too low",
+  9: "Sealer overheating",
+  10: "No foil detected",
+  13: "Mains Air error",
+}
+
+# Status bits tolerated while waiting for the sealer to accept an operation.
+_READY_MASK = ALPS3000Status.WaitingForSealTemperature | ALPS3000Status.PlateNotPresent
+
+
+class ThermoScientificALPS3000(ThermoScientificALPSSealer):
+  """Thermo Scientific ALPS 3000 heat sealer.
+
+  Not verified: has NOT been tested against hardware in PyLabRobot. A warning
+  is emitted at setup.
+  """
+
+  _HUMAN_READABLE_NAME = "Thermo Scientific ALPS 3000 Heat Sealer"
+  STATUS = ALPS3000Status
+  STATUS_MESSAGES = STATUS_MESSAGES
+  ERRORS = ERRORS
+
+  async def setup(self) -> None:
+    await self._open()
+    await self.wait_for_idle(_READY_MASK)
+    await self.set_temperature(self.preheating_temperature)
+
+  async def seal(self, temperature: int = 160, duration: float = 2.5) -> None:
+    """Seal a plate.
+
+    Args:
+      temperature: sealing temperature in degrees C (5..199).
+      duration: sealing time in seconds (0.5..9.9).
+    """
+    await self._seal(temperature, duration, _READY_MASK)

--- a/pylabrobot/thermo_fisher/alps/alps5000.py
+++ b/pylabrobot/thermo_fisher/alps/alps5000.py
@@ -1,0 +1,201 @@
+import asyncio
+import enum
+import logging
+from typing import Dict
+
+from pylabrobot.thermo_fisher.alps.sealer import (
+  ThermoScientificALPSError,
+  ThermoScientificALPSSealer,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ALPS5000Status(enum.IntFlag):
+  """Status byte returned by the ``?`` command (two hex digits).
+
+  ``Ready`` (0x00) is the all-clear value; any other bit is a condition that
+  must be cleared, or masked when ignorable, before an operation runs.
+  """
+
+  Ready = 0x00
+  NoFoil = 0x01
+  Error = 0x02
+  Busy = 0x04
+  WaitingForSealTemperature = 0x08
+  PlateNotPresent = 0x10
+  NotInitialised = 0x20
+  ForceSensorActivated = 0x40
+  PlatePresent = 0x80
+
+
+STATUS_MESSAGES: Dict[enum.IntFlag, str] = {
+  ALPS5000Status.NoFoil: "No foil detected",
+  ALPS5000Status.Error: "Error",
+  ALPS5000Status.Busy: "Busy",
+  ALPS5000Status.WaitingForSealTemperature: "Waiting for seal temperature",
+  ALPS5000Status.PlateNotPresent: "Plate not present in shuttle",
+  ALPS5000Status.NotInitialised: "Not initialised",
+  ALPS5000Status.ForceSensorActivated: "Force sensor is activated",
+  ALPS5000Status.PlatePresent: "Plate present in shuttle",
+}
+
+# Error codes returned by the ``E`` command.
+ERRORS = {
+  1: "Down error",
+  2: "Up error",
+  3: "Shuttle not in",
+  4: "Cutter Error",
+  5: "Thermocouple error - ambient temperature may be too low",
+  6: "Sealer overheating",
+  7: "No foil detected",
+  8: "No plate detected",
+  9: "Force sensor error",
+  10: "Engager Error",
+  11: "Gripper Error",
+  12: "Foil Clamp",
+  13: "Dropped Foil",
+}
+
+MIN_SEALING_FORCE = 5
+MAX_SEALING_FORCE = 50
+MIN_FOIL_LENGTH = 119
+MAX_FOIL_LENGTH = 128
+MIN_SEALING_DISTANCE = 10
+MAX_SEALING_DISTANCE = 50
+
+# Status bits tolerated while waiting for the sealer to accept an operation.
+_SETUP_MASK = (
+  ALPS5000Status.WaitingForSealTemperature
+  | ALPS5000Status.PlateNotPresent
+  | ALPS5000Status.PlatePresent
+)
+_READY_MASK = ALPS5000Status.WaitingForSealTemperature | ALPS5000Status.PlatePresent
+
+# Time the instrument needs to complete its initialisation routine.
+_INIT_SECONDS = 10.0
+
+
+class ThermoScientificALPS5000(ThermoScientificALPSSealer):
+  """Thermo Scientific ALPS 5000 heat sealer.
+
+  Extends the shared ALPS protocol with initialisation, force-sensor control,
+  foil length, sealing distance, and shuttle movement:
+    I            initialise the instrument; replies ok or err
+    PS={f:02d}   set sealing force, 5..50; replies ok
+    FS=1 / FS=0  enable / disable the force sensor; replies ok or err
+    L={n:03d}    set foil length, 119..128; replies ok
+    DO={n:02d}   set sealing distance, 10..50; replies ok
+    SI / SO      move the shuttle in / out; replies ok or err
+
+  Not verified: has NOT been tested against hardware in PyLabRobot. A warning
+  is emitted at setup.
+  """
+
+  _HUMAN_READABLE_NAME = "Thermo Scientific ALPS 5000 Heat Sealer"
+  STATUS = ALPS5000Status
+  STATUS_MESSAGES = STATUS_MESSAGES
+  ERRORS = ERRORS
+
+  async def setup(self) -> None:
+    await self._open()
+    await self.wait_for_idle(_SETUP_MASK)
+    await self.initialise()
+    await asyncio.sleep(_INIT_SECONDS)
+    await self.wait_for_idle(_SETUP_MASK)
+    await self.set_temperature(self.preheating_temperature)
+
+  async def seal(
+    self,
+    temperature: int = 160,
+    duration: float = 2.5,
+    use_force_sensor: bool = False,
+  ) -> None:
+    """Seal a plate.
+
+    Args:
+      temperature: sealing temperature in degrees C (5..199).
+      duration: sealing time in seconds (0.5..9.9).
+      use_force_sensor: enable the force sensor for this seal.
+    """
+    logger.info(
+      "[ALPS5000 %s] sealing at %d C for %.1fs (force sensor %s)",
+      self.io.port,
+      temperature,
+      duration,
+      "on" if use_force_sensor else "off",
+    )
+    await self.wait_for_idle(_READY_MASK)
+    await self.set_sealing_time(duration)
+    await self.set_temperature(temperature)
+    await self.enable_force_sensor(use_force_sensor)
+    await self.wait_for_sealing_temperature()
+    reply = await self.send_command("S")
+    if reply != "ok":
+      raise ThermoScientificALPSError(title="Seal command failed", message=f"S returned {reply!r}")
+    await self.wait_for_idle(_READY_MASK)
+
+  # === Extra commands ===
+
+  async def initialise(self) -> None:
+    """Run the instrument initialisation routine (``I``)."""
+    reply = await self.send_command("I")
+    if reply != "ok":
+      raise ThermoScientificALPSError(
+        title="Initialisation failed", message=f"I returned {reply!r}"
+      )
+
+  async def set_force(self, force: int) -> None:
+    """Set the sealing force (``PS``, 5..50)."""
+    if not MIN_SEALING_FORCE <= force <= MAX_SEALING_FORCE:
+      raise ValueError(f"force must be {MIN_SEALING_FORCE}..{MAX_SEALING_FORCE}")
+    command = f"PS={force:02d}"
+    reply = await self.send_command(command)
+    if reply != "ok":
+      raise ThermoScientificALPSError(
+        title="Setting sealing force failed", message=f"force {force} rejected with {reply!r}"
+      )
+
+  async def enable_force_sensor(self, enable: bool) -> None:
+    """Enable or disable the force sensor (``FS=1`` / ``FS=0``)."""
+    command = "FS=1" if enable else "FS=0"
+    reply = await self.send_command(command)
+    if reply != "ok":
+      raise ThermoScientificALPSError(
+        title="Setting force sensor failed", message=f"{command} returned {reply!r}"
+      )
+
+  async def set_foil_length(self, length: int) -> None:
+    """Set the foil length (``L``, 119..128)."""
+    if not MIN_FOIL_LENGTH <= length <= MAX_FOIL_LENGTH:
+      raise ValueError(f"foil length must be {MIN_FOIL_LENGTH}..{MAX_FOIL_LENGTH}")
+    command = f"L={length:03d}"
+    reply = await self.send_command(command)
+    if reply != "ok":
+      raise ThermoScientificALPSError(
+        title="Setting foil length failed", message=f"length {length} rejected with {reply!r}"
+      )
+
+  async def set_sealing_distance(self, distance: int) -> None:
+    """Set the sealing distance (``DO``, 10..50)."""
+    if not MIN_SEALING_DISTANCE <= distance <= MAX_SEALING_DISTANCE:
+      raise ValueError(f"distance must be {MIN_SEALING_DISTANCE}..{MAX_SEALING_DISTANCE}")
+    command = f"DO={distance:02d}"
+    reply = await self.send_command(command)
+    if reply != "ok":
+      raise ThermoScientificALPSError(
+        title="Setting sealing distance failed",
+        message=f"distance {distance} rejected with {reply!r}",
+      )
+
+  async def shuttle_in(self) -> None:
+    """Move the shuttle in (``SI``)."""
+    reply = await self.send_command("SI")
+    if reply != "ok":
+      raise ThermoScientificALPSError(title="Shuttle in failed", message=f"SI returned {reply!r}")
+
+  async def shuttle_out(self) -> None:
+    """Move the shuttle out (``SO``)."""
+    reply = await self.send_command("SO")
+    if reply != "ok":
+      raise ThermoScientificALPSError(title="Shuttle out failed", message=f"SO returned {reply!r}")

--- a/pylabrobot/thermo_fisher/alps/sealer.py
+++ b/pylabrobot/thermo_fisher/alps/sealer.py
@@ -1,0 +1,307 @@
+import abc
+import asyncio
+import enum
+import logging
+import time
+from typing import Dict, Optional, Type
+
+from pylabrobot.io.serial import Serial
+
+logger = logging.getLogger(__name__)
+
+
+class ThermoScientificALPSError(Exception):
+  """Error raised by a Thermo Scientific ALPS heat sealer."""
+
+  def __init__(
+    self,
+    title: str,
+    message: Optional[str] = None,
+    status: Optional[enum.IntFlag] = None,
+    error_code: Optional[int] = None,
+  ) -> None:
+    self.title = title
+    self.message = message
+    self.status = status
+    self.error_code = error_code
+
+  def __str__(self) -> str:
+    return f"{self.title}: {self.message}" if self.message else self.title
+
+
+class ThermoScientificALPSSealer(abc.ABC):
+  """Shared base for Thermo Scientific ALPS serial heat sealers (300 / 3000 / 5000).
+
+  Every model speaks the same ASCII-over-RS-232 core: a command is written with
+  a CR terminator, the device echoes the command in front of its reply, and the
+  echo is stripped before the reply is parsed (e.g. ``A160`` -> ``A160ok`` ->
+  ``ok``; ``?`` -> ``?3f`` -> ``3f``). This base implements the transport, the
+  status/error polling state machine, and the temperature and time commands.
+  Subclasses supply the model-specific status flags, error table,
+  human-readable name, ``setup``, ``seal``, and any extra commands.
+
+  Shared commands (ASCII, CR-terminated):
+    ?            read status byte, two hex digits (see the model's STATUS enum)
+    E            read error code, decimal digits (see the model's ERRORS table)
+    S            seal the plate; replies ok or err
+    A{t:03d}     set sealing temperature, degrees C (5..199)
+    B{t:02d}     set sealing time, deciseconds (05..99 = 0.5..9.9 s)
+    C            read sealing temperature setpoint, three digits
+    D            read sealing time setpoint, two digits (deciseconds)
+    F            read current heater temperature, three digits
+
+  Serial settings: 9600 baud, 8 data bits, no parity, 1 stop bit, no handshake,
+  CR (``\\r``) terminator.
+  """
+
+  # Human-readable device name, used for the serial handle. Overridden per model.
+  _HUMAN_READABLE_NAME: str = "Thermo Scientific ALPS Heat Sealer"
+
+  # Status flag enum returned by ``?``. Overridden per model.
+  STATUS: Type[enum.IntFlag]
+  # Description for each status bit, used to explain a not-ready condition.
+  STATUS_MESSAGES: Dict[enum.IntFlag, str]
+  # Text for each numeric error code returned by ``E``.
+  ERRORS: Dict[int, str]
+
+  # The low status bits mean the same thing on every model, so the state machine
+  # below works against them directly rather than the per-model enum: bit 0x02 is
+  # the error flag, bit 0x04 is the operation-in-progress flag (named Sealing on
+  # the 300, Busy on the 3000 and 5000), and bit 0x08 is set while the heater is
+  # below the setpoint.
+  _READY = 0x00
+  _ERROR = 0x02
+  _BUSY = 0x04
+  _NOT_AT_SEAL_TEMPERATURE = 0x08
+
+  MIN_SEALING_TEMPERATURE = 5
+  MAX_SEALING_TEMPERATURE = 199
+  MIN_SEALING_DURATION = 0.5
+  MAX_SEALING_DURATION = 9.9
+
+  def __init__(
+    self,
+    port: str,
+    timeout: float = 5.0,
+    settle_time: float = 2.0,
+    preheating_temperature: int = 100,
+  ) -> None:
+    self.timeout = timeout
+    self.settle_time = settle_time
+    self.preheating_temperature = preheating_temperature
+    self.io = Serial(
+      human_readable_device_name=self._HUMAN_READABLE_NAME,
+      port=port,
+      baudrate=9600,
+      bytesize=8,
+      parity="N",
+      stopbits=1,
+      timeout=0.2,
+    )
+
+  # === Subclass contract ===
+
+  @abc.abstractmethod
+  async def setup(self) -> None:
+    """Open the connection and bring the sealer to a ready, pre-heated state."""
+
+  @abc.abstractmethod
+  async def seal(self, temperature: int, duration: float) -> None:
+    """Seal a plate at the given sealing temperature (C) and duration (s)."""
+
+  async def _open(self) -> None:
+    """Open the port, wait out the post-open settling, and clear the buffer.
+
+    Emits the not-tested warning: no ALPS sealer driver has been verified
+    against hardware in PyLabRobot yet.
+    """
+    logger.warning(
+      "%s has NOT been tested against hardware in PyLabRobot. Please make a PR "
+      "to remove this message if you have verified it on your hardware.",
+      type(self).__name__,
+    )
+    await self.io.setup()
+    # Give a USB-to-serial adapter a moment to settle after the port opens.
+    await asyncio.sleep(self.settle_time)
+    await self.io.reset_input_buffer()
+
+  async def stop(self) -> None:
+    """Close the port."""
+    await self.io.stop()
+
+  # === Command layer ===
+
+  async def _read_line(self) -> str:
+    """Read bytes until a CR terminator, skipping stray LF."""
+    start = time.time()
+    buf = bytearray()
+    while True:
+      b = await self.io.read(1)
+      if b == b"":
+        if time.time() - start > self.timeout:
+          raise TimeoutError("Timeout while waiting for response from sealer.")
+        continue
+      if b == b"\r":
+        break
+      if b == b"\n":
+        continue
+      buf += b
+    return buf.decode("ascii", errors="replace")
+
+  async def send_command(self, command: str) -> str:
+    """Send a command and return the reply with the echoed command stripped.
+
+    Args:
+      command: command string without the CR terminator, e.g. "A160", "?".
+    """
+    await self.io.reset_input_buffer()
+    await self.io.write((command + "\r").encode("ascii"))
+    await asyncio.sleep(0.2)
+    text = await self._read_line()
+    return text.lstrip(command) if command else text.strip()
+
+  # === State ===
+
+  async def request_status(self) -> enum.IntFlag:
+    """Read the status byte (``?``)."""
+    reply = await self.send_command("?")
+    try:
+      return self.STATUS(int(reply, 16))
+    except ValueError as e:
+      raise ThermoScientificALPSError(title="Unexpected status reply", message=repr(reply)) from e
+
+  async def request_error_code(self) -> int:
+    """Read the current error code (``E``)."""
+    reply = await self.send_command("E")
+    try:
+      return int(reply)
+    except ValueError as e:
+      raise ThermoScientificALPSError(title="Unexpected error reply", message=repr(reply)) from e
+
+  async def wait_for_idle(self, ignore_mask: Optional[enum.IntFlag] = None) -> enum.IntFlag:
+    """Wait until the device is Ready, tolerating the bits set in ``ignore_mask``.
+
+    Raises ThermoScientificALPSError if any bit outside ``ignore_mask`` is set;
+    if the Error bit is set, the error code and text are attached.
+    """
+    mask = self._READY if ignore_mask is None else int(ignore_mask)
+
+    status = await self.request_status()
+    while status != self._READY:
+      if status & self._BUSY:
+        await asyncio.sleep(0.5)
+        status = await self._wait_for_busy_cleared()
+        continue
+
+      remaining = status & ~mask
+      if remaining == self._READY:
+        break
+
+      description = ", ".join(m for bit, m in self.STATUS_MESSAGES.items() if remaining & bit)
+      if remaining & self._ERROR:
+        code = await self.request_error_code()
+        raise ThermoScientificALPSError(
+          title=f"Sealer error: {description}",
+          message=self.ERRORS.get(code),
+          status=remaining,
+          error_code=code,
+        )
+      raise ThermoScientificALPSError(title=f"Sealer not ready: {description}", status=remaining)
+    return status
+
+  async def _wait_for_busy_cleared(self, timeout: float = 60.0) -> enum.IntFlag:
+    start = time.time()
+    status = await self.request_status()
+    while status & self._BUSY:
+      if time.time() - start > timeout:
+        raise ThermoScientificALPSError(title="Timeout while waiting for the seal to complete")
+      await asyncio.sleep(0.5)
+      status = await self.request_status()
+    return status
+
+  async def wait_for_sealing_temperature(self, timeout: float = 300.0) -> None:
+    """Block until the heater reaches the setpoint (NotAtSealTemperature clears)."""
+    start = time.time()
+    while await self.request_status() & self._NOT_AT_SEAL_TEMPERATURE:
+      if time.time() - start > timeout:
+        raise TimeoutError("Timeout while waiting for sealing temperature.")
+      await asyncio.sleep(5.0)
+
+  # === Parameters ===
+
+  async def set_temperature(self, temperature: int) -> None:
+    """Set the sealing temperature in degrees C (``A``, 5..199)."""
+    if not self.MIN_SEALING_TEMPERATURE <= temperature <= self.MAX_SEALING_TEMPERATURE:
+      raise ValueError(
+        f"temperature must be {self.MIN_SEALING_TEMPERATURE}..{self.MAX_SEALING_TEMPERATURE} C"
+      )
+    command = f"A{temperature:03d}"
+    reply = await self.send_command(command)
+    if reply != "ok":
+      raise ThermoScientificALPSError(
+        title="Setting sealing temperature failed",
+        message=f"temperature {temperature} rejected with {reply!r}",
+      )
+
+  async def set_sealing_time(self, seconds: float) -> None:
+    """Set the sealing time in seconds (``B``, 0.5..9.9)."""
+    if not self.MIN_SEALING_DURATION <= seconds <= self.MAX_SEALING_DURATION:
+      raise ValueError(f"time must be {self.MIN_SEALING_DURATION}..{self.MAX_SEALING_DURATION} s")
+    command = f"B{int(seconds * 10):02d}"
+    reply = await self.send_command(command)
+    if reply != "ok":
+      raise ThermoScientificALPSError(
+        title="Setting sealing time failed",
+        message=f"time {seconds} rejected with {reply!r}",
+      )
+
+  async def request_sealing_temperature(self) -> int:
+    """Read the sealing temperature setpoint in degrees C (``C``)."""
+    reply = await self.send_command("C")
+    try:
+      return int(reply)
+    except ValueError as e:
+      raise ThermoScientificALPSError(
+        title="Unexpected temperature reply", message=repr(reply)
+      ) from e
+
+  async def request_sealing_time(self) -> float:
+    """Read the sealing time setpoint in seconds (``D``)."""
+    reply = await self.send_command("D")
+    try:
+      return int(reply) / 10.0
+    except ValueError as e:
+      raise ThermoScientificALPSError(title="Unexpected time reply", message=repr(reply)) from e
+
+  async def request_temperature(self) -> int:
+    """Read the current heater temperature in degrees C (``F``)."""
+    reply = await self.send_command("F")
+    try:
+      return int(reply)
+    except ValueError as e:
+      raise ThermoScientificALPSError(
+        title="Unexpected temperature reply", message=repr(reply)
+      ) from e
+
+  async def _seal(self, temperature: int, duration: float, ready_mask: enum.IntFlag) -> None:
+    """Shared seal sequence: wait ready, apply time and temperature, wait for the
+    setpoint, seal, then wait for the operation to finish.
+
+    ``ready_mask`` is the set of status bits tolerated while waiting for the
+    device to accept the seal; it differs between models.
+    """
+    logger.info(
+      "[%s %s] sealing at %d C for %.1fs",
+      type(self).__name__,
+      self.io.port,
+      temperature,
+      duration,
+    )
+    await self.wait_for_idle(ready_mask)
+    await self.set_sealing_time(duration)
+    await self.set_temperature(temperature)
+    await self.wait_for_sealing_temperature()
+    reply = await self.send_command("S")
+    if reply != "ok":
+      raise ThermoScientificALPSError(title="Seal command failed", message=f"S returned {reply!r}")
+    await self.wait_for_idle(ready_mask)


### PR DESCRIPTION
Adds drivers for the Thermo Scientific ALPS 300, ALPS 3000, and ALPS 5000 heat
sealers.

- `ThermoScientificALPSSealer` — abstract base with the shared ASCII/RS-232
  protocol: 9600-8N1, CR-terminated, command echoed in front of the reply.
  Shared commands: `?` status, `E` error code, `S` seal, `A`/`B` set
  temperature/time, `C`/`D`/`F` read setpoints and current temperature. It
  implements the transport, the status/error polling state machine, and the
  temperature/time setpoints.
- `ThermoScientificALPS300`, `ThermoScientificALPS3000`,
  `ThermoScientificALPS5000` — one subclass per model. The models share the
  low status bits (error, in-progress, below-temperature) but differ in the
  remaining status bits and in their error tables, so each supplies its own
  `STATUS` flags, `ERRORS`, and ready-state masks.
- `ThermoScientificALPS5000` additionally exposes `initialise()`,
  `set_force()`, `enable_force_sensor()`, `set_foil_length()`,
  `set_sealing_distance()`, and `shuttle_in()`/`shuttle_out()`.
- Each subclass emits a not-verified-against-hardware warning at setup.
- The KBioscience KUBE driver already detects units running the ALPS protocol;
  its message now points at these drivers.

Not yet tested against hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)