### PR TITLE
fix(resources): make TipTracker.get_tip use pending state

### DIFF
--- a/pylabrobot/legacy/liquid_handling/backends/hamilton/STAR_backend.py
+++ b/pylabrobot/legacy/liquid_handling/backends/hamilton/STAR_backend.py
@@ -1473,8 +1473,7 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
 
     x_positions, y_positions, channels_involved = self._ops_to_fw_positions(ops, use_channels)
 
-    tip_spots = [op.resource for op in ops]
-    tips = set(cast(HamiltonTip, tip_spot.get_tip()) for tip_spot in tip_spots)
+    tips = set(cast(HamiltonTip, op.tip) for op in ops)
     if len(tips) > 1:
       raise ValueError("Cannot mix tips with different tip types.")
     ttti = await self.get_or_assign_tip_type_index(tips.pop())
@@ -1484,9 +1483,9 @@ class STARBackend(HamiltonLiquidHandler, HamiltonHeaterShakerInterface):
     max_tip_length = max((op.tip.total_tip_length - op.tip.fitting_depth) for op in ops)
 
     # not sure why this is necessary, but it is according to log files and experiments
-    if self._get_hamilton_tip([op.resource for op in ops]).tip_size == TipSize.LOW_VOLUME:
+    if self._get_hamilton_tip([op.tip for op in ops]).tip_size == TipSize.LOW_VOLUME:
       max_tip_length += 2
-    elif self._get_hamilton_tip([op.resource for op in ops]).tip_size != TipSize.STANDARD_VOLUME:
+    elif self._get_hamilton_tip([op.tip for op in ops]).tip_size != TipSize.STANDARD_VOLUME:
       max_tip_length -= 2
 
     tip = ops[0].tip

--- a/pylabrobot/legacy/liquid_handling/backends/hamilton/STAR_tests.py
+++ b/pylabrobot/legacy/liquid_handling/backends/hamilton/STAR_tests.py
@@ -1178,6 +1178,13 @@ class TestSTARLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
       ]
     )
 
+  async def test_tip_tracking_pick_up(self):
+    set_tip_tracking(enabled=True)
+    try:
+      await self.lh.pick_up_tips(self.tip_rack["A1", "B1"])
+    finally:
+      set_tip_tracking(enabled=False)
+
   async def test_tip_tracking_pick_up96(self):
     set_tip_tracking(enabled=True)
     await self.lh.pick_up_tips96(self.tip_rack)

--- a/pylabrobot/legacy/liquid_handling/backends/hamilton/base.py
+++ b/pylabrobot/legacy/liquid_handling/backends/hamilton/base.py
@@ -21,7 +21,7 @@ from pylabrobot.legacy.liquid_handling.backends.backend import (
   LiquidHandlerBackend,
 )
 from pylabrobot.legacy.liquid_handling.standard import PipettingOp
-from pylabrobot.resources import TipSpot
+from pylabrobot.resources import Tip
 from pylabrobot.resources.hamilton import (
   HamiltonTip,
   TipPickupMethod,
@@ -454,15 +454,14 @@ class HamiltonLiquidHandler(LiquidHandlerBackend, metaclass=ABCMeta):
 
     return self._tth2tti[tip_type_hash]
 
-  def _get_hamilton_tip(self, tip_spots: List[TipSpot]) -> HamiltonTip:
-    """Get the single tip type for all tip spots. If it does not exist or is not a HamiltonTip,
-    raise an error."""
-    tips = set(tip_spot.get_tip() for tip_spot in tip_spots)
-    if len(tips) > 1:
+  def _get_hamilton_tip(self, tips: Sequence[Tip]) -> HamiltonTip:
+    """Get the single Hamilton tip type. If mixed or not a HamiltonTip, raise an error."""
+    unique = set(tips)
+    if len(unique) > 1:
       raise ValueError("Cannot mix tips with different tip types.")
-    if len(tips) == 0:
+    if len(unique) == 0:
       raise ValueError("No tips specified.")
-    tip = tips.pop()
+    tip = unique.pop()
     if not isinstance(tip, HamiltonTip):
       raise ValueError(f"Tip {tip} is not a HamiltonTip.")
     return tip

--- a/pylabrobot/legacy/liquid_handling/backends/hamilton/vantage_backend.py
+++ b/pylabrobot/legacy/liquid_handling/backends/hamilton/vantage_backend.py
@@ -484,7 +484,7 @@ class VantageBackend(HamiltonLiquidHandler):
   ):
     x_positions, y_positions, tip_pattern = self._ops_to_fw_positions(ops, use_channels)
 
-    tips = [cast(HamiltonTip, op.resource.get_tip()) for op in ops]
+    tips = [cast(HamiltonTip, op.tip) for op in ops]
     ttti = [await self.get_or_assign_tip_type_index(tip) for tip in tips]
 
     max_z = max(op.resource.get_location_wrt(self.deck).z + op.offset.z for op in ops)
@@ -492,9 +492,9 @@ class VantageBackend(HamiltonLiquidHandler):
     max_tip_length = max((op.tip.total_tip_length - op.tip.fitting_depth) for op in ops)
 
     # not sure why this is necessary, but it is according to log files and experiments
-    if self._get_hamilton_tip([op.resource for op in ops]).tip_size == TipSize.LOW_VOLUME:
+    if self._get_hamilton_tip([op.tip for op in ops]).tip_size == TipSize.LOW_VOLUME:
       max_tip_length += 2
-    elif self._get_hamilton_tip([op.resource for op in ops]).tip_size != TipSize.STANDARD_VOLUME:
+    elif self._get_hamilton_tip([op.tip for op in ops]).tip_size != TipSize.STANDARD_VOLUME:
       max_tip_length -= 2
 
     try:

--- a/pylabrobot/legacy/liquid_handling/backends/hamilton/vantage_tests.py
+++ b/pylabrobot/legacy/liquid_handling/backends/hamilton/vantage_tests.py
@@ -360,6 +360,13 @@ class TestVantageLiquidHandlerCommands(unittest.IsolatedAsyncioTestCase):
       PICKUP_TIP_FORMAT,
     )
 
+  async def test_tip_tracking_pick_up(self):
+    set_tip_tracking(enabled=True)
+    try:
+      await self.lh.pick_up_tips(self.tip_rack["A1", "B1"])
+    finally:
+      set_tip_tracking(enabled=False)
+
   async def test_tip_drop_01(self):
     await self.test_tip_pickup_01()  # pick up tips first
     await self.lh.drop_tips(self.tip_rack["A1", "B1"])

--- a/pylabrobot/resources/tip_tracker.py
+++ b/pylabrobot/resources/tip_tracker.py
@@ -57,15 +57,15 @@ class TipTracker(SerializableMixin):
     return self._pending_tip is not None
 
   def get_tip(self) -> "Tip":
-    """Get the tip. Note that does includes pending operations.
+    """Get the tip. Note that this includes pending operations.
 
     Raises:
       NoTipError: If the tip spot does not have a tip.
     """
 
-    if self._tip is None:
+    if self._pending_tip is None:
       raise NoTipError(f"{self.thing} does not have a tip.")
-    return self._tip
+    return self._pending_tip
 
   def disable(self) -> None:
     """Disable the tip tracker."""

--- a/pylabrobot/resources/tip_tracker_tests.py
+++ b/pylabrobot/resources/tip_tracker_tests.py
@@ -43,3 +43,17 @@ class TestTipTracker(unittest.TestCase):
 
     with self.assertRaises(NoTipError):
       tracker.get_tip()
+
+  def test_get_tip_includes_pending_add(self):
+    tracker = TipTracker(thing="tester")
+    tracker.add_tip(self.tip, commit=False)
+    self.assertEqual(tracker.has_tip, True)
+    self.assertEqual(tracker.get_tip(), self.tip)
+
+  def test_get_tip_includes_pending_remove(self):
+    tracker = TipTracker(thing="tester")
+    tracker.add_tip(self.tip)
+    tracker.remove_tip(commit=False)
+    self.assertEqual(tracker.has_tip, False)
+    with self.assertRaises(NoTipError):
+      tracker.get_tip()


### PR DESCRIPTION
## Summary

- Align `TipTracker.get_tip()` with `has_tip` so both expose the pending transactional state.
- Fix the contradictory tracker views described in #309.
- Preserve STAR and Vantage pickup behavior with tip tracking enabled: `LiquidHandler` stages removal from the `TipSpot` before calling the backend, so Hamilton backends now use the `Tip` already captured in the pickup operation instead of rereading the mutated `TipSpot`.
- Update Hamilton tip-type resolution accordingly.
- Add regression coverage for pending add/remove, commit/rollback, and STAR/Vantage pickup with tip tracking enabled.

Hardware uncertainty / `UNKNOWN` physical state remains out of scope. This PR is independent of #1207.

## Test plan

- TipTracker transactional-state tests
- STAR pickup with tip tracking enabled
- Vantage pickup with tip tracking enabled
- Relevant LiquidHandler/Hamilton tests
- Ruff check / format

Combined validation with #1207 on current `upstream/main`:

- 236 tests passed
- 101 subtests passed
- `ruff check pylabrobot` passed
- `ruff format --check pylabrobot` passed

## Out of scope

`Vantage.pick_up_tips96` with tip tracking enabled is already broken on `upstream/main`: it checks pending `has_tip` after the frontend stages removal and fails before `get_tip()` is involved. This PR does not change that pre-existing behavior.
