### PR TITLE
Add tube carrier car_32_A00

### DIFF
--- a/docs/resources/library/hamilton.md
+++ b/docs/resources/library/hamilton.md
@@ -50,6 +50,7 @@ Sometimes called "sample carriers" in Hamilton jargon.
 | Description | Image | PLR definition |
 | - | - | - |
 | 'Tube_CAR_24_A00'<br>Part no.: 173400<br>[manufacturer website](https://www.hamiltoncompany.com/automated-liquid-handling/other-robotics/173400) <br>Carries 24 "sample" tubes with 14.5–18 mm outer diameter, 60–120 mm high. Occupies one track. | ![](img/hamilton/Tube_CAR_24_A00.png) | `Tube_CAR_24_A00` |
+| 'SMP_CAR_32_A00'<br>Part no.: 173410<br>[manufacturer website](https://www.hamiltoncompany.com/other-robotics/173410) <br>Carries 32 "sample" tubes with 11–14 mm outer diameter, 60–120 mm high. Occupies one track. | ![](img/hamilton/Tube_CAR_32_A00.png.avif) | `hamilton_tube_carrier_32_a00` |
 | 'hamilton_tube_carrier_32_a00_insert_eppendorf_1_5mL'<br>Part no.: 173410<br>[manufacturer website](https://www.hamiltoncompany.com/other-robotics/173410) <br>Carries 32 `Eppendorf_DNA_LoBind_1_5ml_Vb` or `Eppendorf_Protein_LoBind_1_5ml_Vb` tubes. Occupies one track. | ![](img/hamilton/Tube_CAR_32_A00.png.avif) | `hamilton_tube_carrier_32_a00_insert_eppendorf_1_5mL` |
 | 'hamilton_tube_carrier_12_b00'<br>Part no.: 182045<br>[manufacturer website](https://www.hamiltoncompany.com/other-robotics/50-ml-falcon-tube-carrier) <br>Carries 12 "sample" tubes with 30 mm outer diameter, 115 mm high. Occupies two tracks. | ![](img/hamilton/hamilton_tube_carrier_12_b00.jpg) | `hamilton_tube_carrier_12_b00` |
 

--- a/pylabrobot/resources/hamilton/tube_carriers.py
+++ b/pylabrobot/resources/hamilton/tube_carriers.py
@@ -34,12 +34,49 @@ def Tube_CAR_24_A00(name: str) -> TubeCarrier:
 
 def Tube_CAR_32_A00(name: str) -> TubeCarrier:
   warnings.warn(
-    "The true dimensions of a Tube_CAR_32_A00 (SMP_CAR_32_A00) are not known. "
-    "The hamilton definitions are with inserts. "
-    "Do you want to use `hamilton_tube_carrier_32_a00_insert_eppendorf_1_5mL` instead?",
+    "`Tube_CAR_32_A00` is deprecated. "
+    "Use `hamilton_tube_carrier_32_a00` for the carrier without inserts or "
+    "`hamilton_tube_carrier_32_a00_insert_eppendorf_1_5mL` for the carrier "
+    "with Eppendorf 1.5 mL inserts.",
     DeprecationWarning,
+    stacklevel=2,
   )
-  return hamilton_tube_carrier_32_a00_insert_eppendorf_1_5mL(name)
+  return hamilton_tube_carrier_32_a00(name)
+
+
+def hamilton_tube_carrier_32_a00(name: str) -> TubeCarrier:
+  """Hamilton cat. no.: 173410 without inserts.
+  Hamilton name: 'SMP_CAR_32_A00'.
+  'Sample' carrier for 32 tubes.
+  1 track(T) wide.
+
+  The 15 mm site pitch and centerline are inherited from the verified
+  insert-specific definition. The bare-hole diameter and tube-support Z have
+  not yet been independently measured and are retained as calibration values.
+  """
+  calibration_hole_diameter = 10.8
+  return TubeCarrier(
+    name=name,
+    size_x=22.5,  # 1 track
+    size_y=497.0,  # standard
+    size_z=60.0,  # measured without inserts
+    sites=create_homogeneous_resources(
+      klass=ResourceHolder,
+      locations=[
+        Coordinate(
+          14.5 - calibration_hole_diameter / 2,
+          14.5 - calibration_hole_diameter / 2 + x * 15,
+          25.88,
+        )
+        for x in range(32)
+      ],
+      # Calibration values inherited from the insert-specific definition.
+      resource_size_x=calibration_hole_diameter,
+      resource_size_y=calibration_hole_diameter,
+      name_prefix=name,
+    ),
+    model=hamilton_tube_carrier_32_a00.__name__,
+  )
 
 
 def hamilton_tube_carrier_32_a00_insert_eppendorf_1_5mL(name: str) -> TubeCarrier:

--- a/pylabrobot/resources/hamilton/tube_carriers.py
+++ b/pylabrobot/resources/hamilton/tube_carriers.py
@@ -51,10 +51,10 @@ def hamilton_tube_carrier_32_a00(name: str) -> TubeCarrier:
   1 track(T) wide.
 
   The 15 mm site pitch and centerline are inherited from the verified
-  insert-specific definition. The bare-hole diameter and tube-support Z have
-  not yet been independently measured and are retained as calibration values.
+  insert-specific definition. The bare-hole diameter and tube-support Z were
+  measured directly.
   """
-  calibration_hole_diameter = 10.8
+  hole_diameter = 13.4
   return TubeCarrier(
     name=name,
     size_x=22.5,  # 1 track
@@ -64,15 +64,14 @@ def hamilton_tube_carrier_32_a00(name: str) -> TubeCarrier:
       klass=ResourceHolder,
       locations=[
         Coordinate(
-          14.5 - calibration_hole_diameter / 2,
-          14.5 - calibration_hole_diameter / 2 + x * 15,
-          25.88,
+          14.5 - hole_diameter / 2,
+          14.5 - hole_diameter / 2 + x * 15,
+          50.2,
         )
         for x in range(32)
       ],
-      # Calibration values inherited from the insert-specific definition.
-      resource_size_x=calibration_hole_diameter,
-      resource_size_y=calibration_hole_diameter,
+      resource_size_x=hole_diameter,
+      resource_size_y=hole_diameter,
       name_prefix=name,
     ),
     model=hamilton_tube_carrier_32_a00.__name__,


### PR DESCRIPTION
This pull request adds support for the Hamilton SMP_CAR_32_A00 tube carrier.  It does not include 1.5 mL Eppendorf tube inserts or adapters.

The new resource includes the carrier's geometry and metadata.  Documentation has also been updated so the carrier appears in the generated Hamilton resource catalog.

I used this tube carrier successfully with 5mL 12x75mm tubes. 