### PR TITLE
Add command-line I/O transport

### DIFF
--- a/pylabrobot/io/__init__.py
+++ b/pylabrobot/io/__init__.py
@@ -1,4 +1,5 @@
 from .capture import start_capture, stop_capture
+from .command_line import CommandLineResult, CommandLineTransport, CommandLineValidator
 from .socket import Socket, SocketValidator
 from .validation import end_validation, validate
 from .validation_utils import LOG_LEVEL_IO

--- a/pylabrobot/io/command_line.py
+++ b/pylabrobot/io/command_line.py
@@ -1,0 +1,259 @@
+"""Asynchronous I/O for local command-line programs."""
+
+import asyncio
+import logging
+import shutil
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional, Sequence
+
+from pylabrobot.io.capture import Command, capturer, get_capture_or_validation_active
+from pylabrobot.io.errors import ValidationError
+from pylabrobot.io.validation_utils import LOG_LEVEL_IO
+from pylabrobot.serializer import SerializableMixin
+
+if TYPE_CHECKING:
+  from pylabrobot.io.capture import CaptureReader
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CommandLineResult:
+  """Result returned by :meth:`CommandLineTransport.run`.
+
+  Attributes:
+    returncode: Process exit code.
+    stdout: Decoded standard output.
+    stderr: Decoded standard error.
+  """
+
+  returncode: int
+  stdout: str
+  stderr: str
+
+
+@dataclass
+class CommandLineCommand(Command):
+  """Captured command-line execution."""
+
+  arguments: list[str]
+  timeout: float
+  returncode: int
+  stdout: str
+  stderr: str
+
+  def __init__(
+    self,
+    device_id: str,
+    arguments: list[str],
+    timeout: float,
+    returncode: int,
+    stdout: str,
+    stderr: str,
+    action: str = "run",
+    module: str = "command_line",
+  ) -> None:
+    """Initialize a captured command-line execution."""
+    super().__init__(module=module, device_id=device_id, action=action)
+    self.arguments = arguments
+    self.timeout = timeout
+    self.returncode = returncode
+    self.stdout = stdout
+    self.stderr = stderr
+
+
+class CommandLineTransport(SerializableMixin):
+  """I/O transport for one operator-installed executable.
+
+  The transport owns the executable identity and process lifecycle. Calls are serialized so one
+  transport cannot start overlapping child processes.
+
+  Args:
+    human_readable_device_name: Name used in logs and errors.
+    executable: Absolute path or executable name to resolve from ``PATH`` during setup.
+  """
+
+  def __init__(self, human_readable_device_name: str, executable: str) -> None:
+    """Initialize the command-line transport configuration."""
+    if not human_readable_device_name:
+      raise ValueError("human_readable_device_name must not be empty")
+    if not executable:
+      raise ValueError("executable must not be empty")
+    if get_capture_or_validation_active():
+      raise RuntimeError(
+        "Cannot create a new CommandLineTransport while capture or validation is active"
+      )
+
+    self.human_readable_device_name = human_readable_device_name
+    self.executable = executable
+    self._is_setup = False
+    self._process: Optional[asyncio.subprocess.Process] = None
+    self._run_lock = asyncio.Lock()
+
+  @property
+  def is_setup(self) -> bool:
+    """Return whether the executable has been resolved and the transport is ready."""
+    return self._is_setup
+
+  async def setup(self) -> None:
+    """Resolve the configured executable and mark the transport ready.
+
+    Raises:
+      FileNotFoundError: If the executable cannot be resolved.
+    """
+    if self._is_setup:
+      return
+    resolved = shutil.which(self.executable)
+    if resolved is None:
+      raise FileNotFoundError(f"Command-line executable was not found: {self.executable}")
+    self.executable = resolved
+    self._is_setup = True
+    logger.info("Set up command-line I/O for %s at %s", self.human_readable_device_name, resolved)
+
+  async def stop(self) -> None:
+    """Stop any active child process and mark the transport closed."""
+    self._is_setup = False
+    process = self._process
+    if process is not None and process.returncode is None:
+      try:
+        process.kill()
+      except ProcessLookupError:
+        pass
+      await process.wait()
+    logger.info("Stopped command-line I/O for %s", self.human_readable_device_name)
+
+  async def run(self, arguments: Sequence[str], timeout: float) -> CommandLineResult:
+    """Run the configured executable with arguments and collect its output.
+
+    Args:
+      arguments: Arguments passed to the configured executable.
+      timeout: Maximum runtime in seconds.
+
+    Returns:
+      The process exit code and decoded output streams.
+
+    Raises:
+      RuntimeError: If :meth:`setup` has not been called.
+      ValueError: If ``timeout`` is not positive.
+      asyncio.TimeoutError: If the process does not finish before ``timeout``.
+    """
+    if not self._is_setup:
+      raise RuntimeError(
+        f"Command-line I/O for '{self.human_readable_device_name}' is not set up; "
+        "call setup() first"
+      )
+    if timeout <= 0:
+      raise ValueError("timeout must be positive")
+
+    command_arguments = list(arguments)
+    async with self._run_lock:
+      process = await asyncio.create_subprocess_exec(
+        self.executable,
+        *command_arguments,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+      )
+      self._process = process
+      try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout)
+      except (asyncio.CancelledError, asyncio.TimeoutError):
+        if process.returncode is None:
+          try:
+            process.kill()
+          except ProcessLookupError:
+            pass
+        await process.communicate()
+        raise
+      finally:
+        self._process = None
+
+    returncode = process.returncode
+    if returncode is None:
+      raise RuntimeError("command completed without an exit code")
+    result = CommandLineResult(
+      returncode=returncode,
+      stdout=stdout.decode("utf-8", errors="replace"),
+      stderr=stderr.decode("utf-8", errors="replace"),
+    )
+    logger.log(
+      LOG_LEVEL_IO,
+      "[%s] run %s -> %d",
+      self.executable,
+      command_arguments,
+      result.returncode,
+    )
+    capturer.record(
+      CommandLineCommand(
+        device_id=self.executable,
+        arguments=command_arguments,
+        timeout=timeout,
+        returncode=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
+      )
+    )
+    return result
+
+  def serialize(self) -> dict:
+    """Serialize the command-line transport configuration."""
+    return {
+      "human_readable_device_name": self.human_readable_device_name,
+      "executable": self.executable,
+    }
+
+
+class CommandLineValidator(CommandLineTransport):
+  """Replay captured command-line executions without starting a process."""
+
+  def __init__(
+    self,
+    cr: "CaptureReader",
+    human_readable_device_name: str,
+    executable: str,
+  ) -> None:
+    """Initialize a command-line capture validator."""
+    self.cr = cr
+    self.human_readable_device_name = human_readable_device_name
+    self.executable = executable
+    self._is_setup = False
+    self._process = None
+    self._run_lock = asyncio.Lock()
+
+  async def setup(self) -> None:
+    """Mark the validator ready without resolving an executable."""
+    self._is_setup = True
+
+  async def stop(self) -> None:
+    """Mark the validator closed."""
+    self._is_setup = False
+
+  async def run(self, arguments: Sequence[str], timeout: float) -> CommandLineResult:
+    """Validate an execution against the next captured command."""
+    if not self._is_setup:
+      raise RuntimeError(
+        f"Command-line I/O for '{self.human_readable_device_name}' is not set up; "
+        "call setup() first"
+      )
+    next_command = CommandLineCommand(**self.cr.next_command())
+    if not (
+      next_command.module == "command_line"
+      and next_command.device_id == self.executable
+      and next_command.action == "run"
+    ):
+      raise ValidationError(
+        f"Expected command-line run for {self.executable}, got "
+        f"{next_command.module} {next_command.action} for {next_command.device_id}"
+      )
+    if next_command.arguments != list(arguments):
+      raise ValidationError(
+        f"Command-line arguments differ: expected {next_command.arguments}, got {list(arguments)}"
+      )
+    if next_command.timeout != timeout:
+      raise ValidationError(
+        f"Command-line timeout differs: expected {next_command.timeout}, got {timeout}"
+      )
+    return CommandLineResult(
+      returncode=next_command.returncode,
+      stdout=next_command.stdout,
+      stderr=next_command.stderr,
+    )

--- a/pylabrobot/io/command_line_tests.py
+++ b/pylabrobot/io/command_line_tests.py
@@ -139,6 +139,20 @@ class CommandLineTransportTests(unittest.IsolatedAsyncioTestCase):
 
     self.assertFalse(transport.is_setup)
 
+  async def test_stop_kills_active_process(self) -> None:
+    transport = self.make_transport()
+    await self.setup_transport(transport)
+    process = MagicMock()
+    process.returncode = None
+    process.wait = AsyncMock()
+    transport._process = process
+
+    await transport.stop()
+
+    process.kill.assert_called_once_with()
+    process.wait.assert_awaited_once_with()
+    self.assertFalse(transport.is_setup)
+
   async def test_rejects_non_positive_timeout(self) -> None:
     transport = self.make_transport()
     await self.setup_transport(transport)

--- a/pylabrobot/io/command_line_tests.py
+++ b/pylabrobot/io/command_line_tests.py
@@ -1,0 +1,207 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pylabrobot.io.command_line import (
+  CommandLineCommand,
+  CommandLineResult,
+  CommandLineTransport,
+  CommandLineValidator,
+)
+from pylabrobot.io.errors import ValidationError
+
+
+class CommandLineTransportTests(unittest.IsolatedAsyncioTestCase):
+  """Tests for command-line I/O without starting a real process."""
+
+  def make_transport(self) -> CommandLineTransport:
+    """Return a command-line transport configured for the test executable."""
+    return CommandLineTransport(
+      human_readable_device_name="Test scanner",
+      executable="scanner",
+    )
+
+  async def setup_transport(self, transport: CommandLineTransport) -> None:
+    """Resolve the test executable without reading the host ``PATH``."""
+    with patch("pylabrobot.io.command_line.shutil.which", return_value="/usr/bin/scanner"):
+      await transport.setup()
+
+  async def test_setup_resolves_executable(self) -> None:
+    transport = self.make_transport()
+
+    await self.setup_transport(transport)
+
+    self.assertTrue(transport.is_setup)
+    self.assertEqual(transport.executable, "/usr/bin/scanner")
+
+  async def test_setup_raises_when_executable_is_missing(self) -> None:
+    transport = self.make_transport()
+
+    with (
+      patch("pylabrobot.io.command_line.shutil.which", return_value=None),
+      self.assertRaisesRegex(FileNotFoundError, "scanner"),
+    ):
+      await transport.setup()
+
+    self.assertFalse(transport.is_setup)
+
+  async def test_run_requires_setup(self) -> None:
+    with self.assertRaisesRegex(RuntimeError, "call setup"):
+      await self.make_transport().run(["--acquire"], timeout=1.0)
+
+  async def test_run_returns_and_captures_decoded_process_result(self) -> None:
+    transport = self.make_transport()
+    await self.setup_transport(transport)
+    process = MagicMock()
+    process.returncode = 0
+    process.communicate = AsyncMock(return_value=(b"output\n", b"warning\n"))
+
+    with (
+      patch(
+        "pylabrobot.io.command_line.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=process),
+      ) as create_process,
+      patch("pylabrobot.io.command_line.capturer.record") as record,
+    ):
+      result = await transport.run(["--acquire"], timeout=2.0)
+
+    create_process.assert_awaited_once_with(
+      "/usr/bin/scanner",
+      "--acquire",
+      stdout=asyncio.subprocess.PIPE,
+      stderr=asyncio.subprocess.PIPE,
+    )
+    self.assertEqual(result.returncode, 0)
+    self.assertEqual(result.stdout, "output\n")
+    self.assertEqual(result.stderr, "warning\n")
+    command = record.call_args.args[0]
+    self.assertIsInstance(command, CommandLineCommand)
+    self.assertEqual(command.device_id, "/usr/bin/scanner")
+    self.assertEqual(command.arguments, ["--acquire"])
+    self.assertEqual(command.returncode, 0)
+
+  async def test_timeout_kills_process(self) -> None:
+    transport = self.make_transport()
+    await self.setup_transport(transport)
+    release = asyncio.Event()
+
+    async def communicate():
+      await release.wait()
+      return b"", b""
+
+    process = MagicMock()
+    process.returncode = None
+    process.communicate = communicate
+    process.kill.side_effect = release.set
+
+    with patch(
+      "pylabrobot.io.command_line.asyncio.create_subprocess_exec",
+      AsyncMock(return_value=process),
+    ):
+      with self.assertRaises(asyncio.TimeoutError):
+        await transport.run([], timeout=0.001)
+
+    process.kill.assert_called_once_with()
+
+  async def test_cancellation_kills_process(self) -> None:
+    transport = self.make_transport()
+    await self.setup_transport(transport)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def communicate():
+      started.set()
+      await release.wait()
+      return b"", b""
+
+    process = MagicMock()
+    process.returncode = None
+    process.communicate = communicate
+    process.kill.side_effect = release.set
+
+    with patch(
+      "pylabrobot.io.command_line.asyncio.create_subprocess_exec",
+      AsyncMock(return_value=process),
+    ):
+      task = asyncio.create_task(transport.run([], timeout=10.0))
+      await started.wait()
+      task.cancel()
+      with self.assertRaises(asyncio.CancelledError):
+        await task
+
+    process.kill.assert_called_once_with()
+
+  async def test_stop_marks_transport_closed(self) -> None:
+    transport = self.make_transport()
+    await self.setup_transport(transport)
+
+    await transport.stop()
+
+    self.assertFalse(transport.is_setup)
+
+  async def test_rejects_non_positive_timeout(self) -> None:
+    transport = self.make_transport()
+    await self.setup_transport(transport)
+
+    with self.assertRaisesRegex(ValueError, "positive"):
+      await transport.run([], timeout=0)
+
+  def test_rejects_empty_identity(self) -> None:
+    with self.assertRaisesRegex(ValueError, "human_readable_device_name"):
+      CommandLineTransport("", "scanner")
+    with self.assertRaisesRegex(ValueError, "executable"):
+      CommandLineTransport("Test scanner", "")
+
+  def test_serializes_configuration(self) -> None:
+    self.assertEqual(
+      self.make_transport().serialize(),
+      {
+        "human_readable_device_name": "Test scanner",
+        "executable": "scanner",
+      },
+    )
+
+  async def test_validator_replays_captured_result(self) -> None:
+    capture_reader = MagicMock()
+    capture_reader.next_command.return_value = {
+      "module": "command_line",
+      "device_id": "/usr/bin/scanner",
+      "action": "run",
+      "arguments": ["--acquire"],
+      "timeout": 2.0,
+      "returncode": 0,
+      "stdout": "output",
+      "stderr": "",
+    }
+    validator = CommandLineValidator(
+      cr=capture_reader,
+      human_readable_device_name="Test scanner",
+      executable="/usr/bin/scanner",
+    )
+    await validator.setup()
+
+    result = await validator.run(["--acquire"], timeout=2.0)
+
+    self.assertEqual(result, CommandLineResult(0, "output", ""))
+
+  async def test_validator_rejects_argument_mismatch(self) -> None:
+    capture_reader = MagicMock()
+    capture_reader.next_command.return_value = {
+      "module": "command_line",
+      "device_id": "/usr/bin/scanner",
+      "action": "run",
+      "arguments": ["--expected"],
+      "timeout": 2.0,
+      "returncode": 0,
+      "stdout": "",
+      "stderr": "",
+    }
+    validator = CommandLineValidator(
+      cr=capture_reader,
+      human_readable_device_name="Test scanner",
+      executable="/usr/bin/scanner",
+    )
+    await validator.setup()
+
+    with self.assertRaisesRegex(ValidationError, "arguments differ"):
+      await validator.run(["--actual"], timeout=2.0)

--- a/pylabrobot/io/validation.py
+++ b/pylabrobot/io/validation.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from pylabrobot.io.capture import CaptureReader, capturer
+from pylabrobot.io.command_line import CommandLineTransport, CommandLineValidator
 from pylabrobot.io.ftdi import FTDI, FTDIValidator
 from pylabrobot.io.hid import HID, HIDValidator
 from pylabrobot.io.serial import Serial, SerialValidator
@@ -28,6 +29,7 @@ def validate(capture_file: str):
       Serial: SerialValidator,
       FTDI: FTDIValidator,
       HID: HIDValidator,
+      CommandLineTransport: CommandLineValidator,
     }
     if not hasattr(obj, "io"):
       return False


### PR DESCRIPTION
## Summary

- add lifecycle-managed command-line I/O for one executable
- capture and replay command executions through PyLabRobot validation
- serialize execution, enforce timeouts, and clean up subprocesses on cancellation or shutdown

## Why

Device integrations sometimes communicate through operator-installed helper executables. This keeps that communication behind a reusable PyLabRobot I/O layer instead of calling subprocesses directly from device drivers.

## Validation

- `ruff format --check pylabrobot/io/command_line.py pylabrobot/io/command_line_tests.py pylabrobot/io/validation.py pylabrobot/io/__init__.py`
- `ruff check pylabrobot/io/command_line.py pylabrobot/io/command_line_tests.py pylabrobot/io/validation.py pylabrobot/io/__init__.py`
- `mypy pylabrobot/io/command_line.py pylabrobot/io/validation.py`
- `pytest -q --timeout=20 pylabrobot/io/command_line_tests.py` (13 passed)