### PR TITLE
fix(hamilton): resolve trash_core96 from the deck instead of a stale pointer

### DIFF
--- a/pylabrobot/resources/hamilton/hamilton_deck_tests.py
+++ b/pylabrobot/resources/hamilton/hamilton_deck_tests.py
@@ -96,8 +96,8 @@ class HamiltonDeckTests(unittest.TestCase):
 
   def test_get_trash_area96_survives_serialization_round_trip(self):
     """`serialize()` encodes the 96 trash as a child and sets `with_trash96=False`, so the
-    rebuilt deck's `__init__` leaves the cached `_trash96` pointer as None. `get_trash_area96()`
-    must still resolve it from the child tree rather than raising."""
+    rebuilt deck never runs the `with_trash96` branch in `__init__`. `get_trash_area96()` must
+    still resolve it from the child tree rather than raising."""
     deck = self.build_layout()
     original_location = deck.get_trash_area96().get_location_wrt(deck)
 
@@ -107,10 +107,10 @@ class HamiltonDeckTests(unittest.TestCase):
     self.assertEqual(deck2.get_trash_area96().get_location_wrt(deck2), original_location)
 
   def test_get_trash_area96_raises_after_clear_include_trash(self):
-    """`clear(include_trash=True)` unassigns the 96 trash. `get_trash_area96()` must raise
-    rather than hand back the now-orphaned resource via the stale cached pointer."""
+    """`clear(include_trash=True)` unassigns the 96 trash, so `get_trash_area96()` must raise
+    rather than hand back the now-orphaned resource."""
     deck = self.build_layout()
-    deck.get_trash_area96()  # populate the cache before invalidating it
+    deck.get_trash_area96()  # resolves while still assigned
 
     deck.clear(include_trash=True)
 

--- a/pylabrobot/resources/hamilton/hamilton_deck_tests.py
+++ b/pylabrobot/resources/hamilton/hamilton_deck_tests.py
@@ -1,7 +1,7 @@
 import textwrap
 import unittest
 
-from pylabrobot.resources import TipRack
+from pylabrobot.resources import Deck, TipRack
 from pylabrobot.resources.corning import (
   cor_96_wellplate_360uL_Fb,
 )
@@ -93,6 +93,30 @@ class HamiltonDeckTests(unittest.TestCase):
     self.assertEqual(len(tip_racks), 6)  # 5 added 300 uL racks + the built-in teaching rack
     self.assertEqual(len(matches), 5)
     self.assertNotIn("teaching_tip_rack", {tr.name for tr in matches})
+
+  def test_get_trash_area96_survives_serialization_round_trip(self):
+    """`serialize()` encodes the 96 trash as a child and sets `with_trash96=False`, so the
+    rebuilt deck's `__init__` leaves the cached `_trash96` pointer as None. `get_trash_area96()`
+    must still resolve it from the child tree rather than raising."""
+    deck = self.build_layout()
+    original_location = deck.get_trash_area96().get_location_wrt(deck)
+
+    deck2 = Deck.deserialize(deck.serialize())
+
+    self.assertIn("trash_core96", [child.name for child in deck2.children])
+    self.assertEqual(deck2.get_trash_area96().get_location_wrt(deck2), original_location)
+
+  def test_get_trash_area96_raises_after_clear_include_trash(self):
+    """`clear(include_trash=True)` unassigns the 96 trash. `get_trash_area96()` must raise
+    rather than hand back the now-orphaned resource via the stale cached pointer."""
+    deck = self.build_layout()
+    deck.get_trash_area96()  # populate the cache before invalidating it
+
+    deck.clear(include_trash=True)
+
+    self.assertNotIn("trash_core96", [child.name for child in deck.children])
+    with self.assertRaises(RuntimeError):
+      deck.get_trash_area96()
 
   def test_assign_gigantic_resource(self):
     stanley_cup = StanleyCup_QUENCHER_FLOWSTATE_TUMBLER(name="HUGE")

--- a/pylabrobot/resources/hamilton/hamilton_decks.py
+++ b/pylabrobot/resources/hamilton/hamilton_decks.py
@@ -458,12 +458,11 @@ class HamiltonSTARDeck(HamiltonDeck):
       origin=origin,
     )
 
-    self._trash96: Optional[Trash] = None
     if with_trash96:
       # got this location from a .lay file, but will probably need to be adjusted by the user.
-      self._trash96 = Trash("trash_core96", size_x=122.4, size_y=82.6, size_z=0)  # size of tiprack
+      trash96 = Trash("trash_core96", size_x=122.4, size_y=82.6, size_z=0)  # size of tiprack
       self.assign_child_resource(
-        resource=self._trash96,
+        resource=trash96,
         location=Coordinate(x=-42.0 - 16.2, y=120.3 - 14.3, z=216.4),
       )
 
@@ -548,20 +547,11 @@ class HamiltonSTARDeck(HamiltonDeck):
     return Coordinate(x=x, y=63, z=100)
 
   def get_trash_area96(self) -> Trash:
-    # `_trash96` is only set in `__init__`, so it is stale whenever the deck was rebuilt from a
-    # serialized layout (which encodes the trash as a child and passes `with_trash96=False`) or the
-    # trash was unassigned. Resolve against the child tree instead, and only trust the cached
-    # reference while it is still assigned to this deck.
-    if self._trash96 is not None and self._trash96.parent is self:
-      return self._trash96
-
-    if self.has_resource("trash_core96"):
-      self._trash96 = cast(Trash, self.get_resource("trash_core96"))
-      return self._trash96
-
-    raise RuntimeError(
-      "Trash area for 96-well plates was not created. Initialize with `with_trash96=True`."
-    )
+    if not self.has_resource("trash_core96"):
+      raise RuntimeError(
+        "Trash area for 96-well plates was not created. Initialize with `with_trash96=True`."
+      )
+    return cast(Trash, self.get_resource("trash_core96"))
 
   def clear(self, include_trash: bool = False):
     """Clear the deck, removing all resources except the trash areas and the waste block."""

--- a/pylabrobot/resources/hamilton/hamilton_decks.py
+++ b/pylabrobot/resources/hamilton/hamilton_decks.py
@@ -548,11 +548,20 @@ class HamiltonSTARDeck(HamiltonDeck):
     return Coordinate(x=x, y=63, z=100)
 
   def get_trash_area96(self) -> Trash:
-    if self._trash96 is None:
-      raise RuntimeError(
-        "Trash area for 96-well plates was not created. Initialize with `with_trash96=True`."
-      )
-    return self._trash96
+    # `_trash96` is only set in `__init__`, so it is stale whenever the deck was rebuilt from a
+    # serialized layout (which encodes the trash as a child and passes `with_trash96=False`) or the
+    # trash was unassigned. Resolve against the child tree instead, and only trust the cached
+    # reference while it is still assigned to this deck.
+    if self._trash96 is not None and self._trash96.parent is self:
+      return self._trash96
+
+    if self.has_resource("trash_core96"):
+      self._trash96 = cast(Trash, self.get_resource("trash_core96"))
+      return self._trash96
+
+    raise RuntimeError(
+      "Trash area for 96-well plates was not created. Initialize with `with_trash96=True`."
+    )
 
   def clear(self, include_trash: bool = False):
     """Clear the deck, removing all resources except the trash areas and the waste block."""


### PR DESCRIPTION
## Problem

`HamiltonSTARDeck._trash96` is assigned only in `__init__`, and `get_trash_area96()` returns it directly. That cached reference does not survive the deck being rebuilt or the trash being unassigned, which produces two distinct failures.

**1. Deserialized decks raise even though the trash is present.** `serialize()` encodes the 96 trash as a child resource and emits `with_trash96=False`. A deck restored through `Deck.deserialize()` therefore runs `__init__` with the flag off and leaves `_trash96` as `None`, while `trash_core96` is re-attached from the serialized children. The resource is on the deck and correctly positioned, but the getter raises:

```python
deck2 = Deck.deserialize(STARLetDeck().serialize())
"trash_core96" in [c.name for c in deck2.children]  # True
deck2.get_trash_area96()
# RuntimeError: Trash area for 96-well plates was not created. Initialize with `with_trash96=True`.
```

Anyone loading a saved layout has to re-establish the pointer by hand.

**2. `clear(include_trash=True)` leaves a stale pointer.** `clear()` unassigns the trash but never clears the attribute, so the getter hands back an orphaned `Trash` with `parent = None`. That fails later and further from the cause than an outright error would.

## Fix

Resolve the resource by name against the child tree, mirroring how the base class's `Deck.get_trash_area()` already works, and only trust the cached reference while it is still assigned to this deck. The `parent is self` guard is what fixes the second case: an unassigned trash falls through to the lookup and then raises honestly.

Behaviour when the trash genuinely was not created (`with_trash96=False`) is unchanged.

## Tests

Two regression tests in `hamilton_deck_tests.py`, one per failure mode. Both were confirmed to fail against the unfixed source — the round-trip test errors with the original `RuntimeError`, and the `include_trash` test fails with "RuntimeError not raised" — and to pass with the fix.

## Verification

- `pytest pylabrobot/resources` — 225 passed. The 5 failures are pre-existing Opentrons deck tests that fetch labware over the network and hit `SSL: CERTIFICATE_VERIFY_FAILED` locally; identical on baseline.
- `ruff check` / `ruff format --check` (0.15.4, per the pin) — clean on both changed files.
- `mypy` (1.18.2, per the pin) — `Success: no issues found in 2 source files`.

## Note

Not addressed here, but the underlying design smell is that `serialize()` writes `with_trash`/`with_trash96`/`core_grippers` as `False`/`None` because the data lives in the children — the "not very pretty to have this key though" comments. That constructor-flags-vs-children mismatch is what produced this bug, and may affect other cached references the same way. Happy to follow up separately if that's of interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)