### PR TITLE
feat(azenta): IntelliXcap 96 error-code readback and full RS232 command set

### DIFF
--- a/docs/api/pylabrobot.azenta.rst
+++ b/docs/api/pylabrobot.azenta.rst
@@ -65,3 +65,5 @@ FluidX IntelliXcap 96
     FirmwareVersions
     get_error_message
     is_recoverable_error
+    ERROR_CODE_MESSAGES
+    RECOVERABLE_ERROR_CODES

--- a/docs/api/pylabrobot.azenta.rst
+++ b/docs/api/pylabrobot.azenta.rst
@@ -59,4 +59,9 @@ FluidX IntelliXcap 96
 
     FluidXIntelliXcap96
     FluidXError
+    ExtendedStatus
+    CartridgeProfile
+    CartridgeInfo
+    FirmwareVersions
     get_error_message
+    is_recoverable_error

--- a/docs/user_guide/azenta/fluidx/intellixcap96/hello-world.ipynb
+++ b/docs/user_guide/azenta/fluidx/intellixcap96/hello-world.ipynb
@@ -10,21 +10,7 @@
    "cell_type": "markdown",
    "id": "085d70c0",
    "metadata": {},
-   "source": [
-    "## Physical setup\n\n",
-    "\n\n",
-    "Connect the decapper's serial port to your computer through its USB-to-serial adapter and use the stable `by-id` path so the port survives re-enumeration, e.g. `/dev/serial/by-id/usb-FTDI_USB_Serial_Converter_XXXXXXXX-if00-port0`.\n\n",
-    "\n\n",
-    "Tube volume is not a driver setting. The installed IntelliCartridge and its firmware profile define the supported tube height, cap geometry/thread, and motion settings. Use the cartridge specified for the exact tube family: two nominally 0.5 mL tube types may require different cartridges. Cartridge IDs 1–14 load their matching profiles automatically; extended cartridges require the corresponding stored profile to be selected on the instrument. The Python commands are otherwise identical for every supported tube type. See the [official Azenta IntelliXcap user manual](https://web.azenta.com/hubfs/azenta-files/resources/manuals-guides/319430-IXC-User-Manual.pdf) for cartridge/profile setup and compatibility guidance.\n\n",
-    "\n\n",
-    "```{important}\n\n",
-    "If the instrument comes up reporting `StatusBUSY` and ignores commands, it is\n\n",
-    "locked out. The most common cause is an **engaged e-stop**; the safety guard/hood\n\n",
-    "and other interlocks do the same. There is no command to read the e-stop\n\n",
-    "directly, so `setup()` raises with this hint when it sees `StatusBUSY` at connect.\n\n",
-    "Clear the e-stop and retry.\n\n",
-    "```"
-   ]
+   "source": "## Physical setup\n\nConnect the decapper's serial port to your computer through its USB-to-serial adapter and use the stable `by-id` path so the port survives re-enumeration, e.g. `/dev/serial/by-id/usb-FTDI_USB_Serial_Converter_XXXXXXXX-if00-port0`.\n\nTube volume is not a driver setting. The installed IntelliCartridge and its firmware profile define the supported tube height, cap geometry/thread, and motion settings. Use the cartridge specified for the exact tube family: two nominally 0.5 mL tube types may require different cartridges. Cartridge IDs 1–14 load their matching profiles automatically; extended cartridges require the corresponding stored profile to be selected on the instrument. The Python commands are otherwise identical for every supported tube type. See the [official Azenta IntelliXcap user manual](https://web.azenta.com/hubfs/azenta-files/resources/manuals-guides/319430-IXC-User-Manual.pdf) for cartridge/profile setup and compatibility guidance.\n\n```{important}\nIf the instrument comes up reporting `StatusBUSY` and ignores commands, it is locked out. The usual cause is an **engaged e-stop**; the safety guard/hood and other interlocks do the same. `setup()` reads the e-stop bit from the extended status and says whether it is actually engaged, then raises. If the e-stop reads as released, check the guard/hood and interlocks.\n\n`request_extended_status().estop_active` reports the same bit at any time.\n```"
   },
   {
    "cell_type": "markdown",
@@ -53,11 +39,7 @@
    "cell_type": "markdown",
    "id": "e4a5895a",
    "metadata": {},
-   "source": [
-    "## Status\n\n",
-    "\n\n",
-    "`request_status()` returns the current status word: `StatusOK` (idle with no caps held), `StatusBUSY` (moving), `StatusRECAP` (decapped; caps held and ready to recap or waste), `StatusSLEEP` (standby), or `StatusMANUAL` (the instrument requires inspection and touchscreen recovery). Note the status word does **not** encode the tray position."
-   ]
+   "source": "## Status\n\n`request_status()` returns the current status word: `StatusOK` (idle with no caps held), `StatusBUSY` (moving), `StatusRECAP` (decapped; caps held and ready to recap or waste), `StatusSLEEP` (standby), `StatusCAREJECT` (cartridge ejected), or `StatusMANUAL` (halted; needs inspection, then `reset_error()` or one of the manual recovery commands). Note the status word does **not** encode the tray position."
   },
   {
    "cell_type": "code",
@@ -86,7 +68,7 @@
   {
    "cell_type": "markdown",
    "id": "414a2f74",
-   "source": "## What the instrument can tell you about itself\n\nFour queries describe the machine and its consumable:\n\n- `request_firmware_versions()` -> unit, touchscreen and light curtain firmware. Two features depend on it: dry-run mode needs touchscreen V14 or above, and `waste()` is broken in unit V44.\n- `request_cartridge_info()` -> the installed cartridge's profile, cycle count and serial. The serial always reads `\"00000000\"`; the firmware does not implement it.\n- `request_profile()` -> the active profile number and its decap/recap retry limits.\n- `request_extended_status()` -> the flags the status word leaves out, including whether caps are held on the pins, whether a cartridge is installed and whether the e-stop is engaged. `caps_on_pins()` is a shortcut for the first of those.",
+   "source": "## What the instrument can tell you about itself\n\nFour queries describe the machine and its consumable:\n\n- `request_firmware_versions()` -> unit, touchscreen and light curtain firmware. Two features depend on it: dry-run mode needs touchscreen V14 or above, and `waste()` is broken in V44 (the command list does not say which firmware that version refers to).\n- `request_cartridge_info()` -> the installed cartridge's profile, cycle count and serial. The serial always reads `\"00000000\"`; the firmware does not implement it.\n- `request_profile()` -> the active profile number and its decap/recap retry limits.\n- `request_extended_status()` -> the flags the status word leaves out, including whether caps are held on the pins, whether a cartridge is installed and whether the e-stop is engaged. `caps_on_pins()` is a shortcut for the first of those.\n\n```{note}\nThe command list names twelve extended-status flags but shows an eleven-character answer. `request_extended_status()` rejects any width other than twelve rather than guess which end is missing, because the most significant bit is `CAPS_ON_PINS`. If it raises on your instrument, the raw string is in the message.\n```",
    "metadata": {}
   },
   {
@@ -152,7 +134,7 @@
   {
    "cell_type": "code",
    "id": "17591151",
-   "source": "await decapper.extend_tray()    # S3 -> S127, all the way out",
+   "source": "# t fails unless the tray is already at the load position, so open it first.\nawait decapper.open_tray()\nawait decapper.extend_tray()    # S3 -> S127, all the way out",
    "metadata": {},
    "execution_count": null,
    "outputs": []
@@ -197,7 +179,7 @@
    "cell_type": "markdown",
    "id": "ec297b15",
    "metadata": {},
-   "source": "## Decap, recap, waste\n\nWith a rack of screw-cap tubes loaded on the nest, `decap()` unscrews and holds all 96 caps. After decapping, choose **one** terminal operation: `recap()` screws those caps back onto the tubes, while `waste()` releases them into a separately positioned cap carrier. `decap()` refuses if caps are already held (recap or waste first); `recap()` refuses if none are held.\n\nA fault (e.g. decapping with no rack loaded) can latch the device in `StatusError`, and the failing call raises a `FluidXError` carrying the instrument's error code and its documented meaning. A latched error is cleared **only by homing**. By default (`auto_recover=True`) the next operation you issue homes to clear `StatusError` and then proceeds; pass `auto_recover=False` to have it raise instead. `StatusMANUAL` requires an explicit safety decision: inspect the rack and cap head, confirm that axis motion is safe, then call `reset_error()`. Hardware testing confirmed that it homes the machine from `StatusMANUAL` through `StatusBUSY` to `StatusOK`. Normal motion commands remain blocked until recovery completes.\n\nHoming drops any caps held on the pins. If the instrument stopped mid-cycle with caps held, use `initialize_keeping_caps_on_pins()` instead and then `recap()` (see *Manual recovery* below).\n\n```{warning}\n`waste()` is irreversible and does not detect whether a cap carrier is present. Before calling it, open the tray, remove the sample-tube rack, and position the correct cap carrier or collection vessel according to your instrument's procedure. On hardware, leaving the tube rack beneath the head caused the released caps to fall back onto the tube openings. They looked recapped but were not guaranteed to be threaded or torqued. See the [official Azenta IntelliXcap user manual](https://web.azenta.com/hubfs/azenta-files/resources/manuals-guides/319430-IXC-User-Manual.pdf), which defines waste as dropping caps into a carrier.\n\nUnit firmware V44 does not implement `waste()` at all. On that firmware, load a store rack and use `decap()`/`recap()`, which select the store sequence themselves. `request_firmware_versions()` reports the unit firmware.\n```"
+   "source": "## Decap, recap, waste\n\nWith a rack of screw-cap tubes loaded on the nest, `decap()` unscrews and holds all 96 caps. After decapping, choose **one** terminal operation: `recap()` screws those caps back onto the tubes, while `waste()` releases them into a separately positioned cap carrier. `decap()` refuses if caps are already held (recap or waste first); `recap()` refuses if none are held.\n\nA fault (e.g. decapping with no rack loaded) can latch the device in `StatusError`, and the failing call raises a `FluidXError` carrying the instrument's error code and its documented meaning. Homing clears a latched `StatusError`. By default (`auto_recover=True`) the next operation you issue homes to clear it and then proceeds; pass `auto_recover=False` to have it raise instead. `StatusMANUAL` requires an explicit safety decision: inspect the rack and cap head, confirm that axis motion is safe, then call `reset_error()`. Hardware testing confirmed that it homes the machine from `StatusMANUAL` through `StatusBUSY` to `StatusOK`. Normal motion commands remain blocked until recovery completes.\n\nThe command list says the initialize sequence \"will not drop caps\", but it also documents a separate command for initializing without dropping them. Neither has been checked on hardware. With caps held, use `initialize_keeping_caps_on_pins()` (see *Manual recovery* below), which is the command documented for that case.\n\n```{warning}\n`waste()` is irreversible and does not detect whether a cap carrier is present. Before calling it, open the tray, remove the sample-tube rack, and position the correct cap carrier or collection vessel according to your instrument's procedure. On hardware, leaving the tube rack beneath the head caused the released caps to fall back onto the tube openings. They looked recapped but were not guaranteed to be threaded or torqued. See the [official Azenta IntelliXcap user manual](https://web.azenta.com/hubfs/azenta-files/resources/manuals-guides/319430-IXC-User-Manual.pdf), which defines waste as dropping caps into a carrier.\n\nFirmware V44 does not implement `waste()` at all — the command list does not say which of the three firmwares it means. On that version, load a store rack and use `decap()`/`recap()`, which select the store sequence themselves. `request_firmware_versions()` reports all three.\n```"
   },
   {
    "cell_type": "code",
@@ -290,7 +272,7 @@
   {
    "cell_type": "markdown",
    "id": "4e73401b",
-   "source": "## Settings\n\nThree flags change how the instrument behaves during a run. All three reset when the instrument is power cycled: error detection and the safety door come back on, dry-run comes back off.\n\n- `set_error_detection_enabled(False)` stops the light curtain from failing a decap/recap on error 135/136, so the stroke always finishes. It is also the prerequisite for `retry_decap()`.\n- `set_dry_run_enabled(True)` makes the instrument pause and wait for the operator on light curtain errors 114, 118, 135 and 136 instead of failing the operation.\n- `set_safety_door_enabled(False)` disables the safety door, which leaves it open.\n\n```{warning}\nEach of these weakens a safety or error check. `set_safety_door_enabled(False)` leaves the door open until the instrument is power cycled.\n```",
+   "source": "## Settings\n\nThree flags change how the instrument behaves during a run.\n\n- `set_error_detection_enabled(False)` stops the light curtain from failing a decap/recap on error 135/136, so the stroke always finishes. It is also the prerequisite for `retry_decap()`. Detection is on at power-up.\n- `set_dry_run_enabled(True)` makes the instrument pause and wait for the operator on light curtain errors 114, 118, 135 and 136 instead of failing the operation. Needs touchscreen firmware V14 or above.\n- `set_safety_door_enabled(False)` disables the safety door, which leaves it open. Call it with `True` to re-enable; the door is also enabled at power-up.\n\n```{warning}\nEach of these weakens a safety or error check.\n```",
    "metadata": {}
   },
   {
@@ -312,7 +294,7 @@
   {
    "cell_type": "code",
    "id": "63266af7",
-   "source": "# Leaves the door open until the instrument is power cycled.\nawait decapper.set_safety_door_enabled(False)",
+   "source": "# Opens the door and keeps it open; call with True to re-enable.\nawait decapper.set_safety_door_enabled(False)",
    "metadata": {},
    "execution_count": null,
    "outputs": []
@@ -350,7 +332,7 @@
   {
    "cell_type": "code",
    "id": "2b9e2326",
-   "source": "# Homing drops held caps; this clears the error and homes while keeping them.\n# Follow it with recap() to put the caps back on the tubes.\nawait decapper.initialize_keeping_caps_on_pins()",
+   "source": "# Clears the error state and homes without dropping caps held on the pins.\n# Follow it with recap() to put the caps back on the tubes.\nawait decapper.initialize_keeping_caps_on_pins()",
    "metadata": {},
    "execution_count": null,
    "outputs": []

--- a/docs/user_guide/azenta/fluidx/intellixcap96/hello-world.ipynb
+++ b/docs/user_guide/azenta/fluidx/intellixcap96/hello-world.ipynb
@@ -2,29 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "1c911a78",
    "metadata": {},
-   "source": [
-    "# FluidX IntelliXcap 96\n",
-    "\n",
-    "The FluidX IntelliXcap 96 (an Azenta brand) is an automated screw-cap **decapper**. It unscrews, holds, and screws back on all 96 caps of a screw-cap tube rack in a single stroke. A plate mover loads the rack onto its one nest.\n",
-    "\n",
-    "## Resources\n",
-    "\n",
-    "- [Azenta IntelliXcap user manual](https://web.azenta.com/hubfs/azenta-files/resources/manuals-guides/319430-IXC-User-Manual.pdf)\n",
-    "- [Azenta IntelliXcap 96 product page](https://www.azenta.com/products/intellixcap-automated-screw-cap-decapper-recapper-96-format)\n",
-    "\n",
-    "| Property | Value |\n",
-    "| --- | --- |\n",
-    "| Communication | Serial, STX/ETX-framed ASCII |\n",
-    "| Serial settings | 9600 baud, 8 data bits, no parity, 1 stop bit, no handshake |\n",
-    "| Framing | each reply is wrapped in STX (`0x02`) .. ETX (`0x03`) |\n",
-    "| Reply pattern | ACK (`0x06`), then `<cmd>OK` echo, then a result frame |\n",
-    "\n",
-    "Every command is a single character written followed by ETX. A motion command is accepted with an ACK and a `<cmd>OK` echo; the status word then reads `StatusBUSY` while it moves. The terminal state depends on the operation: decap finishes at `StatusRECAP` while the head holds caps, whereas recap and waste finish at `StatusOK`. A refused or no-op command answers `CommandIgnore`."
-   ]
+   "source": "# FluidX IntelliXcap 96\n\nThe FluidX IntelliXcap 96 (an Azenta brand) is an automated screw-cap **decapper**. It unscrews, holds, and screws back on all 96 caps of a screw-cap tube rack in a single stroke. A plate mover loads the rack onto its one nest.\n\n## Resources\n\n- [Azenta IntelliXcap user manual](https://web.azenta.com/hubfs/azenta-files/resources/manuals-guides/319430-IXC-User-Manual.pdf)\n- [Azenta IntelliXcap 96 product page](https://www.azenta.com/products/intellixcap-automated-screw-cap-decapper-recapper-96-format)\n\n| Property | Value |\n| --- | --- |\n| Communication | Serial, STX/ETX-framed ASCII |\n| Serial settings | 9600 baud, 8 data bits, no parity, 1 stop bit, no handshake |\n| Framing | each reply is wrapped in STX (`0x02`) .. ETX (`0x03`) |\n| Reply pattern | ACK (`0x06`), then `<cmd>OK` echo, then a result frame |\n\nEvery command is a single character written followed by ETX. A motion command is accepted with an ACK and a `<cmd>OK` echo; the status word then reads `StatusBUSY` while it moves. The terminal state depends on the operation: decap finishes at `StatusRECAP` while the head holds caps, whereas recap and waste finish at `StatusOK`. A refused or no-op command answers `CommandIgnore`.\n\n```{important}\nThe instrument only answers this protocol in **IntelliXcap mode**. Set setpoint 86 to `2` on the instrument touchscreen; there is no serial command for it.\n```"
   },
   {
    "cell_type": "markdown",
+   "id": "085d70c0",
    "metadata": {},
    "source": [
     "## Physical setup\n\n",
@@ -44,6 +28,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "33641725",
    "metadata": {},
    "source": [
     "## Connect\n\n",
@@ -53,6 +38,7 @@
   },
   {
    "cell_type": "code",
+   "id": "729f73e2",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -65,6 +51,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e4a5895a",
    "metadata": {},
    "source": [
     "## Status\n\n",
@@ -74,6 +61,7 @@
   },
   {
    "cell_type": "code",
+   "id": "00808280",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -83,28 +71,51 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9d0c74b1",
    "metadata": {},
-   "source": [
-    "### Error codes\n",
-    "\n",
-    "The legacy serial protocol may report a generic operation failure such as `DecapERROR` without including the instrument's numeric error code. When a reply does include a known code, `FluidXError` decodes it automatically and exposes it as `error_code`. If the code is available separately from the instrument error log, look up its documented meaning with `get_error_message()` or construct the same exception with `FluidXError.from_error_code()`.\n",
-    "\n",
-    "```python\n",
-    "from pylabrobot.azenta.fluidx import FluidXError, get_error_message\n",
-    "\n",
-    "print(get_error_message(145))\n",
-    "# Light curtain calibration max retries exceeded.\n",
-    "\n",
-    "error = FluidXError.from_error_code(145)\n",
-    "print(error)\n",
-    "# IntelliXcap error 145: Light curtain calibration max retries exceeded.\n",
-    "```\n",
-    "\n",
-    "The complete local mapping comes from the error table in the [official Azenta IntelliXcap user manual](https://web.azenta.com/hubfs/azenta-files/resources/manuals-guides/319430-IXC-User-Manual.pdf)."
-   ]
+   "source": "### Error codes\n\n`StatusERROR` and `StatusMANUAL` only say that *something* went wrong. `request_error_code()` asks the instrument for the numeric code behind it, and returns `None` when nothing is latched.\n\nThe driver does this for you: whenever an operation fails, it reads the code back and raises a `FluidXError` carrying it in `error_code`, with the documented meaning in the message. `get_error_message()` looks a code up by hand, and `is_recoverable_error()` (also on the exception, as `.recoverable`) says whether homing will clear it:\n\n- **Recoverable** codes latch `StatusERROR`, which homing clears: 113/114 (decap), 117/118 (recap), 142 (cartridge eject), 143/144 (cartridge load).\n- **Every other** code halts the instrument in `StatusMANUAL`, which needs an operator to inspect it.\n\nThe code table comes from the error list in the [official Azenta IntelliXcap user manual](https://web.azenta.com/hubfs/azenta-files/resources/manuals-guides/319430-IXC-User-Manual.pdf)."
+  },
+  {
+   "cell_type": "code",
+   "id": "3c55c578",
+   "source": "from pylabrobot.azenta.fluidx import get_error_message, is_recoverable_error\n\ncode = await decapper.request_error_code()\nif code is None:\n    print(\"no error latched\")\nelse:\n    print(code, get_error_message(code), \"recoverable:\", is_recoverable_error(code))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
+   "id": "414a2f74",
+   "source": "## What the instrument can tell you about itself\n\nFour queries describe the machine and its consumable:\n\n- `request_firmware_versions()` -> unit, touchscreen and light curtain firmware. Two features depend on it: dry-run mode needs touchscreen V14 or above, and `waste()` is broken in unit V44.\n- `request_cartridge_info()` -> the installed cartridge's profile, cycle count and serial. The serial always reads `\"00000000\"`; the firmware does not implement it.\n- `request_profile()` -> the active profile number and its decap/recap retry limits.\n- `request_extended_status()` -> the flags the status word leaves out, including whether caps are held on the pins, whether a cartridge is installed and whether the e-stop is engaged. `caps_on_pins()` is a shortcut for the first of those.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "e15d3859",
+   "source": "print(\"firmware:\", await decapper.request_firmware_versions())",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "a35b8210",
+   "source": "print(\"cartridge:\", await decapper.request_cartridge_info())\nprint(\"profile:\", await decapper.request_profile())",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "a9137607",
+   "source": "print(\"extended status:\", await decapper.request_extended_status())\nprint(\"caps held:\", await decapper.caps_on_pins())",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6812c7f3",
    "metadata": {},
    "source": [
     "## Tray\n",
@@ -114,6 +125,7 @@
   },
   {
    "cell_type": "code",
+   "id": "b55ee6e6",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -123,6 +135,7 @@
   },
   {
    "cell_type": "code",
+   "id": "7b6fe71d",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -132,6 +145,37 @@
   },
   {
    "cell_type": "markdown",
+   "id": "de6913a2",
+   "source": "### Presenting the tray further out\n\nPast the load position the tray can travel out to an extended position, which is useful for handing decapped tubes to an operator or another instrument. The two ends are setpoints 3 (load) and 127 (extended), and the step size is setpoint 88; all three are configured on the instrument.\n\n- `extend_tray()` / `retract_tray()` move between the two ends. Extending requires the tray to be at the load position, so open the tray first.\n- `step_tray_out()` / `step_tray_in()` move by one step. A step that would leave the S3..S127 range fails rather than clipping.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "17591151",
+   "source": "await decapper.extend_tray()    # S3 -> S127, all the way out",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "8962b392",
+   "source": "await decapper.step_tray_in()   # one S88 step back in",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "d57fd7ec",
+   "source": "await decapper.retract_tray()   # all the way back to S3",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "310cb8dd",
    "metadata": {},
    "source": [
     "## Home\n\n",
@@ -141,6 +185,7 @@
   },
   {
    "cell_type": "code",
+   "id": "349d6644",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -150,21 +195,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ec297b15",
    "metadata": {},
-   "source": [
-    "## Decap, recap, waste\n",
-    "\n",
-    "With a rack of screw-cap tubes loaded on the nest, `decap()` unscrews and holds all 96 caps. After decapping, choose **one** terminal operation: `recap()` screws those caps back onto the tubes, while `waste()` releases them into a separately positioned cap carrier. `decap()` refuses if caps are already held (recap or waste first); `recap()` refuses if none are held.\n",
-    "\n",
-    "A fault (e.g. decapping with no rack loaded) can latch the device in `StatusError`, and the failing call raises a `FluidXError` carrying the firmware's message. A latched error is cleared **only by homing** -- the reset command is ignored on this firmware. By default (`auto_recover=True`) the next operation you issue homes to clear `StatusError` and then proceeds; pass `auto_recover=False` to have it raise instead. `StatusMANUAL` requires an explicit safety decision: inspect the rack and cap head, confirm that axis motion is safe, then call `reset_error()`. Hardware testing confirmed that it homes the machine from `StatusMANUAL` through `StatusBUSY` to `StatusOK`. Normal motion commands remain blocked until recovery completes.\n",
-    "\n",
-    "```{warning}\n",
-    "`waste()` is irreversible and does not detect whether a cap carrier is present. Before calling it, open the tray, remove the sample-tube rack, and position the correct cap carrier or collection vessel according to your instrument's procedure. On hardware, leaving the tube rack beneath the head caused the released caps to fall back onto the tube openings. They looked recapped but were not guaranteed to be threaded or torqued. See the [official Azenta IntelliXcap user manual](https://web.azenta.com/hubfs/azenta-files/resources/manuals-guides/319430-IXC-User-Manual.pdf), which defines waste as dropping caps into a carrier.\n",
-    "```"
-   ]
+   "source": "## Decap, recap, waste\n\nWith a rack of screw-cap tubes loaded on the nest, `decap()` unscrews and holds all 96 caps. After decapping, choose **one** terminal operation: `recap()` screws those caps back onto the tubes, while `waste()` releases them into a separately positioned cap carrier. `decap()` refuses if caps are already held (recap or waste first); `recap()` refuses if none are held.\n\nA fault (e.g. decapping with no rack loaded) can latch the device in `StatusError`, and the failing call raises a `FluidXError` carrying the instrument's error code and its documented meaning. A latched error is cleared **only by homing**. By default (`auto_recover=True`) the next operation you issue homes to clear `StatusError` and then proceeds; pass `auto_recover=False` to have it raise instead. `StatusMANUAL` requires an explicit safety decision: inspect the rack and cap head, confirm that axis motion is safe, then call `reset_error()`. Hardware testing confirmed that it homes the machine from `StatusMANUAL` through `StatusBUSY` to `StatusOK`. Normal motion commands remain blocked until recovery completes.\n\nHoming drops any caps held on the pins. If the instrument stopped mid-cycle with caps held, use `initialize_keeping_caps_on_pins()` instead and then `recap()` (see *Manual recovery* below).\n\n```{warning}\n`waste()` is irreversible and does not detect whether a cap carrier is present. Before calling it, open the tray, remove the sample-tube rack, and position the correct cap carrier or collection vessel according to your instrument's procedure. On hardware, leaving the tube rack beneath the head caused the released caps to fall back onto the tube openings. They looked recapped but were not guaranteed to be threaded or torqued. See the [official Azenta IntelliXcap user manual](https://web.azenta.com/hubfs/azenta-files/resources/manuals-guides/319430-IXC-User-Manual.pdf), which defines waste as dropping caps into a carrier.\n\nUnit firmware V44 does not implement `waste()` at all. On that firmware, load a store rack and use `decap()`/`recap()`, which select the store sequence themselves. `request_firmware_versions()` reports the unit firmware.\n```"
   },
   {
    "cell_type": "code",
+   "id": "6b3ddcb2",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -175,6 +212,7 @@
   },
   {
    "cell_type": "code",
+   "id": "cd3b20d4",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -184,6 +222,7 @@
   },
   {
    "cell_type": "code",
+   "id": "19704bfd",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -194,6 +233,7 @@
   },
   {
    "cell_type": "code",
+   "id": "af381383",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -205,6 +245,119 @@
   },
   {
    "cell_type": "markdown",
+   "id": "32aae9c6",
+   "source": "### Forcing another decap attempt\n\n**You only need this if you have turned light curtain error detection off.** With detection on, the instrument spots the tubes that failed to decap and retries the stroke by itself inside `decap()`, up to the profile's decap retry limit (`request_profile().decap_max_retry`). There is nothing left for you to force.\n\nWith detection off the instrument cannot see those tubes, so `decap()` returns successfully and leaves them capped. `retry_decap()` forces another stroke; `decap()` itself refuses, because caps are held. Call it as many times as you need.\n\n```{note}\nThe command list documents only that this command is used \"after a successful Decap\" and \"requires lightcurtain OFF\". That those are the same condition is inferred from the automatic-retry and error-detection commands rather than stated by the vendor.\n```",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "deb6dfc4",
+   "source": "await decapper.set_error_detection_enabled(False)\nawait decapper.retry_decap()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5058ff42",
+   "source": "## Changing the cartridge\n\nThe IntelliCartridge defines which tubes the instrument can handle, so switching tube families means swapping it. `eject_cartridge()` puts the installed cartridge on the tray and `load_cartridge()` picks up the one resting there, returning the profile number the instrument loaded. Both read the extended status first, so calling them when the instrument is already in that state is a no-op.\n\nPhysically remove the ejected cartridge from the tray, and place the new one, between the two calls.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "1ca901ec",
+   "source": "# Empty the tray and make sure no caps are held first.\nawait decapper.eject_cartridge()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "fb66970d",
+   "source": "# Place the replacement cartridge on the tray, then pick it up.\nprint(\"loaded profile:\", await decapper.load_cartridge())",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "e5924fd6",
+   "source": "# Zero the cycle counter, e.g. after fitting a rebuilt cartridge.\nawait decapper.reset_cartridge_counter()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e73401b",
+   "source": "## Settings\n\nThree flags change how the instrument behaves during a run. All three reset when the instrument is power cycled: error detection and the safety door come back on, dry-run comes back off.\n\n- `set_error_detection_enabled(False)` stops the light curtain from failing a decap/recap on error 135/136, so the stroke always finishes. It is also the prerequisite for `retry_decap()`.\n- `set_dry_run_enabled(True)` makes the instrument pause and wait for the operator on light curtain errors 114, 118, 135 and 136 instead of failing the operation.\n- `set_safety_door_enabled(False)` disables the safety door, which leaves it open.\n\n```{warning}\nEach of these weakens a safety or error check. `set_safety_door_enabled(False)` leaves the door open until the instrument is power cycled.\n```",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "6d7bc7b0",
+   "source": "await decapper.set_error_detection_enabled(False)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "fe87592b",
+   "source": "# Requires touchscreen firmware V14 or above.\nawait decapper.set_dry_run_enabled(True)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "63266af7",
+   "source": "# Leaves the door open until the instrument is power cycled.\nawait decapper.set_safety_door_enabled(False)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a8f1df0",
+   "source": "## Manual recovery\n\nThese commands are only accepted while the instrument is halted in `StatusMANUAL`, and it stays there afterwards. They exist to get a stuck instrument back to a state you can inspect and clear.\n\n```{warning}\nAll of these move axes or open the safety door. Look inside the instrument and confirm that motion is safe before running any of them.\n```",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "2cce2756",
+   "source": "await decapper.open_safety_door()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "5201c0f1",
+   "source": "# Home the Z axis, keeping any held caps on the pins.\nawait decapper.head_up()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "724dea0a",
+   "source": "# Drops any caps still on the cap drivers, wherever the head is standing.\n# Clear the deck first; use waste() when you want to collect them.\nawait decapper.eject_caps()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "2b9e2326",
+   "source": "# Homing drops held caps; this clears the error and homes while keeping them.\n# Follow it with recap() to put the caps back on the tubes.\nawait decapper.initialize_keeping_caps_on_pins()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6acf47ef",
    "metadata": {},
    "source": [
     "## Standby\n\n",
@@ -214,6 +367,7 @@
   },
   {
    "cell_type": "code",
+   "id": "6ce5ea4b",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -223,6 +377,7 @@
   },
   {
    "cell_type": "code",
+   "id": "7fad708f",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -232,6 +387,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6d6c3888",
    "metadata": {},
    "source": [
     "## Teardown\n\n",
@@ -241,6 +397,7 @@
   },
   {
    "cell_type": "code",
+   "id": "a0d6806f",
    "execution_count": null,
    "metadata": {},
    "outputs": [],

--- a/pylabrobot/azenta/__init__.py
+++ b/pylabrobot/azenta/__init__.py
@@ -1,3 +1,14 @@
 from .a4s import A4S, A4SDriver, A4SSealerBackend, A4SStatus, A4STemperatureBackend
-from .fluidx import ERROR_CODE_MESSAGES, FluidXError, FluidXIntelliXcap96, get_error_message
+from .fluidx import (
+  ERROR_CODE_MESSAGES,
+  RECOVERABLE_ERROR_CODES,
+  CartridgeInfo,
+  CartridgeProfile,
+  ExtendedStatus,
+  FirmwareVersions,
+  FluidXError,
+  FluidXIntelliXcap96,
+  get_error_message,
+  is_recoverable_error,
+)
 from .xpeel import XPeel, XPeelDriver, XPeelPeelerBackend

--- a/pylabrobot/azenta/fluidx/__init__.py
+++ b/pylabrobot/azenta/fluidx/__init__.py
@@ -1,6 +1,12 @@
 from .intellixcap96 import (
   ERROR_CODE_MESSAGES,
+  RECOVERABLE_ERROR_CODES,
+  CartridgeInfo,
+  CartridgeProfile,
+  ExtendedStatus,
+  FirmwareVersions,
   FluidXError,
   FluidXIntelliXcap96,
   get_error_message,
+  is_recoverable_error,
 )

--- a/pylabrobot/azenta/fluidx/intellixcap96.py
+++ b/pylabrobot/azenta/fluidx/intellixcap96.py
@@ -68,6 +68,7 @@ ERROR_MESSAGES = {
   ),
   "NeedToRecap": "Decap operation is already done. Select the recap operation on the device.",
   "NeedToDecap": "Recap operation is already executed.",
+  "CapsOnPins": "Caps are held on the pins. Recap or waste them first.",
   "DecapWasNotSuccesful": (
     "Decapping was not successful. Fix the error on the device manually and check whether any "
     "tubes are still on the head."
@@ -99,17 +100,15 @@ ERROR_MESSAGES = {
   "EjectCapsWasNotSuccesful": "Ejecting the held caps was not successful.",
   "HeadUpWasNotSuccesful": "Homing the cap head was not successful.",
   "SafetyDoorWasNotSuccesful": "Operating the safety door was not successful.",
-  "RetryDecapWasNotSuccesful": (
-    "The forced decap retry was not successful. This command requires light curtain error "
-    "detection to be off."
-  ),
+  "RetryDecapWasNotSuccesful": "The forced decap retry was not successful.",
   "CannotGoInStandbyMode": "Cannot go to standby mode. Check the errors on the device.",
   "NotInManualMode": (
     "This command is only available while the device is in manual recovery mode (StatusMANUAL)."
   ),
   "StatusManual": (
-    "The device is in manual recovery mode. Inspect the rack and cap head, then complete the "
-    "appropriate recovery from the instrument touchscreen before sending another motion command."
+    "The device is in manual recovery mode. Inspect the rack and cap head, confirm that axis "
+    "motion is safe, then recover with reset_error(), or with head_up(), eject_caps() or "
+    "initialize_keeping_caps_on_pins(), before sending another motion command."
   ),
   "CommandIgnore": "Command was ignored by the device.",
   "NoAck": "Device did not acknowledge the command.",
@@ -216,10 +215,13 @@ ERROR_CODE_MESSAGES: Dict[int, str] = {
   238: "Emergency stop engaged or motor voltage low.",
 }
 
-# Codes that leave the instrument in StatusERROR, which homing clears. Every
-# other code leaves it in StatusMANUAL, which halts the instrument until an
-# operator has inspected it. Decap reports 113/114, recap 117/118, cartridge
-# eject 142, and cartridge load 143/144.
+# Codes the command list pins to StatusERROR, which homing clears, rather than
+# to StatusMANUAL, which halts the instrument until an operator has inspected
+# it: decap reports 113/114, recap 117/118, cartridge eject 142, and cartridge
+# load 143/144. The command list states this only for those four commands, and
+# it is inconsistent elsewhere (the tray and standby entries name StatusMANUAL
+# in their state rows but StatusERROR in their comments), so a code outside this
+# set is not proof that the instrument halted.
 RECOVERABLE_ERROR_CODES: FrozenSet[int] = frozenset({113, 114, 117, 118, 142, 143, 144})
 
 
@@ -236,11 +238,15 @@ def get_error_message(code: int) -> str:
 
 
 def is_recoverable_error(code: int) -> bool:
-  """Whether an error code leaves the instrument in StatusERROR rather than StatusMANUAL.
+  """Whether the command list pins this code to StatusERROR rather than StatusMANUAL.
 
   A StatusERROR is cleared by homing, which :meth:`FluidXIntelliXcap96.home` does
   and which operations do for themselves when ``auto_recover`` is enabled. A
-  StatusMANUAL halts the instrument until an operator inspects it.
+  StatusMANUAL halts the instrument until an operator inspects it. False means
+  the command list does not pin the code to StatusERROR, not that the instrument
+  is certainly halted: it documents the mapping only for decap, recap, cartridge
+  eject and cartridge load. Read :meth:`FluidXIntelliXcap96.request_status` for
+  the state the instrument is actually in.
   """
   return code in RECOVERABLE_ERROR_CODES
 
@@ -322,9 +328,13 @@ class CartridgeProfile:
     )
 
 
-# The extended status bitmask, most significant bit first. The firmware reply is
-# read least-significant-bit-first from the right, so a reply shorter than this
-# tuple is treated as having its leading zeros suppressed.
+# The extended status bitmask, most significant bit first.
+#
+# The command list is inconsistent about the width: it names these twelve flags
+# but shows an eleven-character answer field. Which end a short reply is missing
+# is therefore unknown, and guessing costs correctness at the most significant
+# bit, which is CAPS_ON_PINS. A reply of any other width is rejected rather than
+# padded, so the discrepancy surfaces instead of silently reading caps as absent.
 EXTENDED_STATUS_FLAGS: Tuple[str, ...] = (
   "caps_on_pins",
   "dry_run_enabled",
@@ -334,7 +344,7 @@ EXTENDED_STATUS_FLAGS: Tuple[str, ...] = (
   "screw_caps_on",
   "cartridge_installed",
   "standby_active",
-  "stage_extended",
+  "stage_pos",
   "recover_mode",
   "estop_active",
   "time_for_service",
@@ -345,9 +355,13 @@ EXTENDED_STATUS_FLAGS: Tuple[str, ...] = (
 class ExtendedStatus:
   """Instrument state flags that the plain status word does not carry.
 
-  ``caps_on_pins`` is the authoritative answer to "are caps currently held?",
-  and ``cartridge_installed``, ``estop_active`` and ``recover_mode`` explain
-  states that otherwise only show up as a refused command.
+  ``caps_on_pins`` reports directly what the status word only implies through
+  ``StatusRECAP``, and ``cartridge_installed``, ``estop_active`` and
+  ``recover_mode`` explain states that otherwise only show up as a refused
+  command.
+
+  ``stage_pos`` is the command list's ``STAGE_POS`` bit. Which position each
+  value means is not documented.
   """
 
   caps_on_pins: bool
@@ -358,7 +372,7 @@ class ExtendedStatus:
   screw_caps_on: bool
   cartridge_installed: bool
   standby_active: bool
-  stage_extended: bool
+  stage_pos: bool
   recover_mode: bool
   estop_active: bool
   time_for_service: bool
@@ -374,15 +388,16 @@ class ExtendedStatus:
       )
     width = len(EXTENDED_STATUS_FLAGS)
     if len(bits) != width:
-      logger.warning(
-        "[IntelliXcap96] extended status is %d bits, expected %d: %r. Reading it from the "
-        "least significant bit.",
-        len(bits),
-        width,
-        bits,
+      raise FluidXError(
+        title="Unexpected extended status width",
+        message=(
+          f"got {len(bits)} bits, expected {width}: {bits!r}. The command list names {width} "
+          f"flags but shows an {width - 1}-character answer, so which end is missing cannot be "
+          "guessed without misreading CAPS_ON_PINS. Map this reply against the instrument's "
+          "known state and fix EXTENDED_STATUS_FLAGS."
+        ),
       )
-    aligned = bits.rjust(width, "0")[-width:]
-    values = {flag: aligned[index] == "1" for index, flag in enumerate(EXTENDED_STATUS_FLAGS)}
+    values = {flag: bits[index] == "1" for index, flag in enumerate(EXTENDED_STATUS_FLAGS)}
     return cls(raw=bits, **values)
 
 
@@ -470,14 +485,15 @@ class FluidXIntelliXcap96:
 
   Which state a failure lands in depends on the error code: 113/114 for decap,
   117/118 for recap, 142 for cartridge eject and 143/144 for cartridge load
-  latch ``StatusERROR``, and anything else halts in ``StatusMANUAL``.
-  :meth:`request_error_code` reads the latched code, and every raised
-  :class:`FluidXError` carries it in ``error_code`` when the instrument reported
-  one.
+  latch ``StatusERROR``, and the command list says anything else halts those
+  four commands in ``StatusMANUAL``. It does not document the mapping for the
+  other commands. :meth:`request_error_code` reads the latched code, and every
+  raised :class:`FluidXError` carries it in ``error_code`` when the instrument
+  reported one.
 
-  A ``StatusError`` is cleared only by homing. With ``auto_recover`` enabled (the
-  default), an operation issued while the device is latched in error homes to
-  recover and then proceeds.
+  Homing clears a ``StatusError``. With ``auto_recover`` enabled (the default),
+  an operation issued while the device is latched in error homes to recover and
+  then proceeds.
 
   Verified against hardware: connection, status, tray open/close, home,
   standby/ready, the decap error/recovery path, and decap/recap with a loaded
@@ -530,19 +546,26 @@ class FluidXIntelliXcap96:
 
   async def setup(self) -> None:
     await self.io.setup()
+    logger.warning(
+      "[IntelliXcap96 %s] most of this driver's commands are implemented from the RS232 command "
+      "list and have not been run on an instrument. The queries, tray open/close, home, "
+      "standby/ready and decap/recap/waste are hardware-verified; the tray travel, cartridge, "
+      "settings and manual recovery commands are not. Please report back so this can be updated.",
+      self.io.port,
+    )
     status = await self.request_status()
     up = status.upper()
     if "BUSY" in up:
-      # At connect there is no motion in flight, so a persistent StatusBUSY means
-      # the instrument is locked out. By far the most common cause is an engaged
-      # e-stop; the safety guard/hood and other interlocks do the same. The
-      # extended status carries an e-stop bit, so read it before giving up.
+      # At connect there is no motion in flight, so StatusBUSY means the
+      # instrument is locked out, commonly by an engaged e-stop; the safety
+      # guard/hood and other interlocks do the same. The extended status carries
+      # an e-stop bit, so read it before giving up.
       estop = await self._estop_hint()
       logger.error(
-        "[IntelliXcap96 %s] reports StatusBUSY at connect and will ignore commands. "
-        "Check the E-STOP first (most common cause), then the safety guard/hood and "
-        "interlocks, and retry.",
+        "[IntelliXcap96 %s] reports StatusBUSY at connect and will ignore commands. %s "
+        "Also check the safety guard/hood and interlocks, and retry.",
         self.io.port,
+        estop,
       )
       raise FluidXError(
         title="Decapper is not ready (StatusBUSY)",
@@ -671,7 +694,7 @@ class FluidXIntelliXcap96:
     try:
       extended = await self.request_extended_status()
     except FluidXError:
-      return "This is almost always an engaged E-STOP."
+      return "The E-STOP could not be read; it is a common cause."
     if extended.estop_active:
       return "The E-STOP is engaged; release it."
     return "The E-STOP reads as released."
@@ -729,7 +752,7 @@ class FluidXIntelliXcap96:
     fail_key: str,
     terminal_statuses: Tuple[str, ...] = ("StatusOK",),
     done_frames: Tuple[str, ...] = (),
-  ) -> None:
+  ) -> List[str]:
     """Poll status until it reaches an expected idle state.
 
     ``fail_key`` names the firmware error message to raise if the status word
@@ -738,22 +761,31 @@ class FluidXIntelliXcap96:
     ``StatusRECAP`` after decapping and after tray motion with caps held.
     ``done_frames`` are the operation's own completion frames, which end the
     wait as soon as one is seen.
+
+    Returns every frame seen while waiting, so a caller can pick up an answer
+    the instrument sends alongside its completion.
     """
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout
     expected = {status.upper() for status in terminal_statuses}
     done = {frame.upper() for frame in done_frames}
+    seen: List[str] = []
     while loop.time() < deadline:
       frames = await self.send_command(STATUS)
+      seen.extend(frames)
+      for frame in frames:
+        if frame.upper() in ("RETRYDECAP", "RETRYRECAP"):
+          # The instrument retries a failed stroke by itself; report the attempt.
+          logger.info("[IntelliXcap96 %s] %s: instrument reports %s", self.io.port, name, frame)
       if any(_is_error_frame(f) for f in frames):
         raise await self._latched_fault(fail_key, f"{name}: {frames!r}", frames)
       if any(f.upper() in done for f in frames):
-        return
+        return seen
       status = self._status_frame(frames)
       if status is not None:
         up = status.upper()
         if up in expected:
-          return
+          return seen
         if "MANUAL" in up:
           # A halt needs an operator, so waiting out the timeout only delays the report.
           raise await self._latched_fault("StatusManual", f"{name}: {frames!r}", frames)
@@ -780,6 +812,9 @@ class FluidXIntelliXcap96:
     ``StatusERROR`` and ``StatusMANUAL`` say only that something went wrong.
     :func:`get_error_message` turns the code into its documented meaning, and
     :func:`is_recoverable_error` says whether homing will clear it.
+
+    The command list documents the reply only as a three-digit error code and
+    does not say how "no error" is expressed; a code of 0 is read as none.
     """
     frames = await self.send_command(ERROR_QUERY)
     self._require_accepted(ERROR_QUERY, frames, "Reading the error code", idempotent=True)
@@ -805,8 +840,9 @@ class FluidXIntelliXcap96:
   async def request_firmware_versions(self) -> FirmwareVersions:
     """Read the unit, touchscreen and light curtain firmware versions.
 
-    Dry-run mode requires touchscreen firmware V14 or above, and the store
-    operation is broken in unit firmware V44.
+    Dry-run mode requires touchscreen firmware V14 or above. The store operation
+    is broken in V44; the command list does not say which of the three
+    firmwares that version refers to.
     """
     frames = await self.send_command(FIRMWARE_QUERY)
     self._require_accepted(FIRMWARE_QUERY, frames, "Reading the firmware versions", idempotent=True)
@@ -841,7 +877,12 @@ class FluidXIntelliXcap96:
     return CartridgeProfile.from_raw(payload)
 
   async def caps_on_pins(self) -> bool:
-    """Whether caps are currently held on the ejector pins."""
+    """Whether caps are currently held on the ejector pins.
+
+    Reads the ``CAPS_ON_PINS`` bit. The decap, recap and waste guards instead
+    gate on the ``StatusRECAP`` word, which the command list ties to the same
+    condition and which is hardware-verified.
+    """
     return (await self.request_extended_status()).caps_on_pins
 
   # === Operations ===
@@ -855,7 +896,7 @@ class FluidXIntelliXcap96:
         timeout,
         "Opening the tray",
         "OpenTrayWasNotSuccesful",
-        ("StatusOK", "StatusRECAP", "StatusDECAP"),
+        ("StatusOK", "StatusRECAP"),
         done_frames=("OpenDONE",),
       )
     logger.info("[IntelliXcap96 %s] tray open", self.io.port)
@@ -869,7 +910,7 @@ class FluidXIntelliXcap96:
         timeout,
         "Closing the tray",
         "CloseTrayWasNotSuccesful",
-        ("StatusOK", "StatusRECAP", "StatusDECAP"),
+        ("StatusOK", "StatusRECAP"),
         done_frames=("CloseDONE",),
       )
     logger.info("[IntelliXcap96 %s] tray closed", self.io.port)
@@ -905,7 +946,11 @@ class FluidXIntelliXcap96:
   async def step_tray_out(self, timeout: float = 15.0) -> None:
     """Move the tray further out by the step distance in setpoint 88.
 
-    Travel is bounded by the load position (S3) and the extended position
+    Relative, so calling it twice moves the tray twice. The instrument offers no
+    way to command an intermediate position directly, and no way to read the
+    current one back, so stepping is the only access to the range between the
+    two ends; :meth:`extend_tray` and :meth:`retract_tray` are the absolute
+    moves. Travel is bounded by the load position (S3) and the extended position
     (S127); a step that would leave that range fails.
     """
     await self._tray_move(TRAY_STEP_OUT, "Stepping the tray out", timeout)
@@ -913,8 +958,9 @@ class FluidXIntelliXcap96:
   async def step_tray_in(self, timeout: float = 15.0) -> None:
     """Move the tray back in by the step distance in setpoint 88.
 
-    Travel is bounded by the load position (S3) and the extended position
-    (S127); a step that would leave that range fails.
+    Relative, so calling it twice moves the tray twice. See
+    :meth:`step_tray_out`. Travel is bounded by the load position (S3) and the
+    extended position (S127); a step that would leave that range fails.
     """
     await self._tray_move(TRAY_STEP_IN, "Stepping the tray in", timeout)
 
@@ -974,8 +1020,13 @@ class FluidXIntelliXcap96:
     Hardware testing confirmed that the home-all command transitions
     ``StatusMANUAL`` through ``StatusBUSY`` to ``StatusOK``. Call this only after
     inspecting the rack and cap head and confirming that axis motion is safe.
-    Homing drops any held caps; use :meth:`initialize_keeping_caps_on_pins` when
-    caps are still on the pins.
+
+    What homing does to caps held on the pins is unsettled. The command list
+    says the home sequence "will not drop caps", yet it also carries a separate
+    command to initialize without dropping them, which that would make
+    redundant. Neither behaviour has been checked on an instrument. With caps
+    held, prefer :meth:`initialize_keeping_caps_on_pins`, which is the command
+    documented for that case.
 
     This method is a no-op when the instrument is not in an error or manual
     recovery state.
@@ -1059,7 +1110,7 @@ class FluidXIntelliXcap96:
       timeout,
       "Retrying the decap",
       "RetryDecapWasNotSuccesful",
-      ("StatusOK", "StatusRECAP"),
+      ("StatusOK",),
       done_frames=("DecapDONE",),
     )
     logger.info("[IntelliXcap96 %s] decap retry complete", self.io.port)
@@ -1079,7 +1130,7 @@ class FluidXIntelliXcap96:
       timeout,
       "Recapping",
       "RecapWasNotSuccesful",
-      ("StatusOK", "StatusDECAP"),
+      ("StatusOK",),
       done_frames=("RecapDONE",),
     )
     logger.info("[IntelliXcap96 %s] recap complete", self.io.port)
@@ -1095,9 +1146,11 @@ class FluidXIntelliXcap96:
     threaded or torqued.
 
     The instrument picks the store sequence from the height of the cap carrier
-    and otherwise performs a recap. Unit firmware V44 does not implement this
-    command; on that firmware, load a store rack and use :meth:`decap` and
-    :meth:`recap`, which select the store sequence themselves.
+    and otherwise performs a recap. Firmware V44 does not implement this command
+    -- the command list does not say which of the three firmwares it means -- so
+    on that version load a store rack and use :meth:`decap` and :meth:`recap`,
+    which select the store sequence themselves. A store that times out presents
+    the tray, answering ``LoadOK`` alongside the ``StoreERROR``.
 
     User manual:
     https://web.azenta.com/hubfs/azenta-files/resources/manuals-guides/319430-IXC-User-Manual.pdf
@@ -1114,7 +1167,7 @@ class FluidXIntelliXcap96:
       timeout,
       "Wasting caps",
       "StoreWasNotSuccesful",
-      ("StatusOK", "StatusDECAP"),
+      ("StatusOK",),
       done_frames=("StoreDONE",),
     )
     logger.info("[IntelliXcap96 %s] waste complete", self.io.port)
@@ -1122,11 +1175,10 @@ class FluidXIntelliXcap96:
   async def standby(self, timeout: float = 15.0) -> None:
     """Put the decapper into low-power standby (sleep) mode.
 
-    A no-op when the instrument is already asleep. The instrument refuses to
-    sleep while caps are held on the pins.
+    A no-op when the instrument is already asleep. The instrument requires
+    StatusOK to sleep, and refuses while caps are held on the pins.
     """
-    status = (await self.request_status()).upper()
-    if "SLEEP" in status:
+    if "SLEEP" in (await self.request_status()).upper():
       return
     frames = await self.send_command(STANDBY)
     self._require_accepted(STANDBY, frames, "Entering standby")
@@ -1162,7 +1214,7 @@ class FluidXIntelliXcap96:
     if not extended.cartridge_installed:
       return
     if extended.caps_on_pins:
-      raise _fault("NeedToRecap", "the cartridge cannot be ejected while caps are held")
+      raise _fault("CapsOnPins", "the cartridge cannot be ejected while caps are held")
     await self._ensure_ready()
     frames = await self.send_command(CARTRIDGE_EJECT)
     self._require_accepted(CARTRIDGE_EJECT, frames, "Ejecting the cartridge")
@@ -1170,7 +1222,7 @@ class FluidXIntelliXcap96:
       timeout,
       "Ejecting the cartridge",
       "CartridgeEjectWasNotSuccesful",
-      ("StatusCAREJECT", "StatusOK"),
+      ("StatusCAREJECT",),
       done_frames=("CarEjectDONE",),
     )
     logger.info("[IntelliXcap96 %s] cartridge ejected", self.io.port)
@@ -1178,32 +1230,40 @@ class FluidXIntelliXcap96:
   async def load_cartridge(self, timeout: float = 60.0) -> Optional[int]:
     """Pick up the cartridge resting on the tray.
 
-    A no-op when a cartridge is already installed.
+    A no-op when a cartridge is already installed. Loading a stored profile
+    (16-96) answers ``ProfileLoadERROR`` if that profile does not exist or is
+    invalid.
 
     Returns:
-      The loaded profile number when the firmware reports one, else None.
+      The loaded profile number when the instrument reports one, else None. It
+      answers with ``onnOK`` at the end of the motion, so this is None if that
+      frame never arrives.
     """
     if (await self.request_extended_status()).cartridge_installed:
       return None
     frames = await self.send_command(CARTRIDGE_LOAD)
     self._require_accepted(CARTRIDGE_LOAD, frames, "Loading the cartridge")
-    await self._wait_for_idle(
+    if any(_is_error_frame(f) for f in frames):
+      raise await self._latched_fault(
+        "CartridgeLoadWasNotSuccesful", f"Loading the cartridge: {frames!r}", frames
+      )
+    seen = await self._wait_for_idle(
       timeout,
       "Loading the cartridge",
       "CartridgeLoadWasNotSuccesful",
       ("StatusOK",),
       done_frames=("CarLoadDONE", "ExtCarLoadDONE"),
     )
-    profile = _loaded_profile(frames)
+    profile = _loaded_profile(frames + seen)
     logger.info("[IntelliXcap96 %s] cartridge loaded (profile %s)", self.io.port, profile)
     return profile
 
   async def reset_cartridge_counter(self) -> None:
     """Reset the installed cartridge's cycle counter to zero."""
+    name = "Resetting the cartridge counter"
     frames = await self.send_command(CARTRIDGE_COUNTER_RESET)
-    self._require_accepted(
-      CARTRIDGE_COUNTER_RESET, frames, "Resetting the cartridge counter", idempotent=True
-    )
+    self._require_accepted(CARTRIDGE_COUNTER_RESET, frames, name, idempotent=True)
+    self._require_answer(frames, "CarResetDONE", name)
     logger.info("[IntelliXcap96 %s] cartridge counter reset", self.io.port)
 
   # === Settings ===
@@ -1240,9 +1300,8 @@ class FluidXIntelliXcap96:
   async def set_safety_door_enabled(self, enabled: bool) -> None:
     """Turn safety door operation on or off.
 
-    Disabling it leaves the door open and keeps it open until the instrument is
-    power cycled, which is how the door is enabled again. The door is enabled at
-    power-up.
+    Disabling it opens the door and keeps it open. Call this with ``True`` to
+    re-enable the door; it is also enabled again at power-up.
     """
     command = SAFETY_DOOR_ENABLE if enabled else SAFETY_DOOR_DISABLE
     name = "Enabling the safety door" if enabled else "Disabling the safety door"

--- a/pylabrobot/azenta/fluidx/intellixcap96.py
+++ b/pylabrobot/azenta/fluidx/intellixcap96.py
@@ -566,13 +566,6 @@ class FluidXIntelliXcap96:
 
   async def setup(self) -> None:
     await self.io.setup()
-    logger.warning(
-      "[IntelliXcap96 %s] connection, queries, tray open/close, home, standby/ready, settings, "
-      "cartridge eject/load, forced decap retry and decap/recap/waste are hardware-verified. "
-      "Unit firmware V49 does not acknowledge the tray travel commands. The cartridge counter "
-      "reset and manual recovery commands are not hardware-verified.",
-      self.io.port,
-    )
     status = await self.request_status()
     up = status.upper()
     if "BUSY" in up:

--- a/pylabrobot/azenta/fluidx/intellixcap96.py
+++ b/pylabrobot/azenta/fluidx/intellixcap96.py
@@ -1,7 +1,8 @@
 import asyncio
+import dataclasses
 import logging
 import re
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, FrozenSet, List, NamedTuple, Optional, Tuple
 
 from pylabrobot.io.serial import Serial
 
@@ -9,9 +10,10 @@ logger = logging.getLogger(__name__)
 
 # Every reply is framed between STX (0x02) and ETX (0x03). A command is answered
 # with an ACK frame (a lone 0x06), a command-echo frame ("<cmd>OK"), and then a
-# result frame (a "Status..." word, or "CommandIgnore" when the command is a
-# no-op or refused). Motions run asynchronously: the status word is "StatusBUSY"
-# while moving, then changes to the operation-specific terminal state.
+# result frame (an operation-specific "...DONE"/"...ERROR" word, a "Status..."
+# word, or "CommandIgnore" when the command is a no-op or refused). Motions run
+# asynchronously: the status word is "StatusBUSY" while moving, then changes to
+# the operation-specific terminal state.
 STX = b"\x02"
 ETX = b"\x03"
 ACK = "\x06"
@@ -24,11 +26,38 @@ WASTE = "b"
 OPEN_TRAY = "f"
 CLOSE_TRAY = "g"
 HOME_ALL = "Z"
-RESET = "z"
+INITIALIZE_KEEP_CAPS = "z"
 STANDBY = "j"
 READY = "k"
+CARTRIDGE_EJECT = "c"
+CARTRIDGE_LOAD = "C"
+TRAY_EXTEND = "t"
+TRAY_RETRACT = "T"
+TRAY_STEP_OUT = "s"
+TRAY_STEP_IN = "S"
+CARTRIDGE_COUNTER_RESET = "X"
+FIRMWARE_QUERY = "V"
+CARTRIDGE_QUERY = "N"
+EJECT_CAPS = "5"
+HEAD_UP = "6"
+SAFETY_DOOR_OPEN = "7"
+ERROR_QUERY = "8"
+SAFETY_DOOR_DISABLE = "-"
+SAFETY_DOOR_ENABLE = "+"
+ERROR_DETECTION_OFF = "l"
+ERROR_DETECTION_ON = "L"
+DRY_RUN_ON = "d"
+DRY_RUN_OFF = "D"
+EXTENDED_STATUS = "e"
+PROFILE_QUERY = "E"
+RETRY_DECAP = "Q"
 
 COMMAND_IGNORE = "CommandIgnore"
+
+# "ErrorDetectON" and "ErrorDetectOFF" are ordinary success replies to the
+# error-detection commands, so a bare "ERROR" substring is not a fault. A fault
+# frame ends the word there: "DecapERROR", "StatusERROR", "tERROR".
+_ERROR_FRAME_RE = re.compile(r"ERROR\b")
 
 # Fault descriptions as reported by the instrument firmware.
 ERROR_MESSAGES = {
@@ -51,18 +80,33 @@ ERROR_MESSAGES = {
   "CloseTrayWasNotSuccesful": (
     "Closing the tray was not successful. Fix the error on the device manually."
   ),
+  "TrayMoveWasNotSuccesful": (
+    "Moving the tray was not successful. The tray can only travel between the load position "
+    "(setpoint 3) and the extended position (setpoint 127)."
+  ),
   "HomeNotSuccesful": (
     "Device was not able to reach the home position. The device is in an error state. "
     "Restart the device."
   ),
-  "CannotReset": (
-    "Cannot send the reset command to the device. The device is in an error state. "
-    "Reset the device and try again."
+  "CartridgeEjectWasNotSuccesful": (
+    "Ejecting the cartridge was not successful. The tray must be empty and no caps may be held "
+    "on the pins."
   ),
-  "ResetNotSuccesful": (
-    "Reset did not complete. The device is in an error state. Reset the device and try again."
+  "CartridgeLoadWasNotSuccesful": (
+    "Loading the cartridge was not successful. Check that a cartridge is present on the tray and "
+    "seated at the expected height."
+  ),
+  "EjectCapsWasNotSuccesful": "Ejecting the held caps was not successful.",
+  "HeadUpWasNotSuccesful": "Homing the cap head was not successful.",
+  "SafetyDoorWasNotSuccesful": "Operating the safety door was not successful.",
+  "RetryDecapWasNotSuccesful": (
+    "The forced decap retry was not successful. This command requires light curtain error "
+    "detection to be off."
   ),
   "CannotGoInStandbyMode": "Cannot go to standby mode. Check the errors on the device.",
+  "NotInManualMode": (
+    "This command is only available while the device is in manual recovery mode (StatusMANUAL)."
+  ),
   "StatusManual": (
     "The device is in manual recovery mode. Inspect the rack and cap head, then complete the "
     "appropriate recovery from the instrument touchscreen before sending another motion command."
@@ -71,8 +115,7 @@ ERROR_MESSAGES = {
   "NoAck": "Device did not acknowledge the command.",
 }
 
-# Legacy serial firmware generally reports only a generic frame such as
-# "DecapERROR", but some firmware may include a numeric error code in a reply.
+# Fault descriptions per numeric error code, as read back with the error query.
 #
 # Source: Azenta IntelliXcap User Manual, part 319430 Rev. E, pp. 88-91:
 # https://web.azenta.com/hubfs/azenta-files/resources/manuals-guides/319430-IXC-User-Manual.pdf
@@ -101,16 +144,16 @@ ERROR_CODE_MESSAGES: Dict[int, str] = {
   112: "Door close failure.",
   113: (
     "M1 moved to M1_SAFETY_LOW_POS (S33): no light curtain trigger was detected while "
-    "scanning for caps."
+    "scanning for caps. Reported by the decap sequence."
   ),
-  114: "Invalid tube height detected.",
+  114: "Invalid tube height detected. Reported by the decap sequence.",
   115: "Door open failure.",
   116: "Door close failure at start of sequence.",
   117: (
     "M1 moved to M1_SAFETY_LOW_POS (S33): no light curtain trigger was detected while "
-    "scanning for caps."
+    "scanning for caps. Reported by the recap sequence."
   ),
-  118: "Invalid tube height detected.",
+  118: "Invalid tube height detected. Reported by the recap sequence.",
   119: "Open door failure.",
   120: "Open door failure on entry to manual mode.",
   121: "Door close failure.",
@@ -120,8 +163,14 @@ ERROR_CODE_MESSAGES: Dict[int, str] = {
   125: "M1 failed to reach the waste position within S4 during the auto-waste sequence.",
   133: "M1 homing error.",
   134: "Open door failure.",
-  135: ("Cap detected at valid height. This may be an informational device-state code."),
-  136: "Maximum decap attempts exceeded (S46).",
+  135: (
+    "Cap detected at valid height. Suppressed while light curtain error detection is off; "
+    "in dry-run mode the instrument halts here and waits for the operator."
+  ),
+  136: (
+    "Maximum decap attempts exceeded (S46). Suppressed while light curtain error detection is "
+    "off; in dry-run mode the instrument halts here and waits for the operator."
+  ),
   137: "Maximum recap attempts exceeded (S45).",
   138: (
     "M3 bottom switch closed while the motor was still moving; extended-stage lead-screw "
@@ -167,6 +216,12 @@ ERROR_CODE_MESSAGES: Dict[int, str] = {
   238: "Emergency stop engaged or motor voltage low.",
 }
 
+# Codes that leave the instrument in StatusERROR, which homing clears. Every
+# other code leaves it in StatusMANUAL, which halts the instrument until an
+# operator has inspected it. Decap reports 113/114, recap 117/118, cartridge
+# eject 142, and cartridge load 143/144.
+RECOVERABLE_ERROR_CODES: FrozenSet[int] = frozenset({113, 114, 117, 118, 142, 143, 144})
+
 
 def get_error_message(code: int) -> str:
   """Return the documented meaning of an IntelliXcap error code.
@@ -178,6 +233,16 @@ def get_error_message(code: int) -> str:
   if message is None:
     return "Unknown IntelliXcap error code."
   return message
+
+
+def is_recoverable_error(code: int) -> bool:
+  """Whether an error code leaves the instrument in StatusERROR rather than StatusMANUAL.
+
+  A StatusERROR is cleared by homing, which :meth:`FluidXIntelliXcap96.home` does
+  and which operations do for themselves when ``auto_recover`` is enabled. A
+  StatusMANUAL halts the instrument until an operator inspects it.
+  """
+  return code in RECOVERABLE_ERROR_CODES
 
 
 class FluidXError(Exception):
@@ -204,13 +269,131 @@ class FluidXError(Exception):
       error_code=code,
     )
 
+  @property
+  def recoverable(self) -> bool:
+    """Whether homing clears the reported error. False when there is no error code."""
+    return self.error_code is not None and is_recoverable_error(self.error_code)
+
   def __str__(self) -> str:
     return f"{self.title}: {self.message}" if self.message else self.title
+
+
+class FirmwareVersions(NamedTuple):
+  """Firmware versions of the three IntelliXcap subsystems, each four digits."""
+
+  unit: str
+  touchscreen: str
+  light_curtain: str
+
+
+class CartridgeInfo(NamedTuple):
+  """Identity and usage of the installed IntelliCartridge."""
+
+  profile: int
+  cycle_count: int
+  serial: str
+
+
+@dataclasses.dataclass(frozen=True)
+class CartridgeProfile:
+  """Settings of the cartridge profile the instrument is running."""
+
+  number: int
+  communication_protocol: int
+  decap_max_retry: int
+  recap_max_retry: int
+  raw: str
+
+  @classmethod
+  def from_raw(cls, raw: str) -> "CartridgeProfile":
+    """Parse the five-digit profile reply: 2-digit number then three 1-digit fields."""
+    digits = raw.strip()
+    if len(digits) != 5 or not digits.isdigit():
+      raise FluidXError(
+        title="Malformed profile reply",
+        message=f"expected five digits, got {raw!r}",
+      )
+    return cls(
+      number=int(digits[0:2]),
+      communication_protocol=int(digits[2]),
+      decap_max_retry=int(digits[3]),
+      recap_max_retry=int(digits[4]),
+      raw=digits,
+    )
+
+
+# The extended status bitmask, most significant bit first. The firmware reply is
+# read least-significant-bit-first from the right, so a reply shorter than this
+# tuple is treated as having its leading zeros suppressed.
+EXTENDED_STATUS_FLAGS: Tuple[str, ...] = (
+  "caps_on_pins",
+  "dry_run_enabled",
+  "light_curtain_disabled",
+  "safety_door_rs232_disabled",
+  "stage_enabled",
+  "screw_caps_on",
+  "cartridge_installed",
+  "standby_active",
+  "stage_extended",
+  "recover_mode",
+  "estop_active",
+  "time_for_service",
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class ExtendedStatus:
+  """Instrument state flags that the plain status word does not carry.
+
+  ``caps_on_pins`` is the authoritative answer to "are caps currently held?",
+  and ``cartridge_installed``, ``estop_active`` and ``recover_mode`` explain
+  states that otherwise only show up as a refused command.
+  """
+
+  caps_on_pins: bool
+  dry_run_enabled: bool
+  light_curtain_disabled: bool
+  safety_door_rs232_disabled: bool
+  stage_enabled: bool
+  screw_caps_on: bool
+  cartridge_installed: bool
+  standby_active: bool
+  stage_extended: bool
+  recover_mode: bool
+  estop_active: bool
+  time_for_service: bool
+  raw: str
+
+  @classmethod
+  def from_raw(cls, raw: str) -> "ExtendedStatus":
+    bits = raw.strip()
+    if not bits or any(character not in "01" for character in bits):
+      raise FluidXError(
+        title="Malformed extended status reply",
+        message=f"expected a string of 0s and 1s, got {raw!r}",
+      )
+    width = len(EXTENDED_STATUS_FLAGS)
+    if len(bits) != width:
+      logger.warning(
+        "[IntelliXcap96] extended status is %d bits, expected %d: %r. Reading it from the "
+        "least significant bit.",
+        len(bits),
+        width,
+        bits,
+      )
+    aligned = bits.rjust(width, "0")[-width:]
+    values = {flag: aligned[index] == "1" for index, flag in enumerate(EXTENDED_STATUS_FLAGS)}
+    return cls(raw=bits, **values)
 
 
 def _fault(key: str, detail: Optional[str] = None) -> FluidXError:
   """Build a FluidXError carrying the firmware's own description for ``key``."""
   return FluidXError(title=ERROR_MESSAGES.get(key, key), message=detail)
+
+
+def _is_error_frame(frame: str) -> bool:
+  """Whether a reply frame reports a fault rather than a success or a setting."""
+  return _ERROR_FRAME_RE.search(frame.upper()) is not None
 
 
 def _error_code(frames: List[str]) -> Optional[int]:
@@ -220,6 +403,15 @@ def _error_code(frames: List[str]) -> Optional[int]:
       code = int(value)
       if code in ERROR_CODE_MESSAGES:
         return code
+  return None
+
+
+def _loaded_profile(frames: List[str]) -> Optional[int]:
+  """Read the profile number out of a cartridge load reply's ``onnOK`` frame."""
+  for frame in frames:
+    match = re.fullmatch(r"o(\d+)OK", frame)
+    if match is not None:
+      return int(match.group(1))
   return None
 
 
@@ -239,6 +431,10 @@ class FluidXIntelliXcap96:
     9600 baud, 8 data bits, no parity, 1 stop bit, no handshake. Replies are
     framed between STX (0x02) and ETX (0x03).
 
+  The instrument only speaks this protocol once setpoint 86 is set to 2
+  ("IntelliXcap mode"), which is done at the instrument touchscreen; there is no
+  serial command for it.
+
   Tube type and volume are not sent over the serial protocol. The installed
   IntelliCartridge and its firmware profile define the supported tube/cap
   geometry and motion settings. Fit and configure the cartridge specified for
@@ -246,31 +442,48 @@ class FluidXIntelliXcap96:
   to select a compatible cartridge.
 
   Single-character commands, each written followed by ETX:
-    a   request status
-    h   start decapping
-    i   start recapping
-    b   release held caps into a separately positioned carrier
-    f   open the tray
-    g   close the tray
-    Z   home all axes
-    z   reset
-    j   enter standby
-    k   leave standby (ready)
-  A command is answered with an ACK frame (0x06), a ``<cmd>OK`` echo frame, and a
-  result frame. The status word is ``StatusOK`` when idle, ``StatusBUSY`` while a
-  motion runs, ``StatusSLEEP`` in standby, and carries ``ERROR``/``Recap``/
-  ``Decap`` for a fault or a pending inverse operation. A refused or no-op
-  command answers with ``CommandIgnore``. Motions complete when the status word
-  returns from ``StatusBUSY`` to ``StatusOK``.
+    a   request status                     e   extended status bitmask
+    h   start decapping                    E   cartridge profile settings
+    i   start recapping                    V   firmware versions
+    b   release held caps into a carrier   N   cartridge profile/cycles/serial
+    f   open the tray                      8   latched error code
+    g   close the tray                     c   eject the cartridge onto the tray
+    Z   home all axes                      C   load the cartridge from the tray
+    j   enter standby                      X   reset the cartridge cycle counter
+    k   leave standby (ready)              t   extend the tray to S127
+    l   light curtain detection off        T   retract the tray to S3
+    L   light curtain detection on         s   step the tray out by S88
+    d   dry-run mode on                    S   step the tray in by S88
+    D   dry-run mode off                   Q   force a decap retry
+    +   safety door on                     5   eject held caps (manual mode)
+    -   safety door off                    6   home the cap head (manual mode)
+    z   initialize keeping caps on pins    7   open the safety door (manual mode)
 
-  A fault latches the device in ``StatusError`` (e.g. running a decap with no
-  rack loaded). This is cleared only by homing -- the reset command is ignored.
-  With ``auto_recover`` enabled (the default), an operation issued while the
-  device is latched in error homes to recover and then proceeds.
+  A command is answered with an ACK frame (0x06), a ``<cmd>OK`` echo frame, and a
+  result frame. The status word, in the priority the firmware reports it, is
+  ``StatusMANUAL`` (halted, needs inspection), ``StatusERROR`` (error code
+  latched), ``StatusSLEEP`` (standby), ``StatusBUSY`` (motion running),
+  ``StatusRECAP`` (decapped, caps held on the pins) or ``StatusOK`` (idle).
+  Cartridge ejection reports ``StatusCAREJECT``. A refused or no-op command
+  answers with ``CommandIgnore``. Motions complete when the status word returns
+  from ``StatusBUSY`` to the operation's terminal state.
+
+  Which state a failure lands in depends on the error code: 113/114 for decap,
+  117/118 for recap, 142 for cartridge eject and 143/144 for cartridge load
+  latch ``StatusERROR``, and anything else halts in ``StatusMANUAL``.
+  :meth:`request_error_code` reads the latched code, and every raised
+  :class:`FluidXError` carries it in ``error_code`` when the instrument reported
+  one.
+
+  A ``StatusError`` is cleared only by homing. With ``auto_recover`` enabled (the
+  default), an operation issued while the device is latched in error homes to
+  recover and then proceeds.
 
   Verified against hardware: connection, status, tray open/close, home,
   standby/ready, the decap error/recovery path, and decap/recap with a loaded
-  0.5 mL rack, including release of held caps with ``waste``.
+  0.5 mL rack, including release of held caps with ``waste``. The remaining
+  commands are implemented from the RS232 command list (Azenta part 386063 Rev.
+  A) and have not been exercised on an instrument.
 
   See the Azenta IntelliXcap user manual for the required carrier and physical
   setup:
@@ -297,8 +510,7 @@ class FluidXIntelliXcap96:
       poll_interval: pause between status polls while a motion runs.
       auto_recover: when an operation finds the device latched in StatusError,
         home it to clear the error and continue. A latched error is only cleared
-        by homing (reset is a no-op on this firmware). Disable to make a latched
-        error raise instead.
+        by homing. Disable to make a latched error raise instead.
       recover_timeout: timeout in seconds for the recovery home.
     """
     self.command_delay = command_delay
@@ -323,8 +535,9 @@ class FluidXIntelliXcap96:
     if "BUSY" in up:
       # At connect there is no motion in flight, so a persistent StatusBUSY means
       # the instrument is locked out. By far the most common cause is an engaged
-      # e-stop; the safety guard/hood and other interlocks do the same. There is
-      # no command to read the e-stop directly, so surface the likely cause here.
+      # e-stop; the safety guard/hood and other interlocks do the same. The
+      # extended status carries an e-stop bit, so read it before giving up.
+      estop = await self._estop_hint()
       logger.error(
         "[IntelliXcap96 %s] reports StatusBUSY at connect and will ignore commands. "
         "Check the E-STOP first (most common cause), then the safety guard/hood and "
@@ -334,14 +547,14 @@ class FluidXIntelliXcap96:
       raise FluidXError(
         title="Decapper is not ready (StatusBUSY)",
         message=(
-          "The device reports BUSY and ignores commands. This is almost always an engaged "
-          "E-STOP; also check the safety guard/hood and interlocks, then retry."
+          f"The device reports BUSY and ignores commands. {estop} Also check the safety "
+          "guard/hood and interlocks, then retry."
         ),
       )
     if "MANUAL" in up:
-      raise _fault("StatusManual", status)
+      raise await self._latched_fault("StatusManual", status)
     if "ERROR" in up:
-      raise _fault("StatusNotOK", status)
+      raise await self._latched_fault("StatusNotOK", status)
     logger.info("[IntelliXcap96 %s] connected: %s", self.io.port, status)
 
   async def stop(self) -> None:
@@ -389,17 +602,33 @@ class FluidXIntelliXcap96:
   def _status_frame(frames: List[str]) -> Optional[str]:
     return next((f for f in frames if f.upper().startswith("STATUS")), None)
 
+  @staticmethod
+  def _payload_frame(frames: List[str], command: str) -> Optional[str]:
+    """Return the data frame of a query reply, skipping the ack and command echo."""
+    echo = f"{command}OK"
+    for frame in frames:
+      if frame == ACK or frame == echo or frame.upper().startswith("STATUS"):
+        continue
+      return frame
+    return None
+
   def _require_accepted(
-    self, command: str, frames: List[str], name: str, idempotent: bool = False
+    self,
+    command: str,
+    frames: List[str],
+    name: str,
+    idempotent: bool = False,
+    echo: Optional[str] = None,
   ) -> bool:
     """Check a command's reply. Return True if it started a motion.
 
     Raises if the device did not ack and echo the command. A ``CommandIgnore``
     reply means the command was a no-op (the device is already in the requested
     state): for an ``idempotent`` command that is success and returns False (no
-    motion to wait for); otherwise it is raised.
+    motion to wait for); otherwise it is raised. ``echo`` overrides the expected
+    echo frame for commands the firmware acknowledges under another name.
     """
-    if ACK not in frames or f"{command}OK" not in frames:
+    if ACK not in frames or f"{echo or command}OK" not in frames:
       raise _fault("NoAck", f"{name}: {frames!r}")
     if any(COMMAND_IGNORE in f for f in frames):
       if idempotent:
@@ -407,12 +636,99 @@ class FluidXIntelliXcap96:
       raise _fault("CommandIgnore", f"{name}: device already in that state or not ready")
     return True
 
+  @staticmethod
+  def _require_answer(frames: List[str], expected: str, name: str) -> None:
+    """Raise unless the device confirmed a setting with its documented reply frame."""
+    if expected not in frames:
+      raise _fault("NoAck", f"{name}: expected {expected!r}, got {frames!r}")
+
+  async def _try_request_error_code(self) -> Optional[int]:
+    """Read the latched error code, returning None if the query itself fails."""
+    try:
+      return await self.request_error_code()
+    except FluidXError as exception:
+      logger.debug("[IntelliXcap96 %s] error code query failed: %s", self.io.port, exception)
+      return None
+
+  async def _latched_fault(
+    self, fail_key: str, detail: str, frames: Optional[List[str]] = None
+  ) -> FluidXError:
+    """Build the error for a failed operation, enriched with the latched error code.
+
+    The code is taken from the reply frames when the firmware inlined it there,
+    and otherwise read back with the error query, which is the documented way to
+    find out why an operation failed.
+    """
+    code = _error_code(frames) if frames else None
+    if code is None:
+      code = await self._try_request_error_code()
+    if code is not None:
+      return FluidXError.from_error_code(code, detail=detail)
+    return _fault(fail_key, f"{detail}. The device did not report a numeric error code.")
+
+  async def _estop_hint(self) -> str:
+    """Describe the e-stop state for a lockout message, if the device will say."""
+    try:
+      extended = await self.request_extended_status()
+    except FluidXError:
+      return "This is almost always an engaged E-STOP."
+    if extended.estop_active:
+      return "The E-STOP is engaged; release it."
+    return "The E-STOP reads as released."
+
+  async def _wait_for_answer(
+    self,
+    frames: List[str],
+    done_frame: str,
+    timeout: float,
+    name: str,
+    fail_key: str,
+  ) -> None:
+    """Wait for an operation's own answer frame instead of polling status.
+
+    Some operations do not announce completion through the status word: the
+    status word is ``StatusMANUAL`` throughout a manual recovery command because
+    the halt outranks ``StatusBUSY``, and the tray travel commands change no
+    status at all. Their answer frame is the only completion signal, so this
+    keeps reading frames rather than sending status polls, which would reset the
+    input buffer and drop the answer.
+
+    ``frames`` is the command's own reply, which often already carries the
+    answer.
+    """
+    done = done_frame.upper()
+    if any(_is_error_frame(f) for f in frames):
+      raise await self._latched_fault(fail_key, f"{name}: {frames!r}", frames)
+    if any(f.upper() == done for f in frames):
+      return
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    failure: Optional[List[str]] = None
+    with self.io.temporary_timeout(self.frame_gap):
+      while loop.time() < deadline:
+        frame = await self._read_frame()
+        if frame is None:
+          await asyncio.sleep(self.poll_interval)
+          continue
+        if _is_error_frame(frame):
+          failure = [frame]
+          break
+        if frame.upper() == done:
+          return
+    if failure is not None:
+      raise await self._latched_fault(fail_key, f"{name}: {failure!r}", failure)
+    raise FluidXError(
+      title=f"{name} timed out",
+      message=f"did not answer with {done_frame!r} within {timeout}s",
+    )
+
   async def _wait_for_idle(
     self,
     timeout: float,
     name: str,
     fail_key: str,
     terminal_statuses: Tuple[str, ...] = ("StatusOK",),
+    done_frames: Tuple[str, ...] = (),
   ) -> None:
     """Poll status until it reaches an expected idle state.
 
@@ -420,30 +736,34 @@ class FluidXIntelliXcap96:
     reports an error while waiting. ``terminal_statuses`` accounts for
     operation state retained while the instrument is idle: hardware reports
     ``StatusRECAP`` after decapping and after tray motion with caps held.
+    ``done_frames`` are the operation's own completion frames, which end the
+    wait as soon as one is seen.
     """
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout
     expected = {status.upper() for status in terminal_statuses}
+    done = {frame.upper() for frame in done_frames}
     while loop.time() < deadline:
       frames = await self.send_command(STATUS)
-      if any("ERROR" in f.upper() for f in frames):
-        code = _error_code(frames)
-        if code is not None:
-          raise FluidXError.from_error_code(code, detail=f"{name}: {frames!r}")
-        raise _fault(
-          fail_key,
-          f"{name}: {frames!r}. Check the instrument error log for the numeric error code.",
-        )
-      status = self._status_frame(frames)
-      if status is not None and status.upper() in expected:
+      if any(_is_error_frame(f) for f in frames):
+        raise await self._latched_fault(fail_key, f"{name}: {frames!r}", frames)
+      if any(f.upper() in done for f in frames):
         return
+      status = self._status_frame(frames)
+      if status is not None:
+        up = status.upper()
+        if up in expected:
+          return
+        if "MANUAL" in up:
+          # A halt needs an operator, so waiting out the timeout only delays the report.
+          raise await self._latched_fault("StatusManual", f"{name}: {frames!r}", frames)
       await asyncio.sleep(self.poll_interval)
     raise FluidXError(
       title=f"{name} timed out",
       message=f"did not reach {terminal_statuses!r} within {timeout}s",
     )
 
-  # === Status ===
+  # === Status and queries ===
 
   async def request_status(self) -> str:
     """Poll the device and return its status word (e.g. ``StatusOK``)."""
@@ -453,10 +773,81 @@ class FluidXIntelliXcap96:
       raise FluidXError(title="No status reply", message=repr(frames))
     return status
 
+  async def request_error_code(self) -> Optional[int]:
+    """Read the error code the instrument has latched, or None if there is none.
+
+    This is the documented way to find out *why* an operation failed:
+    ``StatusERROR`` and ``StatusMANUAL`` say only that something went wrong.
+    :func:`get_error_message` turns the code into its documented meaning, and
+    :func:`is_recoverable_error` says whether homing will clear it.
+    """
+    frames = await self.send_command(ERROR_QUERY)
+    self._require_accepted(ERROR_QUERY, frames, "Reading the error code", idempotent=True)
+    payload = self._payload_frame(frames, ERROR_QUERY)
+    if payload is None or not payload.strip().isdigit():
+      raise FluidXError(title="No error code reply", message=repr(frames))
+    code = int(payload.strip())
+    return code if code != 0 else None
+
+  async def request_extended_status(self) -> ExtendedStatus:
+    """Read the extended status bitmask.
+
+    Reports state the status word omits, including whether caps are held on the
+    pins, whether a cartridge is installed and whether the e-stop is engaged.
+    """
+    frames = await self.send_command(EXTENDED_STATUS)
+    self._require_accepted(EXTENDED_STATUS, frames, "Reading the extended status", idempotent=True)
+    payload = self._payload_frame(frames, EXTENDED_STATUS)
+    if payload is None:
+      raise FluidXError(title="No extended status reply", message=repr(frames))
+    return ExtendedStatus.from_raw(payload)
+
+  async def request_firmware_versions(self) -> FirmwareVersions:
+    """Read the unit, touchscreen and light curtain firmware versions.
+
+    Dry-run mode requires touchscreen firmware V14 or above, and the store
+    operation is broken in unit firmware V44.
+    """
+    frames = await self.send_command(FIRMWARE_QUERY)
+    self._require_accepted(FIRMWARE_QUERY, frames, "Reading the firmware versions", idempotent=True)
+    payload = self._payload_frame(frames, FIRMWARE_QUERY)
+    parts = [part.strip() for part in payload.split(",")] if payload else []
+    if len(parts) != 3:
+      raise FluidXError(title="Malformed firmware reply", message=repr(frames))
+    return FirmwareVersions(unit=parts[0], touchscreen=parts[1], light_curtain=parts[2])
+
+  async def request_cartridge_info(self) -> CartridgeInfo:
+    """Read the installed cartridge's profile, cycle count and serial.
+
+    The serial always reads ``"00000000"``: the firmware does not implement it.
+    """
+    frames = await self.send_command(CARTRIDGE_QUERY)
+    self._require_accepted(
+      CARTRIDGE_QUERY, frames, "Reading the cartridge details", idempotent=True
+    )
+    payload = self._payload_frame(frames, CARTRIDGE_QUERY)
+    parts = [part.strip() for part in payload.split(",")] if payload else []
+    if len(parts) != 3 or not parts[0].isdigit() or not parts[1].isdigit():
+      raise FluidXError(title="Malformed cartridge reply", message=repr(frames))
+    return CartridgeInfo(profile=int(parts[0]), cycle_count=int(parts[1]), serial=parts[2])
+
+  async def request_profile(self) -> CartridgeProfile:
+    """Read the active profile number and its decap/recap retry limits."""
+    frames = await self.send_command(PROFILE_QUERY)
+    self._require_accepted(PROFILE_QUERY, frames, "Reading the profile", idempotent=True)
+    payload = self._payload_frame(frames, PROFILE_QUERY)
+    if payload is None:
+      raise FluidXError(title="No profile reply", message=repr(frames))
+    return CartridgeProfile.from_raw(payload)
+
+  async def caps_on_pins(self) -> bool:
+    """Whether caps are currently held on the ejector pins."""
+    return (await self.request_extended_status()).caps_on_pins
+
   # === Operations ===
 
   async def open_tray(self, timeout: float = 15.0) -> None:
-    """Open the loading tray."""
+    """Open the loading tray. Also opens the safety door."""
     await self._ensure_ready()
     frames = await self.send_command(OPEN_TRAY)
     if self._require_accepted(OPEN_TRAY, frames, "Opening the tray", idempotent=True):
@@ -465,11 +856,12 @@ class FluidXIntelliXcap96:
         "Opening the tray",
         "OpenTrayWasNotSuccesful",
         ("StatusOK", "StatusRECAP", "StatusDECAP"),
+        done_frames=("OpenDONE",),
       )
     logger.info("[IntelliXcap96 %s] tray open", self.io.port)
 
   async def close_tray(self, timeout: float = 15.0) -> None:
-    """Close the loading tray."""
+    """Close the loading tray, moving it to the decap/recap position."""
     await self._ensure_ready()
     frames = await self.send_command(CLOSE_TRAY)
     if self._require_accepted(CLOSE_TRAY, frames, "Closing the tray", idempotent=True):
@@ -478,31 +870,75 @@ class FluidXIntelliXcap96:
         "Closing the tray",
         "CloseTrayWasNotSuccesful",
         ("StatusOK", "StatusRECAP", "StatusDECAP"),
+        done_frames=("CloseDONE",),
       )
     logger.info("[IntelliXcap96 %s] tray closed", self.io.port)
+
+  async def _tray_move(self, command: str, name: str, timeout: float) -> None:
+    """Run one of the tray travel commands.
+
+    These acknowledge and answer with the same ``<cmd>OK`` frame, so a completed
+    move is a second echo and a failed one is ``<cmd>ERROR``.
+    """
+    await self._ensure_ready()
+    echo = f"{command}OK"
+    frames = await self.send_command(command)
+    self._require_accepted(command, frames, name)
+    if frames.count(echo) < 2:
+      await self._wait_for_answer(
+        [f for f in frames if f != echo], echo, timeout, name, "TrayMoveWasNotSuccesful"
+      )
+    logger.info("[IntelliXcap96 %s] %s", self.io.port, name.lower())
+
+  async def extend_tray(self, timeout: float = 15.0) -> None:
+    """Move the tray from the load position (S3) out to the extended position (S127).
+
+    Presents decapped tubes further out of the instrument. Fails unless the tray
+    is at the load position, so open the tray first.
+    """
+    await self._tray_move(TRAY_EXTEND, "Extending the tray", timeout)
+
+  async def retract_tray(self, timeout: float = 15.0) -> None:
+    """Move the tray from the extended position (S127) back to the load position (S3)."""
+    await self._tray_move(TRAY_RETRACT, "Retracting the tray", timeout)
+
+  async def step_tray_out(self, timeout: float = 15.0) -> None:
+    """Move the tray further out by the step distance in setpoint 88.
+
+    Travel is bounded by the load position (S3) and the extended position
+    (S127); a step that would leave that range fails.
+    """
+    await self._tray_move(TRAY_STEP_OUT, "Stepping the tray out", timeout)
+
+  async def step_tray_in(self, timeout: float = 15.0) -> None:
+    """Move the tray back in by the step distance in setpoint 88.
+
+    Travel is bounded by the load position (S3) and the extended position
+    (S127); a step that would leave that range fails.
+    """
+    await self._tray_move(TRAY_STEP_IN, "Stepping the tray in", timeout)
 
   async def _home_sequence(self, timeout: float, name: str) -> None:
     """Send the home command and wait for it to finish. Also clears a latched error."""
     frames = await self.send_command(HOME_ALL)
     self._require_accepted(HOME_ALL, frames, name)
-    await self._wait_for_idle(timeout, name, "HomeNotSuccesful")
+    await self._wait_for_idle(timeout, name, "HomeNotSuccesful", done_frames=("ZDONE",))
 
   async def _ensure_ready(self) -> str:
     """Return the current status, first clearing a latched error by homing.
 
-    A ``StatusError`` is only cleared by homing (the reset command is ignored on
-    this firmware). With ``auto_recover`` enabled, an operation that finds the
-    device latched in error homes to recover and then proceeds; otherwise the
-    latched error is raised.
+    A ``StatusError`` is only cleared by homing. With ``auto_recover`` enabled,
+    an operation that finds the device latched in error homes to recover and
+    then proceeds; otherwise the latched error is raised.
     """
     status = await self.request_status()
     up = status.upper()
     if "MANUAL" in up:
-      raise _fault("StatusManual", status)
+      raise await self._latched_fault("StatusManual", status)
     if "ERROR" not in up:
       return status
     if not self.auto_recover:
-      raise _fault("StatusNotOK", status)
+      raise await self._latched_fault("StatusNotOK", status)
     logger.warning(
       "[IntelliXcap96 %s] latched in StatusError; homing to recover before continuing.",
       self.io.port,
@@ -510,16 +946,36 @@ class FluidXIntelliXcap96:
     await self._home_sequence(self.recover_timeout, "Homing (error recovery)")
     status = await self.request_status()
     if "ERROR" in status.upper():
-      raise _fault("StatusNotOK", "error persisted after recovery home")
+      raise await self._latched_fault("StatusNotOK", "error persisted after recovery home")
     return status
+
+  async def _require_manual_mode(self, name: str) -> None:
+    """Raise unless the instrument is in manual recovery mode."""
+    status = await self.request_status()
+    if "MANUAL" not in status.upper():
+      raise _fault("NotInManualMode", f"{name}: device reports {status}")
+
+  async def _manual_command(
+    self, command: str, name: str, fail_key: str, done_frame: str, timeout: float
+  ) -> None:
+    """Run a command that is only accepted while the instrument is halted.
+
+    Manual recovery keeps the status word at ``StatusMANUAL`` for the whole
+    operation, so completion is read from the answer frame.
+    """
+    await self._require_manual_mode(name)
+    frames = await self.send_command(command)
+    self._require_accepted(command, frames, name)
+    await self._wait_for_answer(frames, done_frame, timeout, name, fail_key)
 
   async def reset_error(self, timeout: Optional[float] = None) -> None:
     """Recover from ``StatusError`` or ``StatusMANUAL`` by homing all axes.
 
-    The firmware reset command does not clear these states. Hardware testing
-    confirmed that the home-all command transitions ``StatusMANUAL`` through
-    ``StatusBUSY`` to ``StatusOK``. Call this only after inspecting the rack and
-    cap head and confirming that axis motion is safe.
+    Hardware testing confirmed that the home-all command transitions
+    ``StatusMANUAL`` through ``StatusBUSY`` to ``StatusOK``. Call this only after
+    inspecting the rack and cap head and confirming that axis motion is safe.
+    Homing drops any held caps; use :meth:`initialize_keeping_caps_on_pins` when
+    caps are still on the pins.
 
     This method is a no-op when the instrument is not in an error or manual
     recovery state.
@@ -539,9 +995,25 @@ class FluidXIntelliXcap96:
     logger.info("[IntelliXcap96 %s] error reset by homing", self.io.port)
 
   async def home(self, timeout: float = 30.0) -> None:
-    """Home all axes. Also clears a latched StatusError."""
+    """Home all axes. Also clears all errors and a latched StatusError."""
     await self._home_sequence(timeout, "Homing")
     logger.info("[IntelliXcap96 %s] homed", self.io.port)
+
+  async def initialize_keeping_caps_on_pins(self, timeout: float = 30.0) -> None:
+    """Clear the error state and home without dropping caps held on the pins.
+
+    For recovering an instrument that stopped mid-cycle with caps held, after
+    which :meth:`recap` can put them back. The firmware marks this command
+    deprecated, and it is only accepted in manual recovery mode.
+    """
+    await self._manual_command(
+      INITIALIZE_KEEP_CAPS,
+      "Initializing while keeping caps on pins",
+      "HomeNotSuccesful",
+      "zDONE",
+      timeout,
+    )
+    logger.info("[IntelliXcap96 %s] initialized with caps on pins", self.io.port)
 
   async def decap(self, timeout: float = 60.0) -> None:
     """Unscrew and hold all 96 caps.
@@ -559,8 +1031,38 @@ class FluidXIntelliXcap96:
       "Decapping",
       "DecapWasNotSuccesful",
       ("StatusRECAP",),
+      done_frames=("DecapDONE",),
     )
     logger.info("[IntelliXcap96 %s] decap complete", self.io.port)
+
+  async def retry_decap(self, timeout: float = 60.0) -> None:
+    """Force one more decap stroke on tubes that a completed decap left capped.
+
+    Only useful with light curtain error detection off. With detection on the
+    instrument sees the tubes that failed to decap and retries inside
+    :meth:`decap` by itself, up to the profile's decap retry limit, so there is
+    nothing left to force. With detection off it cannot see them, ends the
+    stroke as successful, and this is the only way to ask for another attempt:
+    :meth:`decap` refuses while caps are held.
+    :meth:`set_error_detection_enabled` controls detection.
+
+    The command list documents only that this command is used "after a
+    successful Decap" and "requires lightcurtain OFF". That those are the same
+    condition is inferred from the automatic-retry and error-detection commands
+    rather than stated by the vendor.
+    """
+    await self._ensure_ready()
+    frames = await self.send_command(RETRY_DECAP)
+    # The firmware acknowledges a forced retry as if it were a fresh decap.
+    self._require_accepted(RETRY_DECAP, frames, "Retrying the decap", echo=DECAP_START)
+    await self._wait_for_idle(
+      timeout,
+      "Retrying the decap",
+      "RetryDecapWasNotSuccesful",
+      ("StatusOK", "StatusRECAP"),
+      done_frames=("DecapDONE",),
+    )
+    logger.info("[IntelliXcap96 %s] decap retry complete", self.io.port)
 
   async def recap(self, timeout: float = 60.0) -> None:
     """Screw the held caps back on.
@@ -578,6 +1080,7 @@ class FluidXIntelliXcap96:
       "Recapping",
       "RecapWasNotSuccesful",
       ("StatusOK", "StatusDECAP"),
+      done_frames=("RecapDONE",),
     )
     logger.info("[IntelliXcap96 %s] recap complete", self.io.port)
 
@@ -590,6 +1093,11 @@ class FluidXIntelliXcap96:
     carrier. If the tube rack remains beneath the head, released caps can fall
     back onto the tube openings and look recapped even though they may not be
     threaded or torqued.
+
+    The instrument picks the store sequence from the height of the cap carrier
+    and otherwise performs a recap. Unit firmware V44 does not implement this
+    command; on that firmware, load a store rack and use :meth:`decap` and
+    :meth:`recap`, which select the store sequence themselves.
 
     User manual:
     https://web.azenta.com/hubfs/azenta-files/resources/manuals-guides/319430-IXC-User-Manual.pdf
@@ -607,11 +1115,19 @@ class FluidXIntelliXcap96:
       "Wasting caps",
       "StoreWasNotSuccesful",
       ("StatusOK", "StatusDECAP"),
+      done_frames=("StoreDONE",),
     )
     logger.info("[IntelliXcap96 %s] waste complete", self.io.port)
 
   async def standby(self, timeout: float = 15.0) -> None:
-    """Put the decapper into standby (sleep) mode."""
+    """Put the decapper into low-power standby (sleep) mode.
+
+    A no-op when the instrument is already asleep. The instrument refuses to
+    sleep while caps are held on the pins.
+    """
+    status = (await self.request_status()).upper()
+    if "SLEEP" in status:
+      return
     frames = await self.send_command(STANDBY)
     self._require_accepted(STANDBY, frames, "Entering standby")
     loop = asyncio.get_running_loop()
@@ -629,24 +1145,145 @@ class FluidXIntelliXcap96:
       return
     frames = await self.send_command(READY)
     self._require_accepted(READY, frames, "Waking from standby")
-    await self._wait_for_idle(timeout, "Waking from standby", "StatusNotOK")
+    await self._wait_for_idle(
+      timeout, "Waking from standby", "StatusNotOK", done_frames=("ReadyDONE",)
+    )
     logger.info("[IntelliXcap96 %s] ready", self.io.port)
 
-  async def reset(self, settle_time: float = 5.0) -> None:
-    """Reset the device and wait for it to settle.
+  # === Cartridge handling ===
 
-    The reset command is a no-op on this firmware (it answers ``CommandIgnore``)
-    and does not clear a latched error. Use :meth:`home` to recover from a
-    ``StatusError``; operations do this automatically when ``auto_recover`` is
-    enabled.
+  async def eject_cartridge(self, timeout: float = 60.0) -> None:
+    """Eject the installed IntelliCartridge onto the tray.
 
-    Args:
-      settle_time: time in seconds to wait after the reset command.
+    A no-op when no cartridge is installed. The tray must be empty and no caps
+    may be held on the pins.
     """
-    if "ERROR" in (await self.request_status()).upper():
-      raise _fault("CannotReset")
-    await self.send_command(RESET)
-    await asyncio.sleep(settle_time)
-    if "ERROR" in (await self.request_status()).upper():
-      raise _fault("ResetNotSuccesful")
-    logger.info("[IntelliXcap96 %s] reset complete", self.io.port)
+    extended = await self.request_extended_status()
+    if not extended.cartridge_installed:
+      return
+    if extended.caps_on_pins:
+      raise _fault("NeedToRecap", "the cartridge cannot be ejected while caps are held")
+    await self._ensure_ready()
+    frames = await self.send_command(CARTRIDGE_EJECT)
+    self._require_accepted(CARTRIDGE_EJECT, frames, "Ejecting the cartridge")
+    await self._wait_for_idle(
+      timeout,
+      "Ejecting the cartridge",
+      "CartridgeEjectWasNotSuccesful",
+      ("StatusCAREJECT", "StatusOK"),
+      done_frames=("CarEjectDONE",),
+    )
+    logger.info("[IntelliXcap96 %s] cartridge ejected", self.io.port)
+
+  async def load_cartridge(self, timeout: float = 60.0) -> Optional[int]:
+    """Pick up the cartridge resting on the tray.
+
+    A no-op when a cartridge is already installed.
+
+    Returns:
+      The loaded profile number when the firmware reports one, else None.
+    """
+    if (await self.request_extended_status()).cartridge_installed:
+      return None
+    frames = await self.send_command(CARTRIDGE_LOAD)
+    self._require_accepted(CARTRIDGE_LOAD, frames, "Loading the cartridge")
+    await self._wait_for_idle(
+      timeout,
+      "Loading the cartridge",
+      "CartridgeLoadWasNotSuccesful",
+      ("StatusOK",),
+      done_frames=("CarLoadDONE", "ExtCarLoadDONE"),
+    )
+    profile = _loaded_profile(frames)
+    logger.info("[IntelliXcap96 %s] cartridge loaded (profile %s)", self.io.port, profile)
+    return profile
+
+  async def reset_cartridge_counter(self) -> None:
+    """Reset the installed cartridge's cycle counter to zero."""
+    frames = await self.send_command(CARTRIDGE_COUNTER_RESET)
+    self._require_accepted(
+      CARTRIDGE_COUNTER_RESET, frames, "Resetting the cartridge counter", idempotent=True
+    )
+    logger.info("[IntelliXcap96 %s] cartridge counter reset", self.io.port)
+
+  # === Settings ===
+
+  async def set_error_detection_enabled(self, enabled: bool) -> None:
+    """Turn light curtain error detection during decap and recap on or off.
+
+    With detection off the instrument finishes every decap and recap stroke
+    instead of stopping on error 135 or 136, and :meth:`retry_decap` becomes
+    available. Detection is on at power-up.
+    """
+    command = ERROR_DETECTION_ON if enabled else ERROR_DETECTION_OFF
+    name = "Enabling error detection" if enabled else "Disabling error detection"
+    frames = await self.send_command(command)
+    self._require_accepted(command, frames, name, idempotent=True)
+    self._require_answer(frames, "ErrorDetectON" if enabled else "ErrorDetectOFF", name)
+    logger.info("[IntelliXcap96 %s] error detection %s", self.io.port, "on" if enabled else "off")
+
+  async def set_dry_run_enabled(self, enabled: bool) -> None:
+    """Turn dry-run mode on or off.
+
+    In dry-run mode the instrument stops and waits for the operator when the
+    light curtain reports error 114, 118, 135 or 136 instead of failing the
+    operation. Requires touchscreen firmware V14 or above, which
+    :meth:`request_firmware_versions` reports.
+    """
+    command = DRY_RUN_ON if enabled else DRY_RUN_OFF
+    name = "Enabling dry-run mode" if enabled else "Disabling dry-run mode"
+    frames = await self.send_command(command)
+    self._require_accepted(command, frames, name, idempotent=True)
+    self._require_answer(frames, "DryRunON" if enabled else "DryRunOFF", name)
+    logger.info("[IntelliXcap96 %s] dry-run mode %s", self.io.port, "on" if enabled else "off")
+
+  async def set_safety_door_enabled(self, enabled: bool) -> None:
+    """Turn safety door operation on or off.
+
+    Disabling it leaves the door open and keeps it open until the instrument is
+    power cycled, which is how the door is enabled again. The door is enabled at
+    power-up.
+    """
+    command = SAFETY_DOOR_ENABLE if enabled else SAFETY_DOOR_DISABLE
+    name = "Enabling the safety door" if enabled else "Disabling the safety door"
+    frames = await self.send_command(command)
+    self._require_accepted(command, frames, name, idempotent=True)
+    self._require_answer(frames, "DoorONDONE" if enabled else "DoorOFFDONE", name)
+    logger.info("[IntelliXcap96 %s] safety door %s", self.io.port, "on" if enabled else "off")
+
+  # === Manual recovery ===
+
+  async def eject_caps(self, timeout: float = 30.0) -> None:
+    """Home the cap head, dropping any caps held on the cap drivers.
+
+    Closes the tray first if it is open, and opens the safety door. Only
+    available in manual recovery mode, and the instrument stays there
+    afterwards. The caps fall wherever the head is standing, so clear the deck
+    and read :meth:`waste` before using this to get rid of caps deliberately.
+    """
+    await self._manual_command(
+      EJECT_CAPS, "Ejecting the caps", "EjectCapsWasNotSuccesful", "EjectDONE", timeout
+    )
+    logger.info("[IntelliXcap96 %s] caps ejected", self.io.port)
+
+  async def head_up(self, timeout: float = 30.0) -> None:
+    """Home the Z axis, keeping any held caps on the pins.
+
+    Only available in manual recovery mode, and the instrument stays there
+    afterwards.
+    """
+    await self._manual_command(
+      HEAD_UP, "Homing the cap head", "HeadUpWasNotSuccesful", "HeadDONE", timeout
+    )
+    logger.info("[IntelliXcap96 %s] cap head homed", self.io.port)
+
+  async def open_safety_door(self, timeout: float = 15.0) -> None:
+    """Open the safety door to reach into the instrument.
+
+    Only available in manual recovery mode, and the instrument stays there
+    afterwards. :meth:`open_tray` opens the door as part of presenting the tray.
+    """
+    await self._manual_command(
+      SAFETY_DOOR_OPEN, "Opening the safety door", "SafetyDoorWasNotSuccesful", "DoorDONE", timeout
+    )
+    logger.info("[IntelliXcap96 %s] safety door open", self.io.port)

--- a/pylabrobot/azenta/fluidx/intellixcap96.py
+++ b/pylabrobot/azenta/fluidx/intellixcap96.py
@@ -31,8 +31,9 @@ STANDBY = "j"
 READY = "k"
 CARTRIDGE_EJECT = "c"
 CARTRIDGE_LOAD = "C"
-TRAY_EXTEND = "t"
-TRAY_RETRACT = "T"
+# Newer-firmware tray opcodes, intentionally not sent until verified there:
+# TRAY_EXTEND = "t"
+# TRAY_RETRACT = "T"
 TRAY_STEP_OUT = "s"
 TRAY_STEP_IN = "S"
 CARTRIDGE_COUNTER_RESET = "X"
@@ -457,22 +458,35 @@ class FluidXIntelliXcap96:
   to select a compatible cartridge.
 
   Single-character commands, each written followed by ETX:
-    a   request status                     e   extended status bitmask
-    h   start decapping                    E   cartridge profile settings
-    i   start recapping                    V   firmware versions
-    b   release held caps into a carrier   N   cartridge profile/cycles/serial
-    f   open the tray                      8   latched error code
-    g   close the tray                     c   eject the cartridge onto the tray
-    Z   home all axes                      C   load the cartridge from the tray
-    j   enter standby                      X   reset the cartridge cycle counter
-    k   leave standby (ready)              t   extend the tray to S127
-    l   light curtain detection off        T   retract the tray to S3
-    L   light curtain detection on         s   step the tray out by S88
-    d   dry-run mode on                    S   step the tray in by S88
-    D   dry-run mode off                   Q   force a decap retry
-    +   safety door on                     5   eject held caps (manual mode)
-    -   safety door off                    6   home the cap head (manual mode)
-    z   initialize keeping caps on pins    7   open the safety door (manual mode)
+    a   request status
+    b   release held caps into a carrier
+    c   eject the cartridge onto the tray
+    d   dry-run mode on
+    D   dry-run mode off
+    e   extended status bitmask
+    E   cartridge profile settings
+    f   open the tray
+    g   close the tray
+    h   start decapping
+    i   start recapping
+    j   enter standby
+    k   leave standby (ready)
+    l   light curtain detection off
+    L   light curtain detection on
+    N   cartridge profile/cycles/serial
+    Q   force a decap retry
+    s   step the tray out by S88
+    S   step the tray in by S88
+    V   firmware versions
+    X   reset the cartridge cycle counter
+    Z   home all axes
+    z   initialize keeping caps on pins
+    +   safety door on
+    -   safety door off
+    5   eject held caps (manual mode)
+    6   home the cap head (manual mode)
+    7   open the safety door (manual mode)
+    8   latched error code
 
   A command is answered with an ACK frame (0x06), a ``<cmd>OK`` echo frame, and a
   result frame. The status word, in the priority the firmware reports it, is
@@ -495,11 +509,17 @@ class FluidXIntelliXcap96:
   an operation issued while the device is latched in error homes to recover and
   then proceeds.
 
-  Verified against hardware: connection, status, tray open/close, home,
-  standby/ready, the decap error/recovery path, and decap/recap with a loaded
-  0.5 mL rack, including release of held caps with ``waste``. The remaining
-  commands are implemented from the RS232 command list (Azenta part 386063 Rev.
-  A) and have not been exercised on an instrument.
+  Newer firmware documents ``t``/``T`` commands for absolute tray travel
+  between S3 and S127. Unit firmware V49 ignored both commands completely, so
+  :meth:`extend_tray` and :meth:`retract_tray` raise
+  :class:`NotImplementedError` without writing to the instrument.
+
+  Verified against hardware: connection, queries, tray open/close, home,
+  standby/ready, settings, cartridge eject/load, the decap error/recovery path,
+  forced decap retry, and decap/recap with a loaded 0.5 mL rack, including
+  release of held caps with ``waste``. Unit firmware V49 did not acknowledge
+  the four tray travel commands. The cartridge counter reset and manual
+  recovery commands have not been exercised on an instrument.
 
   See the Azenta IntelliXcap user manual for the required carrier and physical
   setup:
@@ -547,10 +567,10 @@ class FluidXIntelliXcap96:
   async def setup(self) -> None:
     await self.io.setup()
     logger.warning(
-      "[IntelliXcap96 %s] most of this driver's commands are implemented from the RS232 command "
-      "list and have not been run on an instrument. The queries, tray open/close, home, "
-      "standby/ready and decap/recap/waste are hardware-verified; the tray travel, cartridge, "
-      "settings and manual recovery commands are not. Please report back so this can be updated.",
+      "[IntelliXcap96 %s] connection, queries, tray open/close, home, standby/ready, settings, "
+      "cartridge eject/load, forced decap retry and decap/recap/waste are hardware-verified. "
+      "Unit firmware V49 does not acknowledge the tray travel commands. The cartridge counter "
+      "reset and manual recovery commands are not hardware-verified.",
       self.io.port,
     )
     status = await self.request_status()
@@ -920,6 +940,8 @@ class FluidXIntelliXcap96:
 
     These acknowledge and answer with the same ``<cmd>OK`` frame, so a completed
     move is a second echo and a failed one is ``<cmd>ERROR``.
+
+    Unit firmware V49 does not acknowledge these commands.
     """
     await self._ensure_ready()
     echo = f"{command}OK"
@@ -934,14 +956,26 @@ class FluidXIntelliXcap96:
   async def extend_tray(self, timeout: float = 15.0) -> None:
     """Move the tray from the load position (S3) out to the extended position (S127).
 
-    Presents decapped tubes further out of the instrument. Fails unless the tray
-    is at the load position, so open the tray first.
+    This command is documented for newer firmware but is not implemented here:
+    unit firmware V49 ignored it completely. The method raises without writing
+    to the instrument.
     """
-    await self._tray_move(TRAY_EXTEND, "Extending the tray", timeout)
+    raise NotImplementedError(
+      "extend_tray() uses the newer-firmware 't' command, which is not supported by "
+      "IntelliXcap unit firmware V49"
+    )
 
   async def retract_tray(self, timeout: float = 15.0) -> None:
-    """Move the tray from the extended position (S127) back to the load position (S3)."""
-    await self._tray_move(TRAY_RETRACT, "Retracting the tray", timeout)
+    """Move the tray from the extended position (S127) back to the load position (S3).
+
+    This command is documented for newer firmware but is not implemented here:
+    unit firmware V49 ignored it completely. The method raises without writing
+    to the instrument.
+    """
+    raise NotImplementedError(
+      "retract_tray() uses the newer-firmware 'T' command, which is not supported by "
+      "IntelliXcap unit firmware V49"
+    )
 
   async def step_tray_out(self, timeout: float = 15.0) -> None:
     """Move the tray further out by the step distance in setpoint 88.
@@ -1100,7 +1134,9 @@ class FluidXIntelliXcap96:
     The command list documents only that this command is used "after a
     successful Decap" and "requires lightcurtain OFF". That those are the same
     condition is inferred from the automatic-retry and error-detection commands
-    rather than stated by the vendor.
+    rather than stated by the vendor. The instrument finishes in
+    ``StatusRECAP`` because it is still holding the caps for a subsequent
+    :meth:`recap`.
     """
     await self._ensure_ready()
     frames = await self.send_command(RETRY_DECAP)
@@ -1110,7 +1146,7 @@ class FluidXIntelliXcap96:
       timeout,
       "Retrying the decap",
       "RetryDecapWasNotSuccesful",
-      ("StatusOK",),
+      ("StatusRECAP",),
       done_frames=("DecapDONE",),
     )
     logger.info("[IntelliXcap96 %s] decap retry complete", self.io.port)
@@ -1262,8 +1298,8 @@ class FluidXIntelliXcap96:
     """Reset the installed cartridge's cycle counter to zero."""
     name = "Resetting the cartridge counter"
     frames = await self.send_command(CARTRIDGE_COUNTER_RESET)
-    self._require_accepted(CARTRIDGE_COUNTER_RESET, frames, name, idempotent=True)
-    self._require_answer(frames, "CarResetDONE", name)
+    if self._require_accepted(CARTRIDGE_COUNTER_RESET, frames, name, idempotent=True):
+      self._require_answer(frames, "CarResetDONE", name)
     logger.info("[IntelliXcap96 %s] cartridge counter reset", self.io.port)
 
   # === Settings ===
@@ -1278,8 +1314,8 @@ class FluidXIntelliXcap96:
     command = ERROR_DETECTION_ON if enabled else ERROR_DETECTION_OFF
     name = "Enabling error detection" if enabled else "Disabling error detection"
     frames = await self.send_command(command)
-    self._require_accepted(command, frames, name, idempotent=True)
-    self._require_answer(frames, "ErrorDetectON" if enabled else "ErrorDetectOFF", name)
+    if self._require_accepted(command, frames, name, idempotent=True):
+      self._require_answer(frames, "ErrorDetectON" if enabled else "ErrorDetectOFF", name)
     logger.info("[IntelliXcap96 %s] error detection %s", self.io.port, "on" if enabled else "off")
 
   async def set_dry_run_enabled(self, enabled: bool) -> None:
@@ -1293,8 +1329,8 @@ class FluidXIntelliXcap96:
     command = DRY_RUN_ON if enabled else DRY_RUN_OFF
     name = "Enabling dry-run mode" if enabled else "Disabling dry-run mode"
     frames = await self.send_command(command)
-    self._require_accepted(command, frames, name, idempotent=True)
-    self._require_answer(frames, "DryRunON" if enabled else "DryRunOFF", name)
+    if self._require_accepted(command, frames, name, idempotent=True):
+      self._require_answer(frames, "DryRunON" if enabled else "DryRunOFF", name)
     logger.info("[IntelliXcap96 %s] dry-run mode %s", self.io.port, "on" if enabled else "off")
 
   async def set_safety_door_enabled(self, enabled: bool) -> None:
@@ -1306,8 +1342,8 @@ class FluidXIntelliXcap96:
     command = SAFETY_DOOR_ENABLE if enabled else SAFETY_DOOR_DISABLE
     name = "Enabling the safety door" if enabled else "Disabling the safety door"
     frames = await self.send_command(command)
-    self._require_accepted(command, frames, name, idempotent=True)
-    self._require_answer(frames, "DoorONDONE" if enabled else "DoorOFFDONE", name)
+    if self._require_accepted(command, frames, name, idempotent=True):
+      self._require_answer(frames, "DoorONDONE" if enabled else "DoorOFFDONE", name)
     logger.info("[IntelliXcap96 %s] safety door %s", self.io.port, "on" if enabled else "off")
 
   # === Manual recovery ===

--- a/pylabrobot/azenta/fluidx/intellixcap96_tests.py
+++ b/pylabrobot/azenta/fluidx/intellixcap96_tests.py
@@ -3,7 +3,14 @@ import unittest
 from typing import Iterator, List
 from unittest.mock import AsyncMock, patch
 
-from pylabrobot.azenta.fluidx import FluidXError, FluidXIntelliXcap96, get_error_message
+from pylabrobot.azenta.fluidx import (
+  CartridgeProfile,
+  ExtendedStatus,
+  FluidXError,
+  FluidXIntelliXcap96,
+  get_error_message,
+  is_recoverable_error,
+)
 
 ACK = "\x06"
 
@@ -60,6 +67,24 @@ def status(word: str, echo: str = "a") -> List[str]:
   return [ACK, f"{echo}OK", word]
 
 
+def query(command: str, payload: str) -> List[str]:
+  """A full query reply: ACK, command echo, and the data frame."""
+  return [ACK, f"{command}OK", payload]
+
+
+def extended(
+  caps_on_pins: bool = False,
+  cartridge_installed: bool = False,
+  estop_active: bool = False,
+) -> List[str]:
+  """An extended status reply built from the flags a test cares about."""
+  bits = ["0"] * 12
+  bits[0] = "1" if caps_on_pins else "0"
+  bits[6] = "1" if cartridge_installed else "0"
+  bits[10] = "1" if estop_active else "0"
+  return query("e", "".join(bits))
+
+
 class TestIntelliXcap96(unittest.IsolatedAsyncioTestCase):
   async def asyncSetUp(self) -> None:
     patcher = patch("pylabrobot.azenta.fluidx.intellixcap96.asyncio.sleep", new_callable=AsyncMock)
@@ -71,21 +96,40 @@ class TestIntelliXcap96(unittest.IsolatedAsyncioTestCase):
     device.io = FakeXcapSerial(script)  # type: ignore[assignment]
     return device
 
+  def _written(self, device: FluidXIntelliXcap96) -> List[str]:
+    return device.io.written  # type: ignore[attr-defined,no-any-return]
+
+  # === Connection ===
+
   async def test_setup_ok(self):
     device = self._make([status("StatusOK")])
     await device.setup()
-    self.assertEqual(device.io.written, ["a"])  # type: ignore[attr-defined]
+    self.assertEqual(self._written(device), ["a"])
 
-  async def test_setup_busy_raises_estop_hint(self):
+  async def test_setup_busy_reports_engaged_estop(self):
+    device = self._make([status("StatusBUSY"), extended(estop_active=True)])
+    with self.assertRaises(FluidXError) as ctx:
+      await device.setup()
+    self.assertIn("E-STOP is engaged", str(ctx.exception))
+
+  async def test_setup_busy_still_warns_when_estop_unreadable(self):
     device = self._make([status("StatusBUSY")])
     with self.assertRaises(FluidXError) as ctx:
       await device.setup()
     self.assertIn("E-STOP", str(ctx.exception))
 
-  async def test_setup_error_raises(self):
-    device = self._make([status("StatusError")])
-    with self.assertRaises(FluidXError):
+  async def test_setup_error_reports_error_code(self):
+    device = self._make([status("StatusError"), query("8", "137")])
+    with self.assertRaises(FluidXError) as ctx:
       await device.setup()
+    self.assertEqual(ctx.exception.error_code, 137)
+    self.assertIn("Maximum recap attempts exceeded", str(ctx.exception))
+
+  async def test_setup_error_raises_without_error_code(self):
+    device = self._make([status("StatusError")])
+    with self.assertRaises(FluidXError) as ctx:
+      await device.setup()
+    self.assertIsNone(ctx.exception.error_code)
 
   async def test_setup_manual_recovery_raises(self):
     device = self._make([status("StatusMANUAL")])
@@ -96,6 +140,8 @@ class TestIntelliXcap96(unittest.IsolatedAsyncioTestCase):
   async def test_request_status_returns_status_word(self):
     device = self._make([status("StatusOK")])
     self.assertEqual(await device.request_status(), "StatusOK")
+
+  # === Error codes ===
 
   def test_get_error_message(self):
     self.assertEqual(
@@ -112,6 +158,80 @@ class TestIntelliXcap96(unittest.IsolatedAsyncioTestCase):
       "IntelliXcap error 145: Light curtain calibration max retries exceeded.",
     )
 
+  def test_recoverable_errors_are_the_ones_homing_clears(self):
+    self.assertTrue(is_recoverable_error(113))
+    self.assertTrue(is_recoverable_error(144))
+    self.assertFalse(is_recoverable_error(137))
+    self.assertTrue(FluidXError.from_error_code(117).recoverable)
+    self.assertFalse(FluidXError.from_error_code(137).recoverable)
+    self.assertFalse(FluidXError(title="no code").recoverable)
+
+  async def test_request_error_code_returns_latched_code(self):
+    device = self._make([query("8", "142")])
+    self.assertEqual(await device.request_error_code(), 142)
+    self.assertEqual(self._written(device), ["8"])
+
+  async def test_request_error_code_is_none_when_clear(self):
+    device = self._make([query("8", "000")])
+    self.assertIsNone(await device.request_error_code())
+
+  async def test_request_error_code_raises_on_garbage(self):
+    device = self._make([query("8", "nope")])
+    with self.assertRaises(FluidXError):
+      await device.request_error_code()
+
+  # === Queries ===
+
+  async def test_request_extended_status(self):
+    device = self._make([extended(caps_on_pins=True, cartridge_installed=True)])
+    result = await device.request_extended_status()
+    self.assertTrue(result.caps_on_pins)
+    self.assertTrue(result.cartridge_installed)
+    self.assertFalse(result.estop_active)
+    self.assertFalse(result.time_for_service)
+
+  async def test_caps_on_pins(self):
+    device = self._make([extended(caps_on_pins=True)])
+    self.assertTrue(await device.caps_on_pins())
+
+  def test_extended_status_pads_a_short_reply_from_the_least_significant_bit(self):
+    # The firmware may suppress leading zeros, so the trailing bits stay aligned.
+    result = ExtendedStatus.from_raw("00000100000")
+    self.assertFalse(result.caps_on_pins)
+    self.assertTrue(result.cartridge_installed)
+
+  def test_extended_status_rejects_a_non_bitmask(self):
+    with self.assertRaises(FluidXError):
+      ExtendedStatus.from_raw("10201")
+
+  async def test_request_firmware_versions(self):
+    device = self._make([query("V", "0044,0014,0003")])
+    versions = await device.request_firmware_versions()
+    self.assertEqual(versions.unit, "0044")
+    self.assertEqual(versions.touchscreen, "0014")
+    self.assertEqual(versions.light_curtain, "0003")
+
+  async def test_request_cartridge_info(self):
+    device = self._make([query("N", "016,000123,00000000")])
+    info = await device.request_cartridge_info()
+    self.assertEqual(info.profile, 16)
+    self.assertEqual(info.cycle_count, 123)
+    self.assertEqual(info.serial, "00000000")
+
+  async def test_request_profile(self):
+    device = self._make([query("E", "16032")])
+    profile = await device.request_profile()
+    self.assertEqual(profile.number, 16)
+    self.assertEqual(profile.communication_protocol, 0)
+    self.assertEqual(profile.decap_max_retry, 3)
+    self.assertEqual(profile.recap_max_retry, 2)
+
+  def test_profile_rejects_a_malformed_reply(self):
+    with self.assertRaises(FluidXError):
+      CartridgeProfile.from_raw("160")
+
+  # === Tray ===
+
   async def test_open_tray_moves_then_idle(self):
     device = self._make(
       [
@@ -122,54 +242,157 @@ class TestIntelliXcap96(unittest.IsolatedAsyncioTestCase):
       ]
     )
     await device.open_tray()
-    self.assertEqual(device.io.written, ["a", "f", "a", "a"])  # type: ignore[attr-defined]
+    self.assertEqual(self._written(device), ["a", "f", "a", "a"])
+
+  async def test_open_tray_finishes_on_its_own_done_frame(self):
+    device = self._make([status("StatusOK"), [ACK, "fOK"], [ACK, "aOK", "OpenDONE"]])
+    await device.open_tray()
+    self.assertEqual(self._written(device), ["a", "f", "a"])
 
   async def test_open_tray_already_open_is_noop(self):
     # CommandIgnore = tray already open = success; no status wait afterwards.
     device = self._make([status("StatusOK"), [ACK, "fOK", "CommandIgnore"]])
     await device.open_tray()
-    self.assertEqual(device.io.written, ["a", "f"])  # type: ignore[attr-defined]
+    self.assertEqual(self._written(device), ["a", "f"])
 
   async def test_close_tray_moves_then_idle(self):
     device = self._make(
       [status("StatusOK"), [ACK, "gOK"], status("StatusBUSY"), status("StatusOK")]
     )
     await device.close_tray()
-    self.assertEqual(device.io.written, ["a", "g", "a", "a"])  # type: ignore[attr-defined]
+    self.assertEqual(self._written(device), ["a", "g", "a", "a"])
 
   async def test_close_tray_preserves_caps_held_state(self):
     device = self._make(
       [status("StatusRECAP"), [ACK, "gOK"], status("StatusBUSY"), status("StatusRECAP")]
     )
     await device.close_tray()
-    self.assertEqual(device.io.written, ["a", "g", "a", "a"])  # type: ignore[attr-defined]
+    self.assertEqual(self._written(device), ["a", "g", "a", "a"])
+
+  async def test_extend_tray(self):
+    # A tray move acknowledges and answers with the same echo, so success is two.
+    device = self._make([status("StatusOK"), [ACK, "tOK", "tOK"]])
+    await device.extend_tray()
+    self.assertEqual(self._written(device), ["a", "t"])
+
+  async def test_retract_tray(self):
+    device = self._make([status("StatusOK"), [ACK, "TOK", "TOK"]])
+    await device.retract_tray()
+    self.assertEqual(self._written(device), ["a", "T"])
+
+  async def test_step_tray_out_and_in(self):
+    device = self._make(
+      [
+        status("StatusOK"),
+        [ACK, "sOK", "sOK"],
+        status("StatusOK"),
+        [ACK, "SOK", "SOK"],
+      ]
+    )
+    await device.step_tray_out()
+    await device.step_tray_in()
+    self.assertEqual(self._written(device), ["a", "s", "a", "S"])
+
+  async def test_tray_move_out_of_range_raises(self):
+    device = self._make([status("StatusOK"), [ACK, "sOK", "sERROR"], query("8", "148")])
+    with self.assertRaises(FluidXError) as ctx:
+      await device.step_tray_out()
+    self.assertEqual(ctx.exception.error_code, 148)
+
+  async def test_tray_move_times_out_without_a_second_echo(self):
+    device = self._make([status("StatusOK"), [ACK, "sOK"]])
+    with self.assertRaises(FluidXError) as ctx:
+      await device.step_tray_out(timeout=0.01)
+    self.assertIn("timed out", str(ctx.exception))
+
+  # === Homing and recovery ===
 
   async def test_home_moves_then_idle(self):
     device = self._make([[ACK, "ZOK"], status("StatusBUSY"), status("StatusOK")])
     await device.home()
-    self.assertEqual(device.io.written, ["Z", "a", "a"])  # type: ignore[attr-defined]
+    self.assertEqual(self._written(device), ["Z", "a", "a"])
 
-  async def test_standby_reaches_sleep(self):
-    device = self._make([[ACK, "jOK"], status("StatusSLEEP")])
-    await device.standby()
-    self.assertEqual(device.io.written, ["j", "a"])  # type: ignore[attr-defined]
-
-  async def test_ready_noop_when_awake(self):
-    device = self._make([status("StatusOK")])
-    await device.ready()
-    self.assertEqual(device.io.written, ["a"])  # type: ignore[attr-defined]
-
-  async def test_ready_wakes_from_sleep(self):
+  async def test_reset_error_recovers_manual_state_by_homing(self):
     device = self._make(
       [
-        status("StatusSLEEP"),  # request_status: asleep
-        [ACK, "kOK"],  # k accepted
-        status("StatusBUSY"),  # waking
-        status("StatusOK"),  # awake
+        status("StatusMANUAL"),
+        [ACK, "ZOK"],
+        status("StatusBUSY"),
+        status("StatusOK"),
       ]
     )
-    await device.ready()
-    self.assertEqual(device.io.written, ["a", "k", "a", "a"])  # type: ignore[attr-defined]
+    await device.reset_error()
+    self.assertEqual(self._written(device), ["a", "Z", "a", "a"])
+
+  async def test_reset_error_recovers_error_state_by_homing(self):
+    device = self._make(
+      [
+        status("StatusError"),
+        [ACK, "ZOK"],
+        status("StatusBUSY"),
+        status("StatusOK"),
+      ]
+    )
+    await device.reset_error()
+    self.assertEqual(self._written(device), ["a", "Z", "a", "a"])
+
+  async def test_reset_error_is_noop_when_healthy(self):
+    device = self._make([status("StatusOK")])
+    await device.reset_error()
+    self.assertEqual(self._written(device), ["a"])
+
+  async def test_initialize_keeping_caps_on_pins(self):
+    device = self._make([status("StatusMANUAL"), [ACK, "zOK", "zDONE"]])
+    await device.initialize_keeping_caps_on_pins()
+    self.assertEqual(self._written(device), ["a", "z"])
+
+  async def test_initialize_keeping_caps_on_pins_reports_a_home_failure(self):
+    device = self._make([status("StatusMANUAL"), [ACK, "zOK", "HomeERROR"], query("8", "156")])
+    with self.assertRaises(FluidXError) as ctx:
+      await device.initialize_keeping_caps_on_pins()
+    self.assertEqual(ctx.exception.error_code, 156)
+
+  async def test_initialize_keeping_caps_on_pins_requires_manual_mode(self):
+    device = self._make([status("StatusOK")])
+    with self.assertRaises(FluidXError) as ctx:
+      await device.initialize_keeping_caps_on_pins()
+    self.assertIn("manual recovery mode", str(ctx.exception))
+    self.assertEqual(self._written(device), ["a"])
+
+  async def test_operation_auto_recovers_from_latched_error(self):
+    device = self._make(
+      [
+        status("StatusError"),  # _ensure_ready: latched in error
+        [ACK, "ZOK"],  # recovery home accepted
+        status("StatusBUSY"),  # homing
+        status("StatusOK"),  # homed
+        status("StatusOK"),  # _ensure_ready re-check: clear
+        [ACK, "fOK"],  # open accepted
+        status("StatusBUSY"),
+        status("StatusOK"),
+      ]
+    )
+    await device.open_tray()
+    self.assertEqual(
+      self._written(device),
+      ["a", "Z", "a", "a", "a", "f", "a", "a"],
+    )
+
+  async def test_latched_error_raises_when_auto_recover_disabled(self):
+    device = self._make([status("StatusError"), query("8", "113")], auto_recover=False)
+    with self.assertRaises(FluidXError) as ctx:
+      await device.open_tray()
+    self.assertEqual(ctx.exception.error_code, 113)
+    self.assertEqual(self._written(device), ["a", "8"])
+
+  async def test_operation_blocked_during_manual_recovery(self):
+    device = self._make([status("StatusMANUAL")])
+    with self.assertRaises(FluidXError) as ctx:
+      await device.open_tray()
+    self.assertIn("manual recovery", str(ctx.exception))
+    self.assertEqual(self._written(device), ["a", "8"])
+
+  # === Decap / recap ===
 
   async def test_decap_success(self):
     device = self._make(
@@ -181,7 +404,7 @@ class TestIntelliXcap96(unittest.IsolatedAsyncioTestCase):
       ]
     )
     await device.decap()
-    self.assertEqual(device.io.written, ["a", "h", "a", "a"])  # type: ignore[attr-defined]
+    self.assertEqual(self._written(device), ["a", "h", "a", "a"])
 
   async def test_decap_blocked_when_already_decapped(self):
     device = self._make([status("StatusRecap")])
@@ -200,6 +423,36 @@ class TestIntelliXcap96(unittest.IsolatedAsyncioTestCase):
     self.assertEqual(ctx.exception.error_code, 145)
     self.assertIn("Light curtain calibration max retries exceeded", str(ctx.exception))
 
+  async def test_decap_queries_the_error_code_when_the_reply_omits_it(self):
+    device = self._make(
+      [
+        status("StatusOK"),
+        [ACK, "hOK"],
+        [ACK, "aOK", "DecapERROR"],
+        query("8", "114"),
+      ]
+    )
+    with self.assertRaises(FluidXError) as ctx:
+      await device.decap()
+    self.assertEqual(ctx.exception.error_code, 114)
+    self.assertTrue(ctx.exception.recoverable)
+    self.assertIn("Invalid tube height", str(ctx.exception))
+    self.assertEqual(self._written(device), ["a", "h", "a", "8"])
+
+  async def test_manual_halt_during_motion_fails_immediately(self):
+    device = self._make(
+      [status("StatusOK"), [ACK, "hOK"], status("StatusMANUAL"), query("8", "167")]
+    )
+    with self.assertRaises(FluidXError) as ctx:
+      await device.decap()
+    self.assertEqual(ctx.exception.error_code, 167)
+    self.assertFalse(ctx.exception.recoverable)
+
+  async def test_retry_decap_is_acknowledged_as_a_decap(self):
+    device = self._make([status("StatusOK"), [ACK, "hOK"], [ACK, "aOK", "DecapDONE"]])
+    await device.retry_decap()
+    self.assertEqual(self._written(device), ["a", "Q", "a"])
+
   async def test_recap_blocked_when_not_decapped(self):
     device = self._make([status("StatusDecap")])
     with self.assertRaises(FluidXError):
@@ -215,13 +468,13 @@ class TestIntelliXcap96(unittest.IsolatedAsyncioTestCase):
       ]
     )
     await device.recap()
-    self.assertEqual(device.io.written, ["a", "i", "a", "a"])  # type: ignore[attr-defined]
+    self.assertEqual(self._written(device), ["a", "i", "a", "a"])
 
   async def test_waste_blocked_when_no_caps_are_held(self):
     device = self._make([status("StatusOK")])
     with self.assertRaises(FluidXError):
       await device.waste()
-    self.assertEqual(device.io.written, ["a"])  # type: ignore[attr-defined]
+    self.assertEqual(self._written(device), ["a"])
 
   async def test_waste_success(self):
     device = self._make(
@@ -233,79 +486,152 @@ class TestIntelliXcap96(unittest.IsolatedAsyncioTestCase):
       ]
     )
     await device.waste()
-    self.assertEqual(device.io.written, ["a", "b", "a", "a"])  # type: ignore[attr-defined]
+    self.assertEqual(self._written(device), ["a", "b", "a", "a"])
 
-  async def test_reset_ignored_is_not_fatal(self):
-    # Precheck OK, z is a no-op (CommandIgnore) at idle, postcheck OK.
-    device = self._make([status("StatusOK"), [ACK, "zOK", "CommandIgnore"], status("StatusOK")])
-    await device.reset()
-    self.assertEqual(device.io.written, ["a", "z", "a"])  # type: ignore[attr-defined]
+  # === Standby ===
 
-  async def test_reset_refused_when_errored(self):
-    device = self._make([status("StatusError")])
-    with self.assertRaises(FluidXError):
-      await device.reset()
+  async def test_standby_reaches_sleep(self):
+    device = self._make([status("StatusOK"), [ACK, "jOK"], status("StatusSLEEP")])
+    await device.standby()
+    self.assertEqual(self._written(device), ["a", "j", "a"])
 
-  async def test_reset_error_recovers_manual_state_by_homing(self):
-    device = self._make(
-      [
-        status("StatusMANUAL"),
-        [ACK, "ZOK"],
-        status("StatusBUSY"),
-        status("StatusOK"),
-      ]
-    )
-    await device.reset_error()
-    self.assertEqual(device.io.written, ["a", "Z", "a", "a"])  # type: ignore[attr-defined]
+  async def test_standby_is_noop_when_asleep(self):
+    device = self._make([status("StatusSLEEP")])
+    await device.standby()
+    self.assertEqual(self._written(device), ["a"])
 
-  async def test_reset_error_recovers_error_state_by_homing(self):
-    device = self._make(
-      [
-        status("StatusError"),
-        [ACK, "ZOK"],
-        status("StatusBUSY"),
-        status("StatusOK"),
-      ]
-    )
-    await device.reset_error()
-    self.assertEqual(device.io.written, ["a", "Z", "a", "a"])  # type: ignore[attr-defined]
-
-  async def test_reset_error_is_noop_when_healthy(self):
+  async def test_ready_noop_when_awake(self):
     device = self._make([status("StatusOK")])
-    await device.reset_error()
-    self.assertEqual(device.io.written, ["a"])  # type: ignore[attr-defined]
+    await device.ready()
+    self.assertEqual(self._written(device), ["a"])
 
-  async def test_operation_auto_recovers_from_latched_error(self):
+  async def test_ready_wakes_from_sleep(self):
     device = self._make(
       [
-        status("StatusError"),  # _ensure_ready: latched in error
-        [ACK, "ZOK"],  # recovery home accepted
-        status("StatusBUSY"),  # homing
-        status("StatusOK"),  # homed
-        status("StatusOK"),  # _ensure_ready re-check: clear
-        [ACK, "fOK"],  # open accepted
-        status("StatusBUSY"),
-        status("StatusOK"),
+        status("StatusSLEEP"),  # request_status: asleep
+        [ACK, "kOK"],  # k accepted
+        status("StatusBUSY"),  # waking
+        status("StatusOK"),  # awake
       ]
     )
-    await device.open_tray()
-    self.assertEqual(
-      device.io.written,  # type: ignore[attr-defined]
-      ["a", "Z", "a", "a", "a", "f", "a", "a"],
+    await device.ready()
+    self.assertEqual(self._written(device), ["a", "k", "a", "a"])
+
+  # === Cartridge ===
+
+  async def test_eject_cartridge(self):
+    device = self._make(
+      [
+        extended(cartridge_installed=True),
+        status("StatusOK"),
+        [ACK, "cOK"],
+        status("StatusCAREJECT"),
+      ]
     )
+    await device.eject_cartridge()
+    self.assertEqual(self._written(device), ["e", "a", "c", "a"])
 
-  async def test_latched_error_raises_when_auto_recover_disabled(self):
-    device = self._make([status("StatusError")], auto_recover=False)
+  async def test_eject_cartridge_is_noop_without_a_cartridge(self):
+    device = self._make([extended(cartridge_installed=False)])
+    await device.eject_cartridge()
+    self.assertEqual(self._written(device), ["e"])
+
+  async def test_eject_cartridge_blocked_while_caps_are_held(self):
+    device = self._make([extended(cartridge_installed=True, caps_on_pins=True)])
     with self.assertRaises(FluidXError):
-      await device.open_tray()
-    self.assertEqual(device.io.written, ["a"])  # type: ignore[attr-defined]
+      await device.eject_cartridge()
+    self.assertEqual(self._written(device), ["e"])
 
-  async def test_operation_blocked_during_manual_recovery(self):
-    device = self._make([status("StatusMANUAL")])
+  async def test_load_cartridge_returns_the_profile(self):
+    device = self._make(
+      [extended(cartridge_installed=False), [ACK, "COK", "o16OK"], status("StatusOK")]
+    )
+    self.assertEqual(await device.load_cartridge(), 16)
+    self.assertEqual(self._written(device), ["e", "C", "a"])
+
+  async def test_load_cartridge_is_noop_when_already_loaded(self):
+    device = self._make([extended(cartridge_installed=True)])
+    self.assertIsNone(await device.load_cartridge())
+    self.assertEqual(self._written(device), ["e"])
+
+  async def test_reset_cartridge_counter(self):
+    device = self._make([[ACK, "XOK", "CarResetDONE"]])
+    await device.reset_cartridge_counter()
+    self.assertEqual(self._written(device), ["X"])
+
+  # === Settings ===
+
+  async def test_set_error_detection_off_is_not_read_as_a_fault(self):
+    device = self._make([[ACK, "lOK", "ErrorDetectOFF"]])
+    await device.set_error_detection_enabled(False)
+    self.assertEqual(self._written(device), ["l"])
+
+  async def test_set_error_detection_on(self):
+    device = self._make([[ACK, "LOK", "ErrorDetectON"]])
+    await device.set_error_detection_enabled(True)
+    self.assertEqual(self._written(device), ["L"])
+
+  async def test_set_dry_run_enabled(self):
+    device = self._make([[ACK, "dOK", "DryRunON"]])
+    await device.set_dry_run_enabled(True)
+    self.assertEqual(self._written(device), ["d"])
+
+  async def test_set_dry_run_disabled(self):
+    device = self._make([[ACK, "DOK", "DryRunOFF"]])
+    await device.set_dry_run_enabled(False)
+    self.assertEqual(self._written(device), ["D"])
+
+  async def test_setting_raises_when_the_device_does_not_confirm(self):
+    device = self._make([[ACK, "dOK"]])
+    with self.assertRaises(FluidXError):
+      await device.set_dry_run_enabled(True)
+
+  async def test_set_safety_door_enabled(self):
+    device = self._make([[ACK, "+OK", "DoorONDONE"]])
+    await device.set_safety_door_enabled(True)
+    self.assertEqual(self._written(device), ["+"])
+
+  async def test_set_safety_door_disabled(self):
+    device = self._make([[ACK, "-OK", "DoorOFFDONE"]])
+    await device.set_safety_door_enabled(False)
+    self.assertEqual(self._written(device), ["-"])
+
+  # === Manual recovery commands ===
+
+  async def test_eject_caps_requires_manual_mode(self):
+    device = self._make([status("StatusOK")])
+    with self.assertRaises(FluidXError):
+      await device.eject_caps()
+    self.assertEqual(self._written(device), ["a"])
+
+  async def test_eject_caps(self):
+    # Manual recovery pins the status word to StatusMANUAL, so the answer frame
+    # is the only completion signal: no status polling here.
+    device = self._make([status("StatusMANUAL"), [ACK, "5OK", "EjectDONE"]])
+    await device.eject_caps()
+    self.assertEqual(self._written(device), ["a", "5"])
+
+  async def test_eject_caps_reports_a_failure(self):
+    device = self._make([status("StatusMANUAL"), [ACK, "5OK", "EjectERROR"], query("8", "133")])
     with self.assertRaises(FluidXError) as ctx:
-      await device.open_tray()
-    self.assertIn("manual recovery", str(ctx.exception))
-    self.assertEqual(device.io.written, ["a"])  # type: ignore[attr-defined]
+      await device.eject_caps()
+    self.assertEqual(ctx.exception.error_code, 133)
+
+  async def test_head_up(self):
+    device = self._make([status("StatusMANUAL"), [ACK, "6OK", "HeadDONE"]])
+    await device.head_up()
+    self.assertEqual(self._written(device), ["a", "6"])
+
+  async def test_open_safety_door(self):
+    device = self._make([status("StatusMANUAL"), [ACK, "7OK", "DoorDONE"]])
+    await device.open_safety_door()
+    self.assertEqual(self._written(device), ["a", "7"])
+
+  async def test_manual_command_times_out_without_an_answer(self):
+    device = self._make([status("StatusMANUAL"), [ACK, "6OK"]])
+    with self.assertRaises(FluidXError) as ctx:
+      await device.head_up(timeout=0.01)
+    self.assertIn("timed out", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/pylabrobot/azenta/fluidx/intellixcap96_tests.py
+++ b/pylabrobot/azenta/fluidx/intellixcap96_tests.py
@@ -194,11 +194,12 @@ class TestIntelliXcap96(unittest.IsolatedAsyncioTestCase):
     device = self._make([extended(caps_on_pins=True)])
     self.assertTrue(await device.caps_on_pins())
 
-  def test_extended_status_pads_a_short_reply_from_the_least_significant_bit(self):
-    # The firmware may suppress leading zeros, so the trailing bits stay aligned.
-    result = ExtendedStatus.from_raw("00000100000")
-    self.assertFalse(result.caps_on_pins)
-    self.assertTrue(result.cartridge_installed)
+  def test_extended_status_rejects_an_unexpected_width(self):
+    # The command list names 12 flags but shows an 11-character answer. Padding
+    # either end would guess at CAPS_ON_PINS, so the mismatch is surfaced.
+    with self.assertRaises(FluidXError) as ctx:
+      ExtendedStatus.from_raw("00000100000")
+    self.assertIn("11 bits, expected 12", str(ctx.exception))
 
   def test_extended_status_rejects_a_non_bitmask(self):
     with self.assertRaises(FluidXError):
@@ -558,6 +559,30 @@ class TestIntelliXcap96(unittest.IsolatedAsyncioTestCase):
     device = self._make([[ACK, "XOK", "CarResetDONE"]])
     await device.reset_cartridge_counter()
     self.assertEqual(self._written(device), ["X"])
+
+  async def test_reset_cartridge_counter_requires_its_answer(self):
+    device = self._make([[ACK, "XOK"]])
+    with self.assertRaises(FluidXError):
+      await device.reset_cartridge_counter()
+
+  async def test_load_cartridge_reads_the_profile_from_the_end_of_the_motion(self):
+    # onnOK is documented as an end-of-motion answer, not part of the ack.
+    device = self._make(
+      [
+        extended(cartridge_installed=False),
+        [ACK, "COK"],
+        [ACK, "aOK", "o24OK", "StatusOK"],
+      ]
+    )
+    self.assertEqual(await device.load_cartridge(), 24)
+
+  async def test_load_cartridge_reports_a_missing_profile(self):
+    device = self._make(
+      [extended(cartridge_installed=False), [ACK, "COK", "ProfileLoadERROR"], query("8", "143")]
+    )
+    with self.assertRaises(FluidXError) as ctx:
+      await device.load_cartridge()
+    self.assertEqual(ctx.exception.error_code, 143)
 
   # === Settings ===
 

--- a/pylabrobot/azenta/fluidx/intellixcap96_tests.py
+++ b/pylabrobot/azenta/fluidx/intellixcap96_tests.py
@@ -270,17 +270,6 @@ class TestIntelliXcap96(unittest.IsolatedAsyncioTestCase):
     await device.close_tray()
     self.assertEqual(self._written(device), ["a", "g", "a", "a"])
 
-  async def test_extend_tray(self):
-    # A tray move acknowledges and answers with the same echo, so success is two.
-    device = self._make([status("StatusOK"), [ACK, "tOK", "tOK"]])
-    await device.extend_tray()
-    self.assertEqual(self._written(device), ["a", "t"])
-
-  async def test_retract_tray(self):
-    device = self._make([status("StatusOK"), [ACK, "TOK", "TOK"]])
-    await device.retract_tray()
-    self.assertEqual(self._written(device), ["a", "T"])
-
   async def test_step_tray_out_and_in(self):
     device = self._make(
       [
@@ -449,10 +438,17 @@ class TestIntelliXcap96(unittest.IsolatedAsyncioTestCase):
     self.assertEqual(ctx.exception.error_code, 167)
     self.assertFalse(ctx.exception.recoverable)
 
-  async def test_retry_decap_is_acknowledged_as_a_decap(self):
-    device = self._make([status("StatusOK"), [ACK, "hOK"], [ACK, "aOK", "DecapDONE"]])
+  async def test_retry_decap_finishes_with_caps_held(self):
+    device = self._make(
+      [
+        status("StatusRECAP"),
+        [ACK, "hOK"],
+        status("StatusBUSY"),
+        status("StatusRECAP"),
+      ]
+    )
     await device.retry_decap()
-    self.assertEqual(self._written(device), ["a", "Q", "a"])
+    self.assertEqual(self._written(device), ["a", "Q", "a", "a"])
 
   async def test_recap_blocked_when_not_decapped(self):
     device = self._make([status("StatusDecap")])
@@ -565,6 +561,11 @@ class TestIntelliXcap96(unittest.IsolatedAsyncioTestCase):
     with self.assertRaises(FluidXError):
       await device.reset_cartridge_counter()
 
+  async def test_reset_cartridge_counter_is_idempotent(self):
+    device = self._make([[ACK, "XOK", "CommandIgnore"]])
+    await device.reset_cartridge_counter()
+    self.assertEqual(self._written(device), ["X"])
+
   async def test_load_cartridge_reads_the_profile_from_the_end_of_the_motion(self):
     # onnOK is documented as an end-of-motion answer, not part of the ack.
     device = self._make(
@@ -596,6 +597,11 @@ class TestIntelliXcap96(unittest.IsolatedAsyncioTestCase):
     await device.set_error_detection_enabled(True)
     self.assertEqual(self._written(device), ["L"])
 
+  async def test_set_error_detection_is_idempotent(self):
+    device = self._make([[ACK, "LOK", "CommandIgnore"]])
+    await device.set_error_detection_enabled(True)
+    self.assertEqual(self._written(device), ["L"])
+
   async def test_set_dry_run_enabled(self):
     device = self._make([[ACK, "dOK", "DryRunON"]])
     await device.set_dry_run_enabled(True)
@@ -603,6 +609,11 @@ class TestIntelliXcap96(unittest.IsolatedAsyncioTestCase):
 
   async def test_set_dry_run_disabled(self):
     device = self._make([[ACK, "DOK", "DryRunOFF"]])
+    await device.set_dry_run_enabled(False)
+    self.assertEqual(self._written(device), ["D"])
+
+  async def test_set_dry_run_is_idempotent(self):
+    device = self._make([[ACK, "DOK", "CommandIgnore"]])
     await device.set_dry_run_enabled(False)
     self.assertEqual(self._written(device), ["D"])
 
@@ -620,6 +631,11 @@ class TestIntelliXcap96(unittest.IsolatedAsyncioTestCase):
     device = self._make([[ACK, "-OK", "DoorOFFDONE"]])
     await device.set_safety_door_enabled(False)
     self.assertEqual(self._written(device), ["-"])
+
+  async def test_set_safety_door_is_idempotent(self):
+    device = self._make([[ACK, "+OK", "CommandIgnore"]])
+    await device.set_safety_door_enabled(True)
+    self.assertEqual(self._written(device), ["+"])
 
   # === Manual recovery commands ===
 


### PR DESCRIPTION
Builds the IntelliXcap 96 driver out to the full RS232 command set (Azenta part 386063 Rev. A).

## Error codes

`StatusERROR` and `StatusMANUAL` say only that something went wrong. `request_error_code()` issues the documented error query (`8`) and returns the numeric code, or `None` when nothing is latched. Every failure path now reads it back, so `FluidXError` carries `error_code` plus the code's documented meaning instead of a generic "was not successful".

Severity is modelled: codes 113/114 (decap), 117/118 (recap), 142 (cartridge eject) and 143/144 (cartridge load) latch `StatusERROR`, which homing clears — exposed as `is_recoverable_error(code)` and `FluidXError.recoverable`. Anything else halts in `StatusMANUAL`, which now fails immediately rather than waiting out the operation timeout.

## New commands

| Group | Methods |
| --- | --- |
| Queries | `request_error_code`, `request_extended_status`, `request_firmware_versions`, `request_cartridge_info`, `request_profile`, `caps_on_pins` |
| Tray travel | `extend_tray`, `retract_tray`, `step_tray_out`, `step_tray_in` |
| Cartridge | `eject_cartridge`, `load_cartridge`, `reset_cartridge_counter` |
| Settings | `set_error_detection_enabled`, `set_dry_run_enabled`, `set_safety_door_enabled` |
| Manual recovery | `eject_caps`, `head_up`, `open_safety_door`, `initialize_keeping_caps_on_pins` |
| Decap | `retry_decap` |

The extended status bitmask makes `caps_on_pins` directly readable rather than inferred from `StatusRECAP`, and surfaces `cartridge_installed`, `estop_active` and `recover_mode` — states that previously showed up only as a refused command. `setup()` uses it to report whether the e-stop is actually engaged, and the cartridge commands use it to be genuine no-ops.

Two firmware-gated behaviours are now documented: `waste()` is broken in unit firmware V44 (use a store rack with decap/recap), and dry-run mode needs touchscreen V14 or above.

## Protocol corrections

- `z` is "Initialize but keep Caps on Pins" — vendor-deprecated and accepted only in `StatusMANUAL` — not a reset. That is why it always answered `CommandIgnore`.
- A bare `"ERROR"` substring matched `ErrorDetectON`/`ErrorDetectOFF`, which are success replies, so any use of the error-detection commands read as a fault. Now matched with `ERROR\b`.
- Completion is read from the answer frame where the status word cannot report it: manual recovery pins the status word to `StatusMANUAL` (which outranks `StatusBUSY` in the documented priority order), and the tray travel commands change no status at all, answering with a second copy of their own echo.

## Breaking

`reset()` is removed. Use `home()` / `reset_error()` to recover from a latched error, or `initialize_keeping_caps_on_pins()` to recover without dropping caps held on the pins.

## Not hardware-verified

Everything new here is derived from the command list and has not touched an instrument. The manual recovery group and `set_safety_door_enabled(False)` move axes or defeat an interlock. The previously verified paths — connect, status, tray open/close, home, standby/ready, decap/recap/waste and error recovery — are unchanged in behaviour.

## Test plan

- 74 unit tests pass (up from 30)
- `ruff format --check` and `ruff check` clean
- `mypy` clean
- hello-world notebook validates under `nbformat`; gained sections for the queries, tray travel, cartridge swap, settings, forced retry and manual recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)