### PR TITLE
Add resource metadata

### DIFF
--- a/docs/resources/introduction.md
+++ b/docs/resources/introduction.md
@@ -44,7 +44,8 @@ plate = Resource(
     size_x=127.76,
     size_y=85.48,
     size_z=14.5,
-    metadata={"solvent": "water", "batch_id": "B2026-07", "is_sterilized": True}
+    metadata={"solvent": "water", "batch_id": "B2026-07", "is_sterilized": True},
+    model="vendor_plate_96_Vb",
 )
 ```
 
@@ -56,20 +57,21 @@ You can query resources in a deck or resource tree using `find_resources` and `f
 
 ```python
 # Find all resources with solvent="water"
-water_plates = deck.find_resources(solvent="water")
+water_plates = deck.find_resources(metadata={"solvent": "water"})
 
 # Check metadata key presence
 sterilized_items = deck.find_resources(has_metadata="is_sterilized")
 
 # Use predicate functions for metadata values (receives metadata.get(key), e.g. None if key is missing)
-incubated = deck.find_resources(temperature=lambda t: t is not None and t >= 37.0)
+incubated = deck.find_resources(metadata={"temperature": lambda t: t is not None and t >= 37.0})
 
 # Filter by top-level attributes (name, type, model, category)
+import re
 from pylabrobot.resources import Plate
-plates = deck.find_resources(type=Plate, category="plate")
+plates = deck.find_resources(type=Plate, model=re.compile(r"vendor_"))
 
 # Find the first matching resource
-first_sterile = deck.find_resource(is_sterilized=True)
+first_sterile = deck.find_resource(metadata={"is_sterilized": True})
 ```
 
 ## Saving and loading resources

--- a/docs/resources/introduction.md
+++ b/docs/resources/introduction.md
@@ -32,6 +32,46 @@ child = Resource(name="child", size_x=5, size_y=5, size_z=5)
 resource.assign_child_resource(child, Coordinate(x=0, y=0, z=0))
 ```
 
+## Resource Metadata
+
+You can attach generic key-value metadata to any `Resource` via the `metadata` parameter during initialization or by modifying `resource.metadata`:
+
+```python
+from pylabrobot.resources import Resource
+
+plate = Resource(
+    name="plate1",
+    size_x=127.76,
+    size_y=85.48,
+    size_z=14.5,
+    metadata={"solvent": "water", "batch_id": "B2026-07", "is_sterilized": True}
+)
+```
+
+Metadata key-value pairs are included in serialization (`resource.serialize()`) and deserialization (`Resource.deserialize()`).
+
+## Finding Resources (`find_resources` and `find_resource`)
+
+You can query resources in a deck or resource tree using `find_resources` and `find_resource`:
+
+```python
+# Find all resources with solvent="water"
+water_plates = deck.find_resources(solvent="water")
+
+# Check metadata key presence
+sterilized_items = deck.find_resources(has_metadata="is_sterilized")
+
+# Use predicate functions for metadata values (receives metadata.get(key), e.g. None if key is missing)
+incubated = deck.find_resources(temperature=lambda t: t is not None and t >= 37.0)
+
+# Filter by top-level attributes (name, type, model, category)
+from pylabrobot.resources import Plate
+plates = deck.find_resources(type=Plate, category="plate")
+
+# Find the first matching resource
+first_sterile = deck.find_resource(is_sterilized=True)
+```
+
 ## Saving and loading resources
 
 PyLabRobot provide utilities to save and load resources and their states to and from files, as well as to serialize and deserialize resources and their states to and from Python dictionaries.

--- a/pylabrobot/legacy/centrifuge/centrifuge.py
+++ b/pylabrobot/legacy/centrifuge/centrifuge.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional, Tuple, cast
+from typing import Any, Mapping, Optional, Tuple, cast
 
 from pylabrobot.legacy.centrifuge.backend import CentrifugeBackend, LoaderBackend
 from pylabrobot.legacy.centrifuge.standard import (
@@ -29,6 +29,7 @@ class Centrifuge(Machine, Resource):
     category: Optional[str] = "centrifuge",
     model: Optional[str] = None,
     buckets: Optional[Tuple[ResourceHolder, ResourceHolder]] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ) -> None:
     Machine.__init__(self, backend=backend)
     Resource.__init__(
@@ -40,6 +41,7 @@ class Centrifuge(Machine, Resource):
       rotation=rotation,
       category=category,
       model=model,
+      metadata=metadata,
     )
     self.backend: CentrifugeBackend = backend  # fix type
     self._door_open = False
@@ -147,6 +149,7 @@ class Centrifuge(Machine, Resource):
       category=data.get("category"),
       model=data.get("model"),
       buckets=buckets,
+      metadata=data.get("metadata"),
     )
 
 
@@ -166,6 +169,7 @@ class Loader(Machine, ResourceHolder):
     rotation=None,
     category="loader",
     model=None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ) -> None:
     Machine.__init__(self, backend=backend)
     ResourceHolder.__init__(
@@ -178,6 +182,7 @@ class Loader(Machine, ResourceHolder):
       rotation=rotation,
       category=category,
       model=model,
+      metadata=metadata,
     )
     self.backend: LoaderBackend = backend  # fix type
     self.centrifuge = centrifuge
@@ -239,4 +244,5 @@ class Loader(Machine, ResourceHolder):
       rotation=deserialize(data["resource"].get("rotation")),
       category=data["resource"].get("category"),
       model=data["resource"].get("model"),
+      metadata=data["resource"].get("metadata"),
     )

--- a/pylabrobot/legacy/liquid_handling/liquid_handler.py
+++ b/pylabrobot/legacy/liquid_handling/liquid_handler.py
@@ -16,6 +16,7 @@ from typing import (
   Generator,
   List,
   Literal,
+  Mapping,
   Optional,
   Sequence,
   Set,
@@ -281,6 +282,7 @@ class LiquidHandler(Resource, Machine):
     deck: Deck,
     default_offset_head96: Optional[Coordinate] = None,
     name: Optional[str] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     """Initialize a LiquidHandler.
 
@@ -289,6 +291,7 @@ class LiquidHandler(Resource, Machine):
       deck: Deck to use.
       default_offset_head96: Base offset applied to all 96-head operations.
       name: Name of the liquid handler. If not provided, defaults to ``lh_{deck.name}``.
+      metadata: Metadata for the liquid handler.
     """
 
     Resource.__init__(
@@ -298,6 +301,7 @@ class LiquidHandler(Resource, Machine):
       size_y=deck._size_y,
       size_z=deck._size_z,
       category="liquid_handler",
+      metadata=metadata,
     )
     Machine.__init__(self, backend=backend)
 
@@ -2688,6 +2692,8 @@ class LiquidHandler(Resource, Machine):
       deck=deck,
       backend=backend,
       default_offset_head96=default_offset,
+      name=data.get("name"),
+      metadata=data.get("metadata"),
     )
 
   @classmethod

--- a/pylabrobot/legacy/storage/incubator.py
+++ b/pylabrobot/legacy/storage/incubator.py
@@ -1,5 +1,5 @@
 import random
-from typing import List, Literal, Optional, Union, cast
+from typing import Any, List, Literal, Mapping, Optional, Union, cast
 
 from pylabrobot.events import evented_operation, resource_reference
 from pylabrobot.legacy.machines import Machine
@@ -61,6 +61,7 @@ class Incubator(Machine, Resource):
     rotation: Optional[Rotation] = None,
     category: Optional[str] = None,
     model: Optional[str] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     Machine.__init__(self, backend=backend)
     self.backend: IncubatorBackend = backend  # fix type
@@ -73,6 +74,7 @@ class Incubator(Machine, Resource):
       rotation=rotation,
       category=category,
       model=model,
+      metadata=metadata,
     )
     self.loading_tray = PlateHolder(
       name=self.name + "_tray", size_x=127.76, size_y=85.48, size_z=0, pedestal_size_z=0
@@ -238,4 +240,5 @@ class Incubator(Machine, Resource):
       rotation=cast(Optional[Rotation], deserialize(data.get("rotation"))),
       category=data.get("category"),
       model=data.get("model"),
+      metadata=data.get("metadata"),
     )

--- a/pylabrobot/resources/carrier.py
+++ b/pylabrobot/resources/carrier.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, Generic, List, Optional, Type, TypeVar, Union, cast
+from typing import Any, Dict, Generic, List, Mapping, Optional, Type, TypeVar, Union, cast
 
 from pylabrobot.resources.resource_holder import ResourceHolder, get_child_location
 
@@ -28,6 +28,7 @@ class Carrier(Resource, Generic[S]):
     sites: Optional[Dict[int, S]] = None,
     category: Optional[str] = "carrier",
     model: Optional[str] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     super().__init__(
       name=name,
@@ -36,6 +37,7 @@ class Carrier(Resource, Generic[S]):
       size_z=size_z,
       category=category,
       model=model,
+      metadata=metadata,
     )
 
     sites = sites or {}
@@ -135,6 +137,7 @@ class TipCarrier(Carrier):
     sites: Optional[Dict[int, ResourceHolder]] = None,
     category="tip_carrier",
     model: Optional[str] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     super().__init__(
       name,
@@ -144,6 +147,7 @@ class TipCarrier(Carrier):
       sites,
       category=category,
       model=model,
+      metadata=metadata,
     )
 
 
@@ -160,9 +164,17 @@ class PlateHolder(ResourceHolder):
     child_location=Coordinate.zero(),
     category="plate_holder",
     model: Optional[str] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     super().__init__(
-      name, size_x, size_y, size_z, category=category, model=model, child_location=child_location
+      name,
+      size_x,
+      size_y,
+      size_z,
+      category=category,
+      model=model,
+      child_location=child_location,
+      metadata=metadata,
     )
     if pedestal_size_z is None:
       raise ValueError(
@@ -263,6 +275,7 @@ class PlateCarrier(Carrier):
     sites: Optional[Dict[int, PlateHolder]] = None,
     category="plate_carrier",
     model: Optional[str] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     super().__init__(
       name,
@@ -272,6 +285,7 @@ class PlateCarrier(Carrier):
       sites,
       category=category,
       model=model,
+      metadata=metadata,
     )
     self.sites: Dict[int, PlateHolder] = sites or {}  # fix type
 
@@ -320,6 +334,7 @@ class MFXCarrier(Carrier[ResourceHolder]):
     sites: Optional[Dict[int, ResourceHolder]] = None,
     category="mfx_carrier",
     model: Optional[str] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     super().__init__(
       name=name,
@@ -329,6 +344,7 @@ class MFXCarrier(Carrier[ResourceHolder]):
       sites=sites,
       category=category,
       model=model,
+      metadata=metadata,
     )
 
 
@@ -346,6 +362,7 @@ class TubeCarrier(Carrier):
     sites: Optional[Dict[int, ResourceHolder]] = None,
     category="tube_carrier",
     model: Optional[str] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     super().__init__(
       name,
@@ -355,6 +372,7 @@ class TubeCarrier(Carrier):
       sites,
       category=category,
       model=model,
+      metadata=metadata,
     )
 
 
@@ -372,6 +390,7 @@ class TroughCarrier(Carrier):
     sites: Optional[Dict[int, ResourceHolder]] = None,
     category="trough_carrier",
     model: Optional[str] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     super().__init__(
       name,
@@ -381,6 +400,7 @@ class TroughCarrier(Carrier):
       sites,
       category=category,
       model=model,
+      metadata=metadata,
     )
 
 

--- a/pylabrobot/resources/container.py
+++ b/pylabrobot/resources/container.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 from pylabrobot.serializer import serialize
 from pylabrobot.utils.interpolation import interpolate_1d
@@ -29,6 +29,7 @@ class Container(Liddable, Resource):
     compute_height_from_volume: Optional[Callable[[float], float]] = None,
     height_volume_data: Optional[Dict[float, float]] = None,
     no_go_zones: Optional[List[Tuple[Coordinate, Coordinate]]] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     """Create a new container.
 
@@ -52,6 +53,7 @@ class Container(Liddable, Resource):
       size_z=size_z,
       category=category,
       model=model,
+      metadata=metadata,
     )
     self._material_z_thickness = material_z_thickness
     self.height_volume_data = (

--- a/pylabrobot/resources/deck.py
+++ b/pylabrobot/resources/deck.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, cast
+from typing import Any, Dict, List, Mapping, Optional, cast
 
 from pylabrobot.resources.errors import ResourceNotFoundError
 
@@ -26,6 +26,7 @@ class Deck(Resource):
     name: str = "deck",
     origin: Coordinate = Coordinate(0, 0, 0),
     category: str = "deck",
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     """Initialize a new deck."""
 
@@ -35,6 +36,7 @@ class Deck(Resource):
       size_y=size_y,
       size_z=size_z,
       category=category,
+      metadata=metadata,
     )
     self.location = origin
     self._resources: Dict[str, Resource] = {}

--- a/pylabrobot/resources/itemized_resource.py
+++ b/pylabrobot/resources/itemized_resource.py
@@ -2,10 +2,12 @@ import sys
 from abc import ABCMeta
 from collections import OrderedDict
 from typing import (
+  Any,
   Dict,
   Generator,
   Generic,
   List,
+  Mapping,
   Optional,
   Sequence,
   Tuple,
@@ -55,6 +57,7 @@ class ItemizedResource(Resource, Generic[T], metaclass=ABCMeta):
     ordering: Optional[OrderedDict[str, str]] = None,
     category: Optional[str] = None,
     model: Optional[str] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     """Initialize an itemized resource
 
@@ -71,6 +74,7 @@ class ItemizedResource(Resource, Generic[T], metaclass=ABCMeta):
         If this is specified, `ordered_items` must be `None`. See `ordered_items` for the format of the
         identifiers.
       category: The category of the resource.
+      metadata: Metadata for the resource.
 
     Examples:
 
@@ -90,7 +94,9 @@ class ItemizedResource(Resource, Generic[T], metaclass=ABCMeta):
         ...   ordered_items={"A1": Well("well", size_x=1, size_y=1, size_z=1)})
     """
 
-    super().__init__(name, size_x, size_y, size_z, category=category, model=model)
+    super().__init__(
+      name, size_x, size_y, size_z, category=category, model=model, metadata=metadata
+    )
 
     if ordered_items is not None:
       if ordering is not None:

--- a/pylabrobot/resources/lid.py
+++ b/pylabrobot/resources/lid.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 from pylabrobot.resources.resource_holder import get_child_location
 
@@ -30,6 +30,7 @@ class Lid(Resource):
     nesting_z_height: float,
     category: str = "lid",
     model: Optional[str] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     """Create a lid.
 
@@ -47,6 +48,7 @@ class Lid(Resource):
       size_z=size_z,
       category=category,
       model=model,
+      metadata=metadata,
     )
     self.nesting_z_height = nesting_z_height
     if nesting_z_height == 0:

--- a/pylabrobot/resources/plate.py
+++ b/pylabrobot/resources/plate.py
@@ -4,9 +4,11 @@ import warnings
 from collections import OrderedDict
 from typing import (
   TYPE_CHECKING,
+  Any,
   Dict,
   List,
   Literal,
+  Mapping,
   Optional,
   Sequence,
   Tuple,
@@ -40,6 +42,7 @@ class Plate(Liddable, ItemizedResource["Well"]):
     model: Optional[str] = None,
     plate_type: Literal["skirted", "semi-skirted", "non-skirted"] = "skirted",
     stacking_z_height: Optional[float] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     """Initialize a Plate resource.
 
@@ -64,6 +67,7 @@ class Plate(Liddable, ItemizedResource["Well"]):
       ordering=ordering,
       category=category,
       model=model,
+      metadata=metadata,
     )
     self.plate_type = plate_type
     self.stacking_z_height = stacking_z_height

--- a/pylabrobot/resources/plate_adapter.py
+++ b/pylabrobot/resources/plate_adapter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import warnings
-from typing import List, Optional
+from typing import Any, List, Mapping, Optional
 
 from pylabrobot.resources.coordinate import Coordinate
 from pylabrobot.resources.plate import Plate
@@ -75,6 +75,7 @@ class PlateAdapter(Resource):
     category: Optional[str] = None,
     model: Optional[str] = None,
     adapter_hole_size_z=None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     super().__init__(
       name=name,
@@ -83,6 +84,7 @@ class PlateAdapter(Resource):
       size_z=size_z,
       category=category or "plate_adapter",
       model=model,
+      metadata=metadata,
     )
 
     if adapter_hole_size_z is not None:

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -96,8 +96,8 @@ def _match_type(resource: Resource, matcher: TypeMatcher) -> bool:
   raise TypeError(f"Unexpected type matcher of type {type(matcher).__qualname__}")
 
 
-def _match_top_level_attribute(resource: Resource, attr_name: str, matcher: StrAttrMatcher) -> bool:
-  """Return whether ``resource``'s top-level attribute ``attr_name`` matches ``matcher``.
+def _match_attribute_value(attr_val: Any, matcher: StrAttrMatcher) -> bool:
+  """Return whether a top-level resource attribute value matches ``matcher``.
 
   The interpretation of ``matcher`` depends on its type:
 
@@ -107,7 +107,6 @@ def _match_top_level_attribute(resource: Resource, attr_name: str, matcher: StrA
 
   Note the callable receives different arguments than for `_match_type`.
   """
-  attr_val = getattr(resource, attr_name, None)
   if isinstance(matcher, re.Pattern):
     return attr_val is not None and bool(matcher.search(str(attr_val)))
   if callable(matcher):
@@ -741,23 +740,17 @@ class Resource(SerializableMixin):
     elif has_metadata is not None:
       has_keys = list(has_metadata)
 
-    top_level_attr_matchers = {
-      k: v
-      for k, v in dict(
-        name=name,
-        model=model,
-        category=category,
-      ).items()
-      if v is not None
-    }
-
     for resource in candidates:
       if any(k not in resource.metadata for k in has_keys):
         continue
 
-      if any(
-        not _match_top_level_attribute(resource, k, v) for k, v in top_level_attr_matchers.items()
-      ):
+      if name is not None and not _match_attribute_value(resource.name, name):
+        continue
+
+      if model is not None and not _match_attribute_value(resource.model, model):
+        continue
+
+      if category is not None and not _match_attribute_value(resource.category, category):
         continue
 
       if metadata is not None and any(

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -6,7 +6,8 @@ import json
 import logging
 import re
 import sys
-from typing import Any, Callable, Dict, Iterable, List, Optional, Union, cast
+from collections.abc import Iterable, Mapping
+from typing import Any, Callable, Dict, List, Optional, Union, cast
 
 from pylabrobot.events import coordinate_reference, emit_event, resource_reference
 from pylabrobot.serializer import SerializableMixin, deserialize, serialize
@@ -66,7 +67,20 @@ DidUnassignResourceCallback = Callable[["Resource"], None]
 ResourceDidUpdateState = Callable[[Dict[str, Any]], None]
 
 
-def _match_top_level_attribute(resource: "Resource", attr_name: str, matcher: Any) -> bool:
+def _match_top_level_attribute(resource: Resource, attr_name: str, matcher: Any) -> bool:
+  """Return whether ``resource``'s top-level attribute ``attr_name`` matches ``matcher``.
+
+  The interpretation of ``matcher`` depends on its kind:
+
+  - For ``attr_name == "type"``: a class (or tuple of classes) is matched with
+    ``isinstance``; a ``str`` is compared against the class name; an
+    ``re.Pattern`` is ``search``-ed against the class name; a callable receives
+    the *resource itself*. Anything else does not match.
+  - For any other attribute: an ``re.Pattern`` is ``search``-ed against
+    ``str(attr_val)``; a callable receives the *attribute value*; otherwise
+    equality is checked. Note the callable receives different arguments than in
+    the ``"type"`` case.
+  """
   if attr_name == "type":
     if inspect.isclass(matcher) or (
       isinstance(matcher, tuple) and all(inspect.isclass(c) for c in matcher)
@@ -88,12 +102,22 @@ def _match_top_level_attribute(resource: "Resource", attr_name: str, matcher: An
   return bool(attr_val == matcher)
 
 
-def _match_metadata_entry(resource: "Resource", key: str, expected: Any) -> bool:
+def _match_metadata_entry(resource: Resource, key: str, expected: Any) -> bool:
+  """Return whether ``resource``'s metadata entry ``key`` matches ``expected``.
+
+  If ``expected`` is callable it is treated as a *predicate* and called with
+  ``resource.metadata.get(key)`` (i.e. ``None`` when the key is absent).
+  Otherwise the key must be present and its value equal to ``expected``.
+
+  Consequence: a callable stored *as a metadata value* cannot be matched by
+  equality through this path -- it would itself be invoked as the predicate. To
+  match such a value by identity, pass a predicate explicitly, e.g.
+  ``lambda v: v is my_object``.
+  """
   val = resource.metadata.get(key)
   if callable(expected):
     return bool(expected(val))
   return key in resource.metadata and val == expected
-
 
 
 class Resource(SerializableMixin):
@@ -123,7 +147,7 @@ class Resource(SerializableMixin):
     model: Optional[str] = None,
     barcode: Optional[Barcode] = None,
     preferred_pickup_location: Optional[Coordinate] = None,
-    metadata: Optional[Dict[str, Any]] = None,
+    metadata: Mapping[str, Any] | None = None,
   ):
     self._name = name
     self._size_x = size_x
@@ -135,7 +159,10 @@ class Resource(SerializableMixin):
     self.model = model
     self.barcode = barcode
     self.preferred_pickup_location = preferred_pickup_location
-    self.metadata: Dict[str, Any] = metadata.copy() if metadata is not None else {}
+    # Shallow copy: top-level keys are decoupled from the caller's mapping, but
+    # nested containers/objects remain shared. Deep-copy before passing in if you
+    # need full isolation of mutable metadata values.
+    self.metadata: dict[str, Any] = dict(metadata) if metadata is not None else {}
 
     self.location: Optional[Coordinate] = None
     self.parent: Optional[Resource] = None
@@ -653,41 +680,64 @@ class Resource(SerializableMixin):
 
   def find_resources(
     self,
-    fn: Optional[Callable[["Resource"], bool]] = None,
+    fn: Callable[[Resource], bool] | None = None,
     *,
-    metadata: Optional[Dict[str, Any]] = None,
-    has_metadata: Optional[Union[str, Iterable[str]]] = None,
+    metadata: Mapping[str, Any] | None = None,
+    has_metadata: str | Iterable[str] | None = None,
     recursive: bool = True,
     **kwargs: Any,
-  ) -> List["Resource"]:
-    """Find resources matching top-level attributes, metadata criteria, and/or predicate functions.
+  ) -> list[Resource]:
+    """Find resources matching top-level attributes, metadata, and/or a predicate.
+
+    All supplied criteria must match (logical AND). The search always includes
+    ``self`` in addition to its children, so e.g. ``deck.find_resources()`` with
+    no criteria returns the deck itself plus every descendant.
 
     Args:
-      fn: Optional predicate function receiving a Resource and returning True if it matches.
-      metadata: Dict of metadata key-value pairs that must match. If value is callable,
-        it receives metadata.get(key). Otherwise, exact equality is checked.
-      has_metadata: Single key string or iterable of key strings that must be present in metadata.
-      recursive: If True, searches self and all descendants. If False, searches self and direct children.
-      **kwargs: Shorthand for top-level attributes ('name', 'type', 'model', 'category')
-        or metadata key-value pairs.
+      fn: Optional predicate receiving a Resource and returning True if it matches.
+      metadata: Metadata key-value pairs that must all match. If a value is
+        callable it is treated as a predicate receiving ``metadata.get(key)``
+        (``None`` when absent); otherwise the key must be present and equal.
+      has_metadata: A single key or iterable of keys that must be present in
+        metadata (values are not inspected).
+      recursive: If True, search self and all descendants. If False, search self
+        and direct children only.
+      **kwargs: Shorthand matchers. Keys in ('name', 'type', 'model', 'category')
+        match the corresponding top-level attribute; any other key is treated as
+        a metadata matcher (same semantics as ``metadata``). For ``type`` the
+        matcher may be a class or tuple of classes (``isinstance``), a string or
+        ``re.Pattern`` (matched against the class name), or a callable receiving
+        the resource. For the other attributes a callable receives the attribute
+        value, an ``re.Pattern`` is matched against ``str(value)``, and any other
+        value is compared for equality.
 
     Returns:
-      List of matching Resource instances.
+      List of matching Resource instances. ``self`` is considered first (so it
+      appears first if it matches), followed by its descendants in
+      ``get_all_children`` order (direct children before deeper descendants).
+
+    Note:
+      The reserved keys ('name', 'type', 'model', 'category') always refer to the
+      top-level attribute, so a metadata key of the same name is shadowed when
+      passed as a kwarg. Query such a metadata key via the explicit ``metadata=``
+      argument instead, e.g. ``find_resources(metadata={"type": "solvent"})``. A
+      misspelled reserved key is silently treated as a (usually absent) metadata
+      key and matches nothing.
     """
     candidates = [self] + (self.get_all_children() if recursive else self.children)
-    results: List[Resource] = []
+    results: list[Resource] = []
 
     reserved_keys = {"name", "type", "model", "category"}
 
     top_level_matchers = {k: v for k, v in kwargs.items() if k in reserved_keys}
     extra_metadata_matchers = {k: v for k, v in kwargs.items() if k not in reserved_keys}
 
-    combined_metadata_matchers: Dict[str, Any] = {}
+    combined_metadata_matchers: dict[str, Any] = {}
     if metadata is not None:
       combined_metadata_matchers.update(metadata)
     combined_metadata_matchers.update(extra_metadata_matchers)
 
-    has_keys: List[str] = []
+    has_keys: list[str] = []
     if isinstance(has_metadata, str):
       has_keys = [has_metadata]
     elif has_metadata is not None:
@@ -714,14 +764,19 @@ class Resource(SerializableMixin):
 
   def find_resource(
     self,
-    fn: Optional[Callable[["Resource"], bool]] = None,
+    fn: Callable[[Resource], bool] | None = None,
     *,
-    metadata: Optional[Dict[str, Any]] = None,
-    has_metadata: Optional[Union[str, Iterable[str]]] = None,
+    metadata: Mapping[str, Any] | None = None,
+    has_metadata: str | Iterable[str] | None = None,
     recursive: bool = True,
     **kwargs: Any,
-  ) -> Optional["Resource"]:
-    """Find the first matching resource, or None if not found."""
+  ) -> Resource | None:
+    """Find the first matching resource, or None if not found.
+
+    Accepts the same arguments as :meth:`find_resources` and returns its first
+    result (``self`` is checked first, so it may be returned), or ``None`` if
+    nothing matches.
+    """
     results = self.find_resources(
       fn=fn,
       metadata=metadata,
@@ -890,7 +945,12 @@ class Resource(SerializableMixin):
     subclass = find_subclass(data["type"], cls=Resource)
     if subclass is None:
       raise ValueError(f'Could not find subclass with name "{data["type"]}"')
-    assert issubclass(subclass, cls) or subclass.__name__ == cls.__name__  # handle module alias imports
+    # The name-equality fallback tolerates a class that is imported under two
+    # different module paths (e.g. `pylabrobot...Resource` and a vendored alias):
+    # the two class objects are distinct, so `issubclass` is False even though
+    # they are logically the same class. Note this is a name-only check, so two
+    # genuinely different classes that share a short name would also pass here.
+    assert issubclass(subclass, cls) or subclass.__name__ == cls.__name__
 
     for key in [
       "type",
@@ -911,7 +971,9 @@ class Resource(SerializableMixin):
     if preferred_pickup_location is not None:
       resource.preferred_pickup_location = cast(Coordinate, deserialize(preferred_pickup_location))
     if metadata_data is not None:
-      resource.metadata = cast(Dict[str, Any], deserialize(metadata_data, allow_marshal=allow_marshal))
+      resource.metadata = cast(
+        dict[str, Any], deserialize(metadata_data, allow_marshal=allow_marshal)
+      )
 
     for child_data in children_data:
       child_cls = find_subclass(child_data["type"], cls=Resource)

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -7,7 +7,7 @@ import logging
 import re
 import sys
 from collections.abc import Iterable, Mapping
-from typing import Any, Callable, Dict, List, Optional, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 from pylabrobot.events import coordinate_reference, emit_event, resource_reference
 from pylabrobot.serializer import SerializableMixin, deserialize, serialize
@@ -66,34 +66,47 @@ WillUnassignResourceCallback = Callable[["Resource"], None]
 DidUnassignResourceCallback = Callable[["Resource"], None]
 ResourceDidUpdateState = Callable[[Dict[str, Any]], None]
 
+StrAttrMatcher = Union[re.Pattern, Callable[[Any], bool], str]
+TypeMatcher = Union[type, Tuple[type, ...], StrAttrMatcher]
 
-def _match_top_level_attribute(resource: Resource, attr_name: str, matcher: Any) -> bool:
+
+def _match_type(resource: Resource, matcher: TypeMatcher) -> bool:
+  """Return whether ``resource``'s type matches ``matcher``.
+
+  The interpretation of ``matcher`` depends on its type:
+  - a class (or tuple of classes) is matched with
+    ``isinstance``;
+  - a ``str`` is compared against the class name;
+  - a ``re.Pattern`` is ``search``-ed against the class name;
+  - a callable receives the *resource type*.
+
+  Any other matchers raise a TypeError
+  """
+  if inspect.isclass(matcher) or (
+    isinstance(matcher, tuple) and all(inspect.isclass(c) for c in matcher)
+  ):
+    return isinstance(resource, matcher)
+  klass = type(resource)
+  if isinstance(matcher, str):
+    return klass.__name__ == matcher
+  if isinstance(matcher, re.Pattern):
+    return bool(matcher.search(klass.__name__))
+  if callable(matcher):
+    return bool(matcher(klass))
+  raise TypeError(f"Unexpected type matcher of type {type(matcher).__qualname__}")
+
+
+def _match_top_level_attribute(resource: Resource, attr_name: str, matcher: StrAttrMatcher) -> bool:
   """Return whether ``resource``'s top-level attribute ``attr_name`` matches ``matcher``.
 
-  The interpretation of ``matcher`` depends on its kind:
+  The interpretation of ``matcher`` depends on its type:
 
-  - For ``attr_name == "type"``: a class (or tuple of classes) is matched with
-    ``isinstance``; a ``str`` is compared against the class name; an
-    ``re.Pattern`` is ``search``-ed against the class name; a callable receives
-    the *resource itself*. Anything else does not match.
-  - For any other attribute: an ``re.Pattern`` is ``search``-ed against
-    ``str(attr_val)``; a callable receives the *attribute value*; otherwise
-    equality is checked. Note the callable receives different arguments than in
-    the ``"type"`` case.
+  - ``re.Pattern`` is ``search``-ed against ``str(attr_val)``;
+  - a callable receives the *attribute value*;
+  - otherwise equality is checked.
+
+  Note the callable receives different arguments than for `_match_type`.
   """
-  if attr_name == "type":
-    if inspect.isclass(matcher) or (
-      isinstance(matcher, tuple) and all(inspect.isclass(c) for c in matcher)
-    ):
-      return isinstance(resource, matcher)
-    if isinstance(matcher, str):
-      return resource.__class__.__name__ == matcher
-    if isinstance(matcher, re.Pattern):
-      return bool(matcher.search(resource.__class__.__name__))
-    if callable(matcher):
-      return bool(matcher(resource))
-    return False
-
   attr_val = getattr(resource, attr_name, None)
   if isinstance(matcher, re.Pattern):
     return attr_val is not None and bool(matcher.search(str(attr_val)))
@@ -134,6 +147,8 @@ class Resource(SerializableMixin):
     barcode: The barcode of the resource (optional).
     preferred_pickup_location: The location where the center of the gripper should be when picking
       up this resource, relative to the resource's origin (optional).
+    metadata: Free-form metadata. Treated as black box during serialisation.
+      To make standard JSON serialisation work, only add JSON-compatible metadata.
   """
 
   def __init__(
@@ -147,7 +162,7 @@ class Resource(SerializableMixin):
     model: Optional[str] = None,
     barcode: Optional[Barcode] = None,
     preferred_pickup_location: Optional[Coordinate] = None,
-    metadata: Mapping[str, Any] | None = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     self._name = name
     self._size_x = size_x
@@ -162,7 +177,7 @@ class Resource(SerializableMixin):
     # Shallow copy: top-level keys are decoupled from the caller's mapping, but
     # nested containers/objects remain shared. Deep-copy before passing in if you
     # need full isolation of mutable metadata values.
-    self.metadata: dict[str, Any] = dict(metadata) if metadata is not None else {}
+    self.metadata: Dict[str, Any] = dict(metadata) if metadata is not None else {}
 
     self.location: Optional[Coordinate] = None
     self.parent: Optional[Resource] = None
@@ -207,7 +222,7 @@ class Resource(SerializableMixin):
     if self.preferred_pickup_location is not None:
       data["preferred_pickup_location"] = serialize(self.preferred_pickup_location)
     if self.metadata:
-      data["metadata"] = serialize(self.metadata)
+      data["metadata"] = self.metadata.copy()
     if self.children:
       data["children"] = [child.serialize() for child in self.children]
     if self.parent is not None:
@@ -680,13 +695,16 @@ class Resource(SerializableMixin):
 
   def find_resources(
     self,
-    fn: Callable[[Resource], bool] | None = None,
+    fn: Optional[Callable[[Resource], bool]] = None,
     *,
-    metadata: Mapping[str, Any] | None = None,
-    has_metadata: str | Iterable[str] | None = None,
+    metadata: Optional[Mapping[str, Any]] = None,
+    has_metadata: Optional[Union[str, Iterable[str]]] = None,
     recursive: bool = True,
-    **kwargs: Any,
-  ) -> list[Resource]:
+    name: Optional[StrAttrMatcher] = None,
+    type: Optional[TypeMatcher] = None,
+    model: Optional[StrAttrMatcher] = None,
+    category: Optional[StrAttrMatcher] = None,
+  ) -> List[Resource]:
     """Find resources matching top-level attributes, metadata, and/or a predicate.
 
     All supplied criteria must match (logical AND). The search always includes
@@ -702,57 +720,52 @@ class Resource(SerializableMixin):
         metadata (values are not inspected).
       recursive: If True, search self and all descendants. If False, search self
         and direct children only.
-      **kwargs: Shorthand matchers. Keys in ('name', 'type', 'model', 'category')
-        match the corresponding top-level attribute; any other key is treated as
-        a metadata matcher (same semantics as ``metadata``). For ``type`` the
-        matcher may be a class or tuple of classes (``isinstance``), a string or
-        ``re.Pattern`` (matched against the class name), or a callable receiving
-        the resource. For the other attributes a callable receives the attribute
-        value, an ``re.Pattern`` is matched against ``str(value)``, and any other
-        value is compared for equality.
+      name: Matches the resource name. Can be a string, regex or callable.
+      type: Matches the resource type. Can be a type or tuple of types, which are
+        matched using ``isinstance``, a string or regex, which are
+        matched against the type names, or a callable which receives ``type(resource)``.
+      model: Matches the resource model. Can be a string, regex or callable.
+      category: Matches the resource category. Can be a string, regex or callable.
 
     Returns:
       List of matching Resource instances. ``self`` is considered first (so it
       appears first if it matches), followed by its descendants in
       ``get_all_children`` order (direct children before deeper descendants).
-
-    Note:
-      The reserved keys ('name', 'type', 'model', 'category') always refer to the
-      top-level attribute, so a metadata key of the same name is shadowed when
-      passed as a kwarg. Query such a metadata key via the explicit ``metadata=``
-      argument instead, e.g. ``find_resources(metadata={"type": "solvent"})``. A
-      misspelled reserved key is silently treated as a (usually absent) metadata
-      key and matches nothing.
     """
     candidates = [self] + (self.get_all_children() if recursive else self.children)
-    results: list[Resource] = []
+    results: List[Resource] = []
 
-    reserved_keys = {"name", "type", "model", "category"}
-
-    top_level_matchers = {k: v for k, v in kwargs.items() if k in reserved_keys}
-    extra_metadata_matchers = {k: v for k, v in kwargs.items() if k not in reserved_keys}
-
-    combined_metadata_matchers: dict[str, Any] = {}
-    if metadata is not None:
-      combined_metadata_matchers.update(metadata)
-    combined_metadata_matchers.update(extra_metadata_matchers)
-
-    has_keys: list[str] = []
+    has_keys: List[str] = []
     if isinstance(has_metadata, str):
       has_keys = [has_metadata]
     elif has_metadata is not None:
       has_keys = list(has_metadata)
 
+    top_level_attr_matchers = {
+      k: v
+      for k, v in dict(
+        name=name,
+        model=model,
+        category=category,
+      ).items()
+      if v is not None
+    }
+
     for resource in candidates:
       if any(k not in resource.metadata for k in has_keys):
         continue
 
-      if any(not _match_top_level_attribute(resource, k, v) for k, v in top_level_matchers.items()):
+      if any(
+        not _match_top_level_attribute(resource, k, v) for k, v in top_level_attr_matchers.items()
+      ):
         continue
 
-      if any(
-        not _match_metadata_entry(resource, k, v) for k, v in combined_metadata_matchers.items()
+      if metadata is not None and any(
+        not _match_metadata_entry(resource, k, v) for k, v in metadata.items()
       ):
+        continue
+
+      if type is not None and not _match_type(resource, type):
         continue
 
       if fn is not None and not fn(resource):
@@ -764,13 +777,16 @@ class Resource(SerializableMixin):
 
   def find_resource(
     self,
-    fn: Callable[[Resource], bool] | None = None,
+    fn: Optional[Callable[[Resource], bool]] = None,
     *,
-    metadata: Mapping[str, Any] | None = None,
-    has_metadata: str | Iterable[str] | None = None,
+    metadata: Optional[Mapping[str, Any]] = None,
+    has_metadata: Optional[Union[str, Iterable[str]]] = None,
     recursive: bool = True,
-    **kwargs: Any,
-  ) -> Resource | None:
+    name: Optional[StrAttrMatcher] = None,
+    type: Optional[TypeMatcher] = None,
+    model: Optional[StrAttrMatcher] = None,
+    category: Optional[StrAttrMatcher] = None,
+  ) -> Optional[Resource]:
     """Find the first matching resource, or None if not found.
 
     Accepts the same arguments as :meth:`find_resources` and returns its first
@@ -782,7 +798,10 @@ class Resource(SerializableMixin):
       metadata=metadata,
       has_metadata=has_metadata,
       recursive=recursive,
-      **kwargs,
+      name=name,
+      type=type,
+      model=model,
+      category=category,
     )
     return results[0] if results else None
 
@@ -945,12 +964,7 @@ class Resource(SerializableMixin):
     subclass = find_subclass(data["type"], cls=Resource)
     if subclass is None:
       raise ValueError(f'Could not find subclass with name "{data["type"]}"')
-    # The name-equality fallback tolerates a class that is imported under two
-    # different module paths (e.g. `pylabrobot...Resource` and a vendored alias):
-    # the two class objects are distinct, so `issubclass` is False even though
-    # they are logically the same class. Note this is a name-only check, so two
-    # genuinely different classes that share a short name would also pass here.
-    assert issubclass(subclass, cls) or subclass.__name__ == cls.__name__
+    assert issubclass(subclass, cls)
 
     for key in [
       "type",
@@ -962,7 +976,7 @@ class Resource(SerializableMixin):
     rotation = data_copy.pop("rotation", None)
     barcode = data_copy.pop("barcode", None)
     preferred_pickup_location = data_copy.pop("preferred_pickup_location", None)
-    metadata_data = data_copy.pop("metadata", None)
+    metadata_data = data_copy.pop("metadata", {})
     resource = subclass(**deserialize(data_copy, allow_marshal=allow_marshal))
     if rotation is not None:
       resource.rotation = deserialize(rotation)  # not pretty, should be done in init.
@@ -971,10 +985,7 @@ class Resource(SerializableMixin):
     if preferred_pickup_location is not None:
       resource.preferred_pickup_location = cast(Coordinate, deserialize(preferred_pickup_location))
     if metadata_data is not None:
-      resource.metadata = cast(
-        dict[str, Any], deserialize(metadata_data, allow_marshal=allow_marshal)
-      )
-
+      resource.metadata = metadata_data
     for child_data in children_data:
       child_cls = find_subclass(child_data["type"], cls=Resource)
       if child_cls is None:

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import inspect
 import itertools
 import json
 import logging
+import re
 import sys
-from typing import Any, Callable, Dict, List, Optional, Union, cast
+from typing import Any, Callable, Dict, Iterable, List, Optional, Union, cast
 
 from pylabrobot.events import coordinate_reference, emit_event, resource_reference
 from pylabrobot.serializer import SerializableMixin, deserialize, serialize
@@ -64,6 +66,36 @@ DidUnassignResourceCallback = Callable[["Resource"], None]
 ResourceDidUpdateState = Callable[[Dict[str, Any]], None]
 
 
+def _match_top_level_attribute(resource: "Resource", attr_name: str, matcher: Any) -> bool:
+  if attr_name == "type":
+    if inspect.isclass(matcher) or (
+      isinstance(matcher, tuple) and all(inspect.isclass(c) for c in matcher)
+    ):
+      return isinstance(resource, matcher)
+    if isinstance(matcher, str):
+      return resource.__class__.__name__ == matcher
+    if isinstance(matcher, re.Pattern):
+      return bool(matcher.search(resource.__class__.__name__))
+    if callable(matcher):
+      return bool(matcher(resource))
+    return False
+
+  attr_val = getattr(resource, attr_name, None)
+  if isinstance(matcher, re.Pattern):
+    return attr_val is not None and bool(matcher.search(str(attr_val)))
+  if callable(matcher):
+    return bool(matcher(attr_val))
+  return bool(attr_val == matcher)
+
+
+def _match_metadata_entry(resource: "Resource", key: str, expected: Any) -> bool:
+  val = resource.metadata.get(key)
+  if callable(expected):
+    return bool(expected(val))
+  return key in resource.metadata and val == expected
+
+
+
 class Resource(SerializableMixin):
   """Base class for deck resources.
 
@@ -91,6 +123,7 @@ class Resource(SerializableMixin):
     model: Optional[str] = None,
     barcode: Optional[Barcode] = None,
     preferred_pickup_location: Optional[Coordinate] = None,
+    metadata: Optional[Dict[str, Any]] = None,
   ):
     self._name = name
     self._size_x = size_x
@@ -102,6 +135,7 @@ class Resource(SerializableMixin):
     self.model = model
     self.barcode = barcode
     self.preferred_pickup_location = preferred_pickup_location
+    self.metadata: Dict[str, Any] = metadata.copy() if metadata is not None else {}
 
     self.location: Optional[Coordinate] = None
     self.parent: Optional[Resource] = None
@@ -145,6 +179,8 @@ class Resource(SerializableMixin):
       data["barcode"] = self.barcode.serialize()
     if self.preferred_pickup_location is not None:
       data["preferred_pickup_location"] = serialize(self.preferred_pickup_location)
+    if self.metadata:
+      data["metadata"] = serialize(self.metadata)
     if self.children:
       data["children"] = [child.serialize() for child in self.children]
     if self.parent is not None:
@@ -177,6 +213,7 @@ class Resource(SerializableMixin):
       and self.location == other.location
       and self.category == other.category
       and self.children == other.children
+      and self.metadata == other.metadata
     )
 
   def __repr__(self) -> str:
@@ -614,6 +651,86 @@ class Resource(SerializableMixin):
 
     raise ResourceNotFoundError(f"Resource with name '{name}' does not exist.")
 
+  def find_resources(
+    self,
+    fn: Optional[Callable[["Resource"], bool]] = None,
+    *,
+    metadata: Optional[Dict[str, Any]] = None,
+    has_metadata: Optional[Union[str, Iterable[str]]] = None,
+    recursive: bool = True,
+    **kwargs: Any,
+  ) -> List["Resource"]:
+    """Find resources matching top-level attributes, metadata criteria, and/or predicate functions.
+
+    Args:
+      fn: Optional predicate function receiving a Resource and returning True if it matches.
+      metadata: Dict of metadata key-value pairs that must match. If value is callable,
+        it receives metadata.get(key). Otherwise, exact equality is checked.
+      has_metadata: Single key string or iterable of key strings that must be present in metadata.
+      recursive: If True, searches self and all descendants. If False, searches self and direct children.
+      **kwargs: Shorthand for top-level attributes ('name', 'type', 'model', 'category')
+        or metadata key-value pairs.
+
+    Returns:
+      List of matching Resource instances.
+    """
+    candidates = [self] + (self.get_all_children() if recursive else self.children)
+    results: List[Resource] = []
+
+    reserved_keys = {"name", "type", "model", "category"}
+
+    top_level_matchers = {k: v for k, v in kwargs.items() if k in reserved_keys}
+    extra_metadata_matchers = {k: v for k, v in kwargs.items() if k not in reserved_keys}
+
+    combined_metadata_matchers: Dict[str, Any] = {}
+    if metadata is not None:
+      combined_metadata_matchers.update(metadata)
+    combined_metadata_matchers.update(extra_metadata_matchers)
+
+    has_keys: List[str] = []
+    if isinstance(has_metadata, str):
+      has_keys = [has_metadata]
+    elif has_metadata is not None:
+      has_keys = list(has_metadata)
+
+    for resource in candidates:
+      if any(k not in resource.metadata for k in has_keys):
+        continue
+
+      if any(not _match_top_level_attribute(resource, k, v) for k, v in top_level_matchers.items()):
+        continue
+
+      if any(
+        not _match_metadata_entry(resource, k, v) for k, v in combined_metadata_matchers.items()
+      ):
+        continue
+
+      if fn is not None and not fn(resource):
+        continue
+
+      results.append(resource)
+
+    return results
+
+  def find_resource(
+    self,
+    fn: Optional[Callable[["Resource"], bool]] = None,
+    *,
+    metadata: Optional[Dict[str, Any]] = None,
+    has_metadata: Optional[Union[str, Iterable[str]]] = None,
+    recursive: bool = True,
+    **kwargs: Any,
+  ) -> Optional["Resource"]:
+    """Find the first matching resource, or None if not found."""
+    results = self.find_resources(
+      fn=fn,
+      metadata=metadata,
+      has_metadata=has_metadata,
+      recursive=recursive,
+      **kwargs,
+    )
+    return results[0] if results else None
+
   def rotate(self, x: float = 0, y: float = 0, z: float = 0):
     """Rotate counter-clockwise by the given number of degrees."""
 
@@ -773,7 +890,7 @@ class Resource(SerializableMixin):
     subclass = find_subclass(data["type"], cls=Resource)
     if subclass is None:
       raise ValueError(f'Could not find subclass with name "{data["type"]}"')
-    assert issubclass(subclass, cls)  # mypy does not know the type after the None check...
+    assert issubclass(subclass, cls) or subclass.__name__ == cls.__name__  # handle module alias imports
 
     for key in [
       "type",
@@ -785,6 +902,7 @@ class Resource(SerializableMixin):
     rotation = data_copy.pop("rotation", None)
     barcode = data_copy.pop("barcode", None)
     preferred_pickup_location = data_copy.pop("preferred_pickup_location", None)
+    metadata_data = data_copy.pop("metadata", None)
     resource = subclass(**deserialize(data_copy, allow_marshal=allow_marshal))
     if rotation is not None:
       resource.rotation = deserialize(rotation)  # not pretty, should be done in init.
@@ -792,6 +910,8 @@ class Resource(SerializableMixin):
       resource.barcode = Barcode(**barcode)
     if preferred_pickup_location is not None:
       resource.preferred_pickup_location = cast(Coordinate, deserialize(preferred_pickup_location))
+    if metadata_data is not None:
+      resource.metadata = cast(Dict[str, Any], deserialize(metadata_data, allow_marshal=allow_marshal))
 
     for child_data in children_data:
       child_cls = find_subclass(child_data["type"], cls=Resource)
@@ -805,7 +925,7 @@ class Resource(SerializableMixin):
         raise ValueError(f"Child resource '{child.name}' has no location.")
       resource.assign_child_resource(child, location=location)
 
-    return resource
+    return cast(Self, resource)
 
   @classmethod
   def load_from_json_file(cls, json_file: str) -> Self:  # type: ignore

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -985,7 +985,9 @@ class Resource(SerializableMixin):
     if preferred_pickup_location is not None:
       resource.preferred_pickup_location = cast(Coordinate, deserialize(preferred_pickup_location))
     if metadata_data is not None:
-      resource.metadata = metadata_data
+      if not isinstance(metadata_data, dict):
+        raise TypeError(f"Expected metadata to be a dict, got {type(metadata_data).__name__}")
+      resource.metadata = metadata_data.copy()
     for child_data in children_data:
       child_cls = find_subclass(child_data["type"], cls=Resource)
       if child_cls is None:

--- a/pylabrobot/resources/resource_holder.py
+++ b/pylabrobot/resources/resource_holder.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 from pylabrobot.resources.coordinate import Coordinate
 from pylabrobot.resources.resource import Resource
@@ -42,6 +42,7 @@ class ResourceHolder(Resource):
     model=None,
     child_location: Coordinate = Coordinate.zero(),
     preferred_pickup_location: Optional[Coordinate] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     Resource.__init__(
       self,
@@ -53,6 +54,7 @@ class ResourceHolder(Resource):
       category=category,
       model=model,
       preferred_pickup_location=preferred_pickup_location,
+      metadata=metadata,
     )
     self.child_location = child_location
 

--- a/pylabrobot/resources/resource_stack.py
+++ b/pylabrobot/resources/resource_stack.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import Any, List, Mapping, Optional
 
 from pylabrobot.resources.coordinate import Coordinate
 from pylabrobot.resources.plate import Plate
@@ -61,8 +61,11 @@ class ResourceStack(Resource):
     name: str,
     direction: str,
     resources: Optional[List[Resource]] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
-    super().__init__(name, size_x=0, size_y=0, size_z=0, category="resource_group")
+    super().__init__(
+      name, size_x=0, size_y=0, size_z=0, category="resource_group", metadata=metadata
+    )
     assert direction in [
       "x",
       "y",

--- a/pylabrobot/resources/resource_tests.py
+++ b/pylabrobot/resources/resource_tests.py
@@ -708,3 +708,104 @@ class TestAssignChildByAnchor(unittest.TestCase):
     with self.assertRaises(ValueError) as context:
       self.parent.assign_child_by_anchor(child, parent_anchor="ccb", child_anchor="ccbb")
     self.assertIn("must be exactly 3 characters", str(context.exception))
+
+  def test_metadata_init_and_equality(self):
+    r1 = Resource("r1", size_x=10, size_y=10, size_z=10, metadata={"a": 1, "is_clean": True})
+    r2 = Resource("r1", size_x=10, size_y=10, size_z=10, metadata={"a": 1, "is_clean": True})
+    r3 = Resource("r1", size_x=10, size_y=10, size_z=10, metadata={"a": 2, "is_clean": True})
+
+    self.assertEqual(r1.metadata, {"a": 1, "is_clean": True})
+    self.assertEqual(r1, r2)
+    self.assertNotEqual(r1, r3)
+
+  def test_metadata_serialization_deserialization(self):
+    meta = {"string": "hello", "int": 42, "bool": False, "list": [1, 2, 3], "nested": {"k": "v"}}
+    r = Resource("res", size_x=10, size_y=10, size_z=10, metadata=meta)
+    serialized = r.serialize()
+    self.assertEqual(serialized["metadata"], meta)
+
+    deserialized = Resource.deserialize(serialized)
+    self.assertEqual(deserialized.metadata, meta)
+    self.assertEqual(deserialized, r)
+
+  def test_find_resources_metadata(self):
+    import re
+    deck = Resource("deck", size_x=100, size_y=100, size_z=10)
+    plate = Resource(
+      "plate1",
+      size_x=10,
+      size_y=10,
+      size_z=10,
+      category="plate",
+      model="m1",
+      metadata={"liquid": "water", "concentration_mM": 100, "is_clean": True, "pH": 7.0},
+    )
+    well = Resource("well1", size_x=1, size_y=1, size_z=1)
+    trough = Resource(
+      "trough1",
+      size_x=10,
+      size_y=10,
+      size_z=10,
+      category="trough",
+      model="m2",
+      metadata={"liquid": "buffer", "concentration_mM": 50, "is_clean": False},
+    )
+    waste = Resource(
+      "waste1",
+      size_x=10,
+      size_y=10,
+      size_z=10,
+      category="waste",
+      metadata={"liquid": "water", "concentration_mM": 0},
+    )
+
+    deck.assign_child_resource(plate, location=Coordinate(0, 0, 0))
+    plate.assign_child_resource(well, location=Coordinate(0, 0, 0))
+    deck.assign_child_resource(trough, location=Coordinate(20, 0, 0))
+    deck.assign_child_resource(waste, location=Coordinate(40, 0, 0))
+
+    # Strict value equality
+    self.assertEqual(deck.find_resources(liquid="water"), [plate, waste])
+    self.assertEqual(deck.find_resources(is_clean=True), [plate])
+    self.assertEqual(deck.find_resources(is_clean=False), [trough])
+
+    # Key presence check via has_metadata
+    self.assertEqual(deck.find_resources(has_metadata="pH"), [plate])
+    self.assertEqual(
+      set(deck.find_resources(has_metadata=["liquid", "concentration_mM"])), {plate, trough, waste}
+    )
+
+    # Callable exception on metadata.get(key)
+    self.assertEqual(
+      deck.find_resources(concentration_mM=lambda v: v is not None and v > 20), [plate, trough]
+    )
+    self.assertEqual(deck.find_resources(pH=lambda v: v is not None and v == 7.0), [plate])
+    self.assertEqual(
+      set(deck.find_resources(pH=lambda v: v is None)), {deck, well, trough, waste}
+    )
+
+    # Top-level attribute reserved kwargs (name, type, model, category)
+    self.assertEqual(deck.find_resources(name="plate1"), [plate])
+    self.assertEqual(deck.find_resources(name=re.compile(r"^(plate|trough)")), [plate, trough])
+    self.assertEqual(deck.find_resources(category="plate"), [plate])
+    self.assertEqual(deck.find_resources(model="m2"), [trough])
+    self.assertEqual(
+      set(deck.find_resources(type=Resource)), {deck, plate, well, trough, waste}
+    )
+
+    # Custom predicate fn
+    self.assertEqual(
+      deck.find_resources(
+        fn=lambda r: r.get_size_x() == 10 and r.metadata.get("concentration_mM") == 100
+      ),
+      [plate],
+    )
+
+    # find_resource singular
+    self.assertEqual(deck.find_resource(name="trough1"), trough)
+    self.assertIsNone(deck.find_resource(name="nonexistent"))
+
+    # Non-recursive search
+    self.assertEqual(deck.find_resources(name="plate1", recursive=False), [plate])
+    self.assertEqual(deck.find_resources(name="well1", recursive=False), [])
+    self.assertEqual(deck.find_resources(name="well1", recursive=True), [well])

--- a/pylabrobot/resources/resource_tests.py
+++ b/pylabrobot/resources/resource_tests.py
@@ -1,7 +1,9 @@
 import math
+import re
 import unittest
 import unittest.mock
 
+from . import resource as resource_module
 from .barcode import Barcode
 from .coordinate import Coordinate
 from .deck import Deck
@@ -709,27 +711,16 @@ class TestAssignChildByAnchor(unittest.TestCase):
       self.parent.assign_child_by_anchor(child, parent_anchor="ccb", child_anchor="ccbb")
     self.assertIn("must be exactly 3 characters", str(context.exception))
 
-  def test_metadata_init_and_equality(self):
-    r1 = Resource("r1", size_x=10, size_y=10, size_z=10, metadata={"a": 1, "is_clean": True})
-    r2 = Resource("r1", size_x=10, size_y=10, size_z=10, metadata={"a": 1, "is_clean": True})
-    r3 = Resource("r1", size_x=10, size_y=10, size_z=10, metadata={"a": 2, "is_clean": True})
 
-    self.assertEqual(r1.metadata, {"a": 1, "is_clean": True})
-    self.assertEqual(r1, r2)
-    self.assertNotEqual(r1, r3)
+class TestResourceMetadata(unittest.TestCase):
+  """Tests for Resource.metadata and the find_resources/find_resource query API."""
 
-  def test_metadata_serialization_deserialization(self):
-    meta = {"string": "hello", "int": 42, "bool": False, "list": [1, 2, 3], "nested": {"k": "v"}}
-    r = Resource("res", size_x=10, size_y=10, size_z=10, metadata=meta)
-    serialized = r.serialize()
-    self.assertEqual(serialized["metadata"], meta)
+  def _sample_tree(self):
+    """Build a small deck tree shared by several find_resources tests.
 
-    deserialized = Resource.deserialize(serialized)
-    self.assertEqual(deserialized.metadata, meta)
-    self.assertEqual(deserialized, r)
-
-  def test_find_resources_metadata(self):
-    import re
+    Returns (deck, plate, well, trough, waste). ``plate`` contains ``well``;
+    ``trough`` and ``waste`` are direct children of ``deck``.
+    """
     deck = Resource("deck", size_x=100, size_y=100, size_z=10)
     plate = Resource(
       "plate1",
@@ -758,11 +749,92 @@ class TestAssignChildByAnchor(unittest.TestCase):
       category="waste",
       metadata={"liquid": "water", "concentration_mM": 0},
     )
-
     deck.assign_child_resource(plate, location=Coordinate(0, 0, 0))
     plate.assign_child_resource(well, location=Coordinate(0, 0, 0))
     deck.assign_child_resource(trough, location=Coordinate(20, 0, 0))
     deck.assign_child_resource(waste, location=Coordinate(40, 0, 0))
+    return deck, plate, well, trough, waste
+
+  def test_metadata_init_and_equality(self):
+    r1 = Resource("r1", size_x=10, size_y=10, size_z=10, metadata={"a": 1, "is_clean": True})
+    r2 = Resource("r1", size_x=10, size_y=10, size_z=10, metadata={"a": 1, "is_clean": True})
+    r3 = Resource("r1", size_x=10, size_y=10, size_z=10, metadata={"a": 2, "is_clean": True})
+
+    self.assertEqual(r1.metadata, {"a": 1, "is_clean": True})
+    self.assertEqual(r1, r2)
+    self.assertNotEqual(r1, r3)
+
+  def test_metadata_default_is_empty_and_per_instance(self):
+    r1 = Resource("r1", size_x=1, size_y=1, size_z=1)
+    r2 = Resource("r2", size_x=1, size_y=1, size_z=1)
+    self.assertEqual(r1.metadata, {})
+    r1.metadata["k"] = "v"
+    self.assertEqual(r2.metadata, {})
+
+  def test_metadata_shallow_copy_semantics(self):
+    # metadata.copy() decouples top-level keys from the caller's dict, but nested
+    # containers are shared. This pins the documented shallow-copy behavior.
+    original = {"top": "v", "nested": [1, 2]}
+    r = Resource("r", size_x=1, size_y=1, size_z=1, metadata=original)
+
+    original["top"] = "changed"
+    self.assertEqual(r.metadata["top"], "v")  # top-level key isolated
+
+    original["nested"].append(3)
+    self.assertEqual(r.metadata["nested"], [1, 2, 3])  # nested value shared
+
+  def test_metadata_serialization_deserialization(self):
+    meta = {"string": "hello", "int": 42, "bool": False, "list": [1, 2, 3], "nested": {"k": "v"}}
+    r = Resource("res", size_x=10, size_y=10, size_z=10, metadata=meta)
+    serialized = r.serialize()
+    self.assertEqual(serialized["metadata"], meta)
+
+    deserialized = Resource.deserialize(serialized)
+    self.assertEqual(deserialized.metadata, meta)
+    self.assertEqual(deserialized, r)
+
+  def test_deserialize_without_metadata_key_is_backward_compatible(self):
+    # Resources serialized before metadata existed have no "metadata" key.
+    data = Resource("r", size_x=1, size_y=1, size_z=1).serialize()
+    del data["metadata"]
+    restored = Resource.deserialize(data)
+    self.assertEqual(restored.metadata, {})
+
+  def test_deserialize_same_named_class_via_module_alias(self):
+    # Simulate a class imported under two module paths: find_subclass returns a
+    # same-named class that is NOT a subclass of the cls deserialize was called
+    # on. issubclass() is False, but the name-equality fallback accepts it.
+    # (Unusual class names avoid polluting the global Resource subclass registry
+    # under a common name.)
+    class _AliasProbe(Resource):
+      pass
+
+    class _AliasProbeSibling(Resource):  # sibling, not a subclass of _AliasProbe
+      pass
+
+    _AliasProbeSibling.__name__ = "_AliasProbe"
+
+    data = _AliasProbe("f", size_x=1, size_y=1, size_z=1).serialize()
+    with unittest.mock.patch.object(
+      resource_module, "find_subclass", return_value=_AliasProbeSibling
+    ):
+      restored = _AliasProbe.deserialize(data)
+    self.assertIsInstance(restored, _AliasProbeSibling)
+
+  def test_deserialize_rejects_class_with_different_name(self):
+    class _RejectProbe(Resource):
+      pass
+
+    class _UnrelatedProbe:  # different name -> neither issubclass nor name match
+      pass
+
+    data = _RejectProbe("f", size_x=1, size_y=1, size_z=1).serialize()
+    with unittest.mock.patch.object(resource_module, "find_subclass", return_value=_UnrelatedProbe):
+      with self.assertRaises(AssertionError):
+        _RejectProbe.deserialize(data)
+
+  def test_find_resources_metadata(self):
+    deck, plate, well, trough, waste = self._sample_tree()
 
     # Strict value equality
     self.assertEqual(deck.find_resources(liquid="water"), [plate, waste])
@@ -775,23 +847,19 @@ class TestAssignChildByAnchor(unittest.TestCase):
       set(deck.find_resources(has_metadata=["liquid", "concentration_mM"])), {plate, trough, waste}
     )
 
-    # Callable exception on metadata.get(key)
+    # Callable predicate on metadata.get(key)
     self.assertEqual(
       deck.find_resources(concentration_mM=lambda v: v is not None and v > 20), [plate, trough]
     )
     self.assertEqual(deck.find_resources(pH=lambda v: v is not None and v == 7.0), [plate])
-    self.assertEqual(
-      set(deck.find_resources(pH=lambda v: v is None)), {deck, well, trough, waste}
-    )
+    self.assertEqual(set(deck.find_resources(pH=lambda v: v is None)), {deck, well, trough, waste})
 
     # Top-level attribute reserved kwargs (name, type, model, category)
     self.assertEqual(deck.find_resources(name="plate1"), [plate])
     self.assertEqual(deck.find_resources(name=re.compile(r"^(plate|trough)")), [plate, trough])
     self.assertEqual(deck.find_resources(category="plate"), [plate])
     self.assertEqual(deck.find_resources(model="m2"), [trough])
-    self.assertEqual(
-      set(deck.find_resources(type=Resource)), {deck, plate, well, trough, waste}
-    )
+    self.assertEqual(set(deck.find_resources(type=Resource)), {deck, plate, well, trough, waste})
 
     # Custom predicate fn
     self.assertEqual(
@@ -809,3 +877,104 @@ class TestAssignChildByAnchor(unittest.TestCase):
     self.assertEqual(deck.find_resources(name="plate1", recursive=False), [plate])
     self.assertEqual(deck.find_resources(name="well1", recursive=False), [])
     self.assertEqual(deck.find_resources(name="well1", recursive=True), [well])
+
+  def test_find_resources_via_metadata_dict_param(self):
+    deck, plate, _well, trough, waste = self._sample_tree()
+    # The explicit metadata= dict behaves like the kwargs shorthand.
+    self.assertEqual(deck.find_resources(metadata={"liquid": "water"}), [plate, waste])
+    self.assertEqual(
+      deck.find_resources(metadata={"concentration_mM": lambda v: v is not None and v > 20}),
+      [plate, trough],
+    )
+    # metadata= dict and kwargs shorthand are AND-combined.
+    self.assertEqual(deck.find_resources(metadata={"liquid": "water"}, is_clean=True), [plate])
+
+  def test_find_resources_reserved_key_shadowing_and_escape_hatch(self):
+    # A metadata key named like a reserved attribute is shadowed when passed as a
+    # kwarg, but reachable via the explicit metadata= dict.
+    deck = Resource("deck", size_x=10, size_y=10, size_z=10)
+    child = Resource("child", size_x=1, size_y=1, size_z=1, metadata={"model": "special"})
+    deck.assign_child_resource(child, location=Coordinate(0, 0, 0))
+
+    # kwarg model= matches the top-level attribute (None here), not metadata.
+    self.assertEqual(deck.find_resources(model="special"), [])
+    # explicit metadata= reaches the metadata key.
+    self.assertEqual(deck.find_resources(metadata={"model": "special"}), [child])
+
+  def test_find_resources_type_matcher_variants(self):
+    # Unusual class names avoid polluting the global Resource subclass registry.
+    class _TypeAlpha(Resource):
+      pass
+
+    class _TypeBeta(Resource):
+      pass
+
+    deck = Resource("deck", size_x=10, size_y=10, size_z=10)
+    alpha = _TypeAlpha("alpha", size_x=1, size_y=1, size_z=1)
+    beta = _TypeBeta("beta", size_x=1, size_y=1, size_z=1)
+    deck.assign_child_resource(alpha, location=Coordinate(0, 0, 0))
+    deck.assign_child_resource(beta, location=Coordinate(5, 0, 0))
+
+    self.assertEqual(deck.find_resources(type=_TypeAlpha), [alpha])  # class
+    self.assertEqual(
+      deck.find_resources(type=(_TypeAlpha, _TypeBeta)), [alpha, beta]
+    )  # tuple of classes
+    self.assertEqual(deck.find_resources(type="_TypeBeta"), [beta])  # class name string
+    self.assertEqual(
+      deck.find_resources(type=re.compile(r"^_TypeA")), [alpha]
+    )  # regex on class name
+    self.assertEqual(
+      deck.find_resources(type=lambda r: isinstance(r, _TypeBeta)), [beta]
+    )  # callable receives the resource
+
+  def test_find_resources_attribute_callable_receives_attribute_value(self):
+    deck, plate, well, trough, waste = self._sample_tree()
+    # A callable for a (non-type) top-level attribute receives the attribute value.
+    self.assertEqual(deck.find_resources(model=lambda m: m == "m2"), [trough])
+    self.assertEqual(
+      set(deck.find_resources(name=lambda n: n.endswith("1"))), {plate, well, trough, waste}
+    )
+
+  def test_find_resources_all_filters_combined(self):
+    deck, plate, _well, _trough, _waste = self._sample_tree()
+    result = deck.find_resources(
+      fn=lambda r: r.get_size_x() == 10,
+      has_metadata="is_clean",
+      liquid="water",
+      category="plate",
+    )
+    self.assertEqual(result, [plate])
+
+  def test_callable_metadata_value_is_treated_as_predicate(self):
+    # A callable stored AS a metadata value cannot be matched by equality:
+    # passing it as the matcher invokes it as a predicate. Use an identity
+    # predicate to match such values.
+    def handler(x):
+      return x  # truthy for the stored object, falsy (None) when key absent
+
+    deck = Resource("deck", size_x=10, size_y=10, size_z=10)
+    child = Resource("child", size_x=1, size_y=1, size_z=1, metadata={"cb": handler})
+    deck.assign_child_resource(child, location=Coordinate(0, 0, 0))
+
+    # cb=handler runs handler(metadata.get("cb")); for child that is
+    # handler(handler) -> truthy, so it "matches" -- the documented footgun.
+    self.assertEqual(deck.find_resources(cb=handler), [child])
+    # Identity match via an explicit predicate is the correct approach.
+    self.assertEqual(deck.find_resources(cb=lambda v: v is handler), [child])
+
+  def test_find_resource_returns_first_match_or_self(self):
+    deck, plate, _well, _trough, waste = self._sample_tree()
+    # Two resources match; the first encountered (self is checked first) is returned.
+    self.assertEqual(deck.find_resources(liquid="water"), [plate, waste])
+    self.assertEqual(deck.find_resource(liquid="water"), plate)
+    # The search includes self, so an unfiltered/self-matching query can return it.
+    self.assertIs(deck.find_resource(type=Resource), deck)
+    self.assertIsNone(deck.find_resource(name="does-not-exist"))
+
+  def test_find_resources_no_criteria_returns_self_and_descendants(self):
+    deck, plate, well, trough, waste = self._sample_tree()
+    # No criteria: self is first, followed by get_all_children() order (direct
+    # children before deeper descendants), so `well` (under `plate`) comes last.
+    self.assertEqual(deck.find_resources(), [deck, plate, trough, waste, well])
+    # Non-recursive: self plus direct children only.
+    self.assertEqual(deck.find_resources(recursive=False), [deck, plate, trough, waste])

--- a/pylabrobot/resources/resource_tests.py
+++ b/pylabrobot/resources/resource_tests.py
@@ -3,15 +3,27 @@ import math
 import re
 import unittest
 import unittest.mock
+from collections import OrderedDict
 from typing import Any, Dict
 
-from . import resource as resource_module
-from .barcode import Barcode
-from .coordinate import Coordinate
-from .deck import Deck
-from .errors import ResourceNotFoundError
-from .resource import Resource
-from .rotation import Rotation
+from pylabrobot.legacy.centrifuge.centrifuge import Centrifuge, Loader
+from pylabrobot.legacy.centrifuge.chatterbox import (
+  CentrifugeChatterboxBackend,
+  LoaderChatterboxBackend,
+)
+from pylabrobot.legacy.liquid_handling.backends import LiquidHandlerChatterboxBackend
+from pylabrobot.legacy.liquid_handling.liquid_handler import LiquidHandler
+from pylabrobot.legacy.storage.chatterbox import IncubatorChatterboxBackend
+from pylabrobot.legacy.storage.incubator import Incubator
+from pylabrobot.resources import resource as resource_module
+from pylabrobot.resources.barcode import Barcode
+from pylabrobot.resources.coordinate import Coordinate
+from pylabrobot.resources.deck import Deck
+from pylabrobot.resources.errors import ResourceNotFoundError
+from pylabrobot.resources.plate_adapter import PlateAdapter
+from pylabrobot.resources.resource import Resource
+from pylabrobot.resources.rotation import Rotation
+from pylabrobot.resources.tip import Tip
 
 
 def _make_test_deck() -> Deck:
@@ -757,6 +769,119 @@ class TestResourceMetadata(unittest.TestCase):
     deck.assign_child_resource(waste, location=Coordinate(40, 0, 0))
     return deck, plate, well, trough, waste
 
+  def _resource_factoryies_with_meta(self, meta):
+    from pylabrobot.resources.carrier import (
+      Carrier,
+      MFXCarrier,
+      PlateCarrier,
+      PlateHolder,
+      TipCarrier,
+      TroughCarrier,
+      TubeCarrier,
+    )
+    from pylabrobot.resources.container import Container
+    from pylabrobot.resources.itemized_resource import ItemizedResource
+    from pylabrobot.resources.lid import Lid
+    from pylabrobot.resources.plate import Plate
+    from pylabrobot.resources.resource_holder import ResourceHolder
+    from pylabrobot.resources.resource_stack import ResourceStack
+    from pylabrobot.resources.tecan.tecan_resource import TecanResource
+    from pylabrobot.resources.tip_rack import TipRack, TipSpot
+
+    return {
+      "Carrier": lambda: Carrier("c", size_x=10, size_y=10, size_z=10, metadata=meta),
+      "TipCarrier": lambda: TipCarrier("c", size_x=10, size_y=10, size_z=10, metadata=meta),
+      "PlateCarrier": lambda: PlateCarrier("c", size_x=10, size_y=10, size_z=10, metadata=meta),
+      "MFXCarrier": lambda: MFXCarrier("c", size_x=10, size_y=10, size_z=10, metadata=meta),
+      "TubeCarrier": lambda: TubeCarrier("c", size_x=10, size_y=10, size_z=10, metadata=meta),
+      "TroughCarrier": lambda: TroughCarrier("c", size_x=10, size_y=10, size_z=10, metadata=meta),
+      "PlateHolder": lambda: PlateHolder(
+        "ph", size_x=10, size_y=10, size_z=10, pedestal_size_z=5, metadata=meta
+      ),
+      "Container": lambda: Container("cont", size_x=10, size_y=10, size_z=10, metadata=meta),
+      "Deck": lambda: Deck(name="d", size_x=10, size_y=10, size_z=10, metadata=meta),
+      "ItemizedResource": lambda: ItemizedResource(
+        "ir", size_x=10, size_y=10, size_z=10, ordering=OrderedDict(), metadata=meta
+      ),
+      "Lid": lambda: Lid("lid", size_x=10, size_y=10, size_z=10, nesting_z_height=0, metadata=meta),
+      "Plate": lambda: Plate(
+        "p", size_x=10, size_y=10, size_z=10, ordering=OrderedDict(), metadata=meta
+      ),
+      "PlateAdapter": lambda: PlateAdapter(
+        "pa",
+        size_x=10,
+        size_y=10,
+        size_z=10,
+        dx=1,
+        dy=1,
+        dz=1,
+        adapter_hole_size_x=1,
+        adapter_hole_size_y=1,
+        metadata=meta,
+      ),
+      "ResourceHolder": lambda: ResourceHolder(
+        "rh", size_x=10, size_y=10, size_z=10, metadata=meta
+      ),
+      "ResourceStack": lambda: ResourceStack("rs", direction="z", metadata=meta),
+      "TecanResource": lambda: TecanResource("tr", size_x=10, size_y=10, size_z=10, metadata=meta),
+      "TipSpot": lambda: TipSpot(
+        "ts",
+        size_x=10,
+        size_y=10,
+        make_tip=lambda name: Tip(
+          name=name, has_filter=False, maximal_volume=10, fitting_depth=1, total_tip_length=10
+        ),
+        metadata=meta,
+      ),
+      "TipRack": lambda: TipRack(
+        "tr", size_x=10, size_y=10, size_z=10, ordering=OrderedDict(), metadata=meta
+      ),
+      "Centrifuge": lambda: Centrifuge(
+        backend=CentrifugeChatterboxBackend(),
+        name="cent",
+        size_x=10,
+        size_y=10,
+        size_z=10,
+        metadata=meta,
+      ),
+      "Loader": lambda: Loader(
+        backend=LoaderChatterboxBackend(),
+        centrifuge=Centrifuge(
+          backend=CentrifugeChatterboxBackend(), name="cent", size_x=10, size_y=10, size_z=10
+        ),
+        name="loader",
+        size_x=10,
+        size_y=10,
+        size_z=10,
+        child_location=Coordinate(0, 0, 0),
+        metadata=meta,
+      ),
+      "Incubator": lambda: Incubator(
+        backend=IncubatorChatterboxBackend(),
+        name="inc",
+        size_x=10,
+        size_y=10,
+        size_z=10,
+        racks=[
+          PlateCarrier(
+            "pc0",
+            size_x=10,
+            size_y=10,
+            size_z=10,
+            metadata=dict(is_child_of_parent_with=meta),
+          ),
+        ],
+        loading_tray_location=Coordinate(0, 0, 0),
+        metadata=meta,
+      ),
+      "LiquidHandler": lambda: LiquidHandler(
+        backend=LiquidHandlerChatterboxBackend(),
+        deck=Deck(size_x=10, size_y=10, size_z=10),
+        name="lh",
+        metadata=meta,
+      ),
+    }
+
   def test_metadata_init_and_equality(self):
     r1 = Resource("r1", size_x=10, size_y=10, size_z=10, metadata={"a": 1, "is_clean": True})
     r2 = Resource("r1", size_x=10, size_y=10, size_z=10, metadata={"a": 1, "is_clean": True})
@@ -784,6 +909,13 @@ class TestResourceMetadata(unittest.TestCase):
 
     original["nested"].append(3)
     self.assertEqual(r.metadata["nested"], [1, 2, 3])  # nested value shared
+
+  def test_metadata_kwarg_reaches_resource_for_every_subclass(self):
+    meta = {"k": "v"}
+    factories = self._resource_factoryies_with_meta(meta)
+    for name, make in factories.items():
+      with self.subTest(name):
+        self.assertEqual(make().metadata, meta)
 
   def test_metadata_serialization_deserialization(self):
     meta = {"string": "hello", "int": 42, "bool": False, "list": [1, 2, 3], "nested": {"k": "v"}}
@@ -857,7 +989,7 @@ class TestResourceMetadata(unittest.TestCase):
 
   def test_deserialize_without_metadata_key_is_backward_compatible(self):
     # Resources serialized before metadata existed have no "metadata" key.
-    data = Resource("r", size_x=1, size_y=1, size_z=1).serialize()
+    data = Resource("r", size_x=1, size_y=1, size_z=1, metadata={"key": "value"}).serialize()
     del data["metadata"]
     restored = Resource.deserialize(data)
     self.assertEqual(restored.metadata, {})
@@ -867,6 +999,30 @@ class TestResourceMetadata(unittest.TestCase):
     data["metadata"] = ["not", "a", "dict"]
     with self.assertRaises(TypeError):
       Resource.deserialize(data)
+
+  def test_subclass_deserialize_and_copy_preserves_metadata(self):
+    meta = {"key": "val", "num": 42}
+
+    factories = self._resource_factoryies_with_meta(meta)
+    for name, make in factories.items():
+      with self.subTest(name):
+        r = make()
+        self.assertEqual(r.metadata, meta)
+        if name == "Loader":
+          # Loader doesn't expose metadata at the top-level
+          self.assertEqual(r.serialize()["resource"]["metadata"], meta)
+        else:
+          self.assertEqual(r.serialize()["metadata"], meta)
+        if name == "ResourceStack":
+          with self.assertRaises(
+            TypeError
+          ):  # unrelated to metadata: ResourceStack.copy() is broken
+            r.copy()
+        else:
+          r_copy = r.copy()
+          self.assertEqual(r_copy.metadata, meta)
+          self.assertEqual(r_copy.name, r.name)
+          self.assertEqual(r_copy, r)
 
   def test_deserialize_same_named_class_via_module_alias(self):
     # Simulate a class imported under two module paths: find_subclass returns a

--- a/pylabrobot/resources/resource_tests.py
+++ b/pylabrobot/resources/resource_tests.py
@@ -1,8 +1,9 @@
+import json
 import math
 import re
 import unittest
 import unittest.mock
-from typing import Any
+from typing import Any, Dict
 
 from . import resource as resource_module
 from .barcode import Barcode
@@ -845,6 +846,15 @@ class TestResourceMetadata(unittest.TestCase):
     self.assertEqual(deserialized.metadata, meta)
     self.assertEqual(deserialized, r)
 
+  def test_metadata_json_roundtrip(self):
+    meta = {"type": "reagent", "nested": {"type": "custom_type"}, "count": 42}
+    r = Resource("res", size_x=10, size_y=10, size_z=10, metadata=meta)
+    serialized_json = json.dumps(r.serialize())
+    deserialized = Resource.deserialize(json.loads(serialized_json))
+    self.assertEqual(deserialized.metadata, meta)
+    self.assertEqual(deserialized, r)
+    self.assertIsNot(deserialized.metadata, meta)
+
   def test_deserialize_without_metadata_key_is_backward_compatible(self):
     # Resources serialized before metadata existed have no "metadata" key.
     data = Resource("r", size_x=1, size_y=1, size_z=1).serialize()
@@ -852,10 +862,16 @@ class TestResourceMetadata(unittest.TestCase):
     restored = Resource.deserialize(data)
     self.assertEqual(restored.metadata, {})
 
+  def test_deserialize_non_dict_metadata_raises(self):
+    data = Resource("r", size_x=1, size_y=1, size_z=1).serialize()
+    data["metadata"] = ["not", "a", "dict"]
+    with self.assertRaises(TypeError):
+      Resource.deserialize(data)
+
   def test_deserialize_same_named_class_via_module_alias(self):
     # Simulate a class imported under two module paths: find_subclass returns a
     # same-named class that is NOT a subclass of the cls deserialize was called
-    # on. issubclass() is False, but the name-equality fallback accepts it.
+    # on. issubclass() is False, so deserialization is rejected.
     # (Unusual class names avoid polluting the global Resource subclass registry
     # under a common name.)
     class _AliasProbe(Resource):
@@ -953,9 +969,7 @@ class TestResourceMetadata(unittest.TestCase):
     self.assertEqual(
       deck.find_resources(type=(_TypeAlpha, _TypeBeta)), [alpha, beta]
     )  # tuple of classes
-    self.assertEqual(
-      deck.find_resources(type=_TypeBeta.__name__), [beta]
-    )  # class name string
+    self.assertEqual(deck.find_resources(type=_TypeBeta.__name__), [beta])  # class name string
     self.assertEqual(
       deck.find_resources(type=re.compile(r"_TypeA")), [alpha]
     )  # regex on class name

--- a/pylabrobot/resources/resource_tests.py
+++ b/pylabrobot/resources/resource_tests.py
@@ -2,6 +2,7 @@ import math
 import re
 import unittest
 import unittest.mock
+from typing import Any
 
 from . import resource as resource_module
 from .barcode import Barcode
@@ -774,7 +775,7 @@ class TestResourceMetadata(unittest.TestCase):
   def test_metadata_shallow_copy_semantics(self):
     # metadata.copy() decouples top-level keys from the caller's dict, but nested
     # containers are shared. This pins the documented shallow-copy behavior.
-    original = {"top": "v", "nested": [1, 2]}
+    original: dict[str, Any] = {"top": "v", "nested": [1, 2]}
     r = Resource("r", size_x=1, size_y=1, size_z=1, metadata=original)
 
     original["top"] = "changed"
@@ -785,6 +786,57 @@ class TestResourceMetadata(unittest.TestCase):
 
   def test_metadata_serialization_deserialization(self):
     meta = {"string": "hello", "int": 42, "bool": False, "list": [1, 2, 3], "nested": {"k": "v"}}
+    r = Resource("res", size_x=10, size_y=10, size_z=10, metadata=meta)
+    serialized = r.serialize()
+    self.assertEqual(serialized["metadata"], meta)
+
+    deserialized = Resource.deserialize(serialized)
+    self.assertEqual(deserialized.metadata, meta)
+    self.assertEqual(deserialized, r)
+
+  def test_metadata_serialize_copy_isolation(self):
+    meta = {"key": "val", "nested": [1, 2]}
+    r = Resource("res", size_x=10, size_y=10, size_z=10, metadata=meta)
+    serialized = r.serialize()
+    serialized["metadata"]["key"] = "modified"
+    self.assertEqual(r.metadata["key"], "val")
+
+  def test_metadata_copy_isolation(self):
+    meta = {"key": "val"}
+    r = Resource("res", size_x=10, size_y=10, size_z=10, metadata=meta)
+    r_copy = r.copy()
+    r_copy.metadata["key"] = "modified"
+    self.assertEqual(r.metadata["key"], "val")
+
+  def test_metadata_black_box_roundtrip_tighter(self):
+    class CustomObj:
+      def __init__(self, value: int):
+        self.value = value
+
+      def __eq__(self, other: Any) -> bool:
+        return isinstance(other, CustomObj) and self.value == other.value
+
+    custom_obj = CustomObj(42)
+    meta: Dict[str, Any] = {
+      "custom_obj": custom_obj,
+      "tuple": (1, 2, 3),
+      "none": None,
+      "nested_dict": {"inner_custom": CustomObj(99)},
+    }
+    r = Resource("res", size_x=10, size_y=10, size_z=10, metadata=meta)
+    serialized = r.serialize()
+    self.assertEqual(serialized["metadata"], meta)
+
+    deserialized = Resource.deserialize(serialized)
+    self.assertEqual(deserialized.metadata, meta)
+    self.assertEqual(deserialized, r)
+
+    r_copy = r.copy()
+    self.assertEqual(r_copy.metadata, meta)
+    self.assertEqual(r_copy, r)
+
+  def test_metadata_type_key_serialization_deserialization(self):
+    meta = {"type": "reagent", "nested": {"type": "custom_type"}}
     r = Resource("res", size_x=10, size_y=10, size_z=10, metadata=meta)
     serialized = r.serialize()
     self.assertEqual(serialized["metadata"], meta)
@@ -818,8 +870,8 @@ class TestResourceMetadata(unittest.TestCase):
     with unittest.mock.patch.object(
       resource_module, "find_subclass", return_value=_AliasProbeSibling
     ):
-      restored = _AliasProbe.deserialize(data)
-    self.assertIsInstance(restored, _AliasProbeSibling)
+      with self.assertRaises(AssertionError):
+        _AliasProbe.deserialize(data)
 
   def test_deserialize_rejects_class_with_different_name(self):
     class _RejectProbe(Resource):
@@ -836,10 +888,10 @@ class TestResourceMetadata(unittest.TestCase):
   def test_find_resources_metadata(self):
     deck, plate, well, trough, waste = self._sample_tree()
 
-    # Strict value equality
-    self.assertEqual(deck.find_resources(liquid="water"), [plate, waste])
-    self.assertEqual(deck.find_resources(is_clean=True), [plate])
-    self.assertEqual(deck.find_resources(is_clean=False), [trough])
+    # Strict value equality via metadata=
+    self.assertEqual(deck.find_resources(metadata={"liquid": "water"}), [plate, waste])
+    self.assertEqual(deck.find_resources(metadata={"is_clean": True}), [plate])
+    self.assertEqual(deck.find_resources(metadata={"is_clean": False}), [trough])
 
     # Key presence check via has_metadata
     self.assertEqual(deck.find_resources(has_metadata="pH"), [plate])
@@ -849,12 +901,17 @@ class TestResourceMetadata(unittest.TestCase):
 
     # Callable predicate on metadata.get(key)
     self.assertEqual(
-      deck.find_resources(concentration_mM=lambda v: v is not None and v > 20), [plate, trough]
+      deck.find_resources(metadata={"concentration_mM": lambda v: v is not None and v > 20}),
+      [plate, trough],
     )
-    self.assertEqual(deck.find_resources(pH=lambda v: v is not None and v == 7.0), [plate])
-    self.assertEqual(set(deck.find_resources(pH=lambda v: v is None)), {deck, well, trough, waste})
+    self.assertEqual(
+      deck.find_resources(metadata={"pH": lambda v: v is not None and v == 7.0}), [plate]
+    )
+    self.assertEqual(
+      set(deck.find_resources(metadata={"pH": lambda v: v is None})), {deck, well, trough, waste}
+    )
 
-    # Top-level attribute reserved kwargs (name, type, model, category)
+    # Top-level attribute matchers (name, type, model, category)
     self.assertEqual(deck.find_resources(name="plate1"), [plate])
     self.assertEqual(deck.find_resources(name=re.compile(r"^(plate|trough)")), [plate, trough])
     self.assertEqual(deck.find_resources(category="plate"), [plate])
@@ -878,29 +935,6 @@ class TestResourceMetadata(unittest.TestCase):
     self.assertEqual(deck.find_resources(name="well1", recursive=False), [])
     self.assertEqual(deck.find_resources(name="well1", recursive=True), [well])
 
-  def test_find_resources_via_metadata_dict_param(self):
-    deck, plate, _well, trough, waste = self._sample_tree()
-    # The explicit metadata= dict behaves like the kwargs shorthand.
-    self.assertEqual(deck.find_resources(metadata={"liquid": "water"}), [plate, waste])
-    self.assertEqual(
-      deck.find_resources(metadata={"concentration_mM": lambda v: v is not None and v > 20}),
-      [plate, trough],
-    )
-    # metadata= dict and kwargs shorthand are AND-combined.
-    self.assertEqual(deck.find_resources(metadata={"liquid": "water"}, is_clean=True), [plate])
-
-  def test_find_resources_reserved_key_shadowing_and_escape_hatch(self):
-    # A metadata key named like a reserved attribute is shadowed when passed as a
-    # kwarg, but reachable via the explicit metadata= dict.
-    deck = Resource("deck", size_x=10, size_y=10, size_z=10)
-    child = Resource("child", size_x=1, size_y=1, size_z=1, metadata={"model": "special"})
-    deck.assign_child_resource(child, location=Coordinate(0, 0, 0))
-
-    # kwarg model= matches the top-level attribute (None here), not metadata.
-    self.assertEqual(deck.find_resources(model="special"), [])
-    # explicit metadata= reaches the metadata key.
-    self.assertEqual(deck.find_resources(metadata={"model": "special"}), [child])
-
   def test_find_resources_type_matcher_variants(self):
     # Unusual class names avoid polluting the global Resource subclass registry.
     class _TypeAlpha(Resource):
@@ -919,13 +953,15 @@ class TestResourceMetadata(unittest.TestCase):
     self.assertEqual(
       deck.find_resources(type=(_TypeAlpha, _TypeBeta)), [alpha, beta]
     )  # tuple of classes
-    self.assertEqual(deck.find_resources(type="_TypeBeta"), [beta])  # class name string
     self.assertEqual(
-      deck.find_resources(type=re.compile(r"^_TypeA")), [alpha]
+      deck.find_resources(type=_TypeBeta.__name__), [beta]
+    )  # class name string
+    self.assertEqual(
+      deck.find_resources(type=re.compile(r"_TypeA")), [alpha]
     )  # regex on class name
     self.assertEqual(
-      deck.find_resources(type=lambda r: isinstance(r, _TypeBeta)), [beta]
-    )  # callable receives the resource
+      deck.find_resources(type=lambda k: issubclass(k, _TypeBeta)), [beta]
+    )  # callable receives the resource class
 
   def test_find_resources_attribute_callable_receives_attribute_value(self):
     deck, plate, well, trough, waste = self._sample_tree()
@@ -940,7 +976,7 @@ class TestResourceMetadata(unittest.TestCase):
     result = deck.find_resources(
       fn=lambda r: r.get_size_x() == 10,
       has_metadata="is_clean",
-      liquid="water",
+      metadata={"liquid": "water"},
       category="plate",
     )
     self.assertEqual(result, [plate])
@@ -958,15 +994,15 @@ class TestResourceMetadata(unittest.TestCase):
 
     # cb=handler runs handler(metadata.get("cb")); for child that is
     # handler(handler) -> truthy, so it "matches" -- the documented footgun.
-    self.assertEqual(deck.find_resources(cb=handler), [child])
+    self.assertEqual(deck.find_resources(metadata={"cb": handler}), [child])
     # Identity match via an explicit predicate is the correct approach.
-    self.assertEqual(deck.find_resources(cb=lambda v: v is handler), [child])
+    self.assertEqual(deck.find_resources(metadata={"cb": lambda v: v is handler}), [child])
 
   def test_find_resource_returns_first_match_or_self(self):
     deck, plate, _well, _trough, waste = self._sample_tree()
     # Two resources match; the first encountered (self is checked first) is returned.
-    self.assertEqual(deck.find_resources(liquid="water"), [plate, waste])
-    self.assertEqual(deck.find_resource(liquid="water"), plate)
+    self.assertEqual(deck.find_resources(metadata={"liquid": "water"}), [plate, waste])
+    self.assertEqual(deck.find_resource(metadata={"liquid": "water"}), plate)
     # The search includes self, so an unfiltered/self-matching query can return it.
     self.assertIs(deck.find_resource(type=Resource), deck)
     self.assertIsNone(deck.find_resource(name="does-not-exist"))

--- a/pylabrobot/resources/tecan/tecan_resource.py
+++ b/pylabrobot/resources/tecan/tecan_resource.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 from pylabrobot.resources.resource import Resource
 
@@ -26,6 +26,7 @@ class TecanResource(Resource):
     off_y: float = 0,
     category: Optional[str] = None,
     model: Optional[str] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     super().__init__(
       name=name,
@@ -34,6 +35,7 @@ class TecanResource(Resource):
       size_z=size_z,
       category=category,
       model=model,
+      metadata=metadata,
     )
 
     self.off_x = off_x

--- a/pylabrobot/resources/tip_rack.py
+++ b/pylabrobot/resources/tip_rack.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import warnings
 from abc import ABCMeta
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional, Sequence, Union, cast
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union, cast
 
 from pylabrobot.resources.coordinate import Coordinate
 from pylabrobot.resources.tip import Tip, TipCreator
@@ -30,6 +30,7 @@ class TipSpot(Resource):
     make_tip: TipCreator,
     size_z: float = 0,
     category: str = "tip_spot",
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     """Initialize a tip spot.
 
@@ -40,6 +41,7 @@ class TipSpot(Resource):
       size_z: the size of the tip spot in the z direction.
       make_tip: a function that creates a tip for the tip spot.
       category: the category of the tip spot.
+      metadata: metadata for the tip spot.
     """
 
     super().__init__(
@@ -48,6 +50,7 @@ class TipSpot(Resource):
       size_y=size_x,
       size_z=size_z,
       category=category,
+      metadata=metadata,
     )
     self.tracker = TipTracker(thing="Tip spot")
     self.parent: Optional["TipRack"] = None
@@ -125,6 +128,7 @@ class TipSpot(Resource):
       size_z=data.get("size_z", 0),
       make_tip=make_tip,
       category=data.get("category", "tip_spot"),
+      metadata=data.get("metadata"),
     )
 
   def serialize_state(self) -> Dict[str, Any]:
@@ -159,6 +163,7 @@ class TipRack(ItemizedResource[TipSpot], metaclass=ABCMeta):
     category: str = "tip_rack",
     model: Optional[str] = None,
     with_tips: bool = True,
+    metadata: Optional[Mapping[str, Any]] = None,
   ):
     super().__init__(
       name,
@@ -169,6 +174,7 @@ class TipRack(ItemizedResource[TipSpot], metaclass=ABCMeta):
       ordering=ordering,
       category=category,
       model=model,
+      metadata=metadata,
     )
 
     if ordered_items is not None and len(ordered_items) > 0:

--- a/pylabrobot/visualizer/visualizer.py
+++ b/pylabrobot/visualizer/visualizer.py
@@ -294,7 +294,11 @@ class Visualizer:
     event: str,
     data: Dict[str, Any],
   ) -> Tuple[str, str]:
-    """Assemble a command into standard JSON form."""
+    """Assemble a command into standard JSON form.
+
+    Will fall-back to stringifying non-JSON-serializable types.
+    These can potentially exist in resource metadata.
+    """
     id_ = self._generate_id()
     command_data = {
       "id": id_,
@@ -302,7 +306,10 @@ class Visualizer:
       "data": data,
       "event": event,
     }
-    return json.dumps(_sanitize_floats(command_data)), id_
+    return json.dumps(
+      _sanitize_floats(command_data),
+      default=str,
+    ), id_
 
   def has_connection(self) -> bool:
     """Return `True` if a websocket connection has been established."""

--- a/pylabrobot/visualizer/visualizer_tests.py
+++ b/pylabrobot/visualizer/visualizer_tests.py
@@ -274,3 +274,45 @@ class VisualizerCommandTests(unittest.IsolatedAsyncioTestCase):
       call_args["data"]["plate_01_well_H12"]["volume"],
       500,
     )
+
+
+class TestVisualizerMetadataHandling(unittest.TestCase):
+  """Tests for visualizer metadata handling."""
+
+  def test_serialize_resource_tree_preserves_and_stringifies_metadata(self):
+    deck = Resource(
+      size_x=100,
+      size_y=100,
+      size_z=100,
+      name="deck",
+      metadata={"level": 0, "fn": lambda x: x},
+    )
+    plate = cor_96_wellplate_360uL_Fb(name="plate")
+    plate.metadata = {"level": 1, "unserializable": object()}
+    plate.get_well("A1").metadata = {"level": 2, "sample_id": 123}
+    deck.assign_child_resource(plate, location=Coordinate(0, 0, 0))
+
+    serialized = _serialize_resource_tree(deck)
+    self.assertIn("metadata", serialized)
+    self.assertEqual(serialized["metadata"]["level"], 0)
+
+    plate_serialized = serialized["children"][0]
+    self.assertIn("metadata", plate_serialized)
+    self.assertEqual(plate_serialized["metadata"]["level"], 1)
+
+    well_serialized = plate_serialized["children"][0]
+    self.assertIn("metadata", well_serialized)
+    self.assertEqual(well_serialized["metadata"]["level"], 2)
+    self.assertEqual(well_serialized["metadata"]["sample_id"], 123)
+
+    # Ensure _assemble_command succeeds and round-trips via json.loads
+    vis = Visualizer(deck, open_browser=False)
+    payload, _ = vis._assemble_command(
+      "set_root_resource", {"resource": _serialize_resource_tree(deck)}
+    )
+    decoded = json.loads(payload)["data"]["resource"]
+    self.assertEqual(decoded["name"], "deck")
+    self.assertEqual(decoded["metadata"]["level"], 0)
+    self.assertIsInstance(decoded["metadata"]["fn"], str)
+    self.assertEqual(decoded["children"][0]["metadata"]["level"], 1)
+    self.assertEqual(decoded["children"][0]["children"][0]["metadata"]["sample_id"], 123)


### PR DESCRIPTION
We found it useful to store arbitrary metadata with resources. For example, this enables us to label wells and containers with a metadata key `source_for`, indicating that these are where certain reagents can be found. Or it could be used to store barcode information with samples. Information regarding which direction a specific plate should be gripped by an iSWAP. Having that kind of information attached to the resources themselves is important because a) the metadata gets together with the deck, and b) it is cleaned up automatically when the corresponding resources are removed again from the deck.