### PR TITLE
legacy(precise_flex): expose the lifecycle steps behind setup and stop

### DIFF
--- a/pylabrobot/legacy/arms/precise_flex/precise_flex_backend.py
+++ b/pylabrobot/legacy/arms/precise_flex/precise_flex_backend.py
@@ -91,16 +91,37 @@ class PreciseFlexBackend(SCARABackend, ABC):
     return arr
 
   async def setup(self, skip_home: bool = False):
-    """Initialize the PreciseFlex backend."""
-    await self.io.setup()
-    await self.set_response_mode("pc")
-    await self.power_on_robot()
-    await self.attach(1)
+    """Bring the arm up: link, power, control, and (unless skipped) home."""
+    await self.connect()
+    await self.initialize()
     if not skip_home:
       await self.home()
 
+  async def connect(self):
+    """Open the link and agree the response protocol. Powers nothing, moves nothing."""
+    await self.io.setup()
+    await self.set_response_mode("pc")
+
+  async def initialize(self):
+    """Raise high power and take control, so the arm accepts commands. Moves nothing.
+
+    Homing stays separate because it is the only step that moves: it sweeps the
+    arm through its whole envelope, which is far too much to do just to read a
+    position or check what the controller reports.
+    """
+    await self.power_on_robot()
+    await self.attach(1)
+
   async def stop(self):
-    """Stop the PreciseFlex backend."""
+    """Release the arm."""
+    await self.disconnect()
+
+  async def disconnect(self):
+    """Drop high power and release the link, moving nothing.
+
+    Powers down as well as disconnecting, because ``initialize`` is what raised
+    high power.
+    """
     await self.detach()
     await self.power_off_robot()
     await self.exit()

--- a/pylabrobot/legacy/arms/precise_flex/precise_flex_backend_tests.py
+++ b/pylabrobot/legacy/arms/precise_flex/precise_flex_backend_tests.py
@@ -115,6 +115,51 @@ class PreciseFlexBackendTests(unittest.IsolatedAsyncioTestCase):
     self.mock_socket_instance.write.assert_any_call(b"exit\n")
     self.mock_socket_instance.stop.assert_called_once()
 
+  async def test_connect_opens_the_link_without_powering_or_homing(self):
+    self.mock_socket_instance.readline.side_effect = [b"0 OK\r\n"]  # set_mode
+    await self.backend.connect()
+    self.mock_socket_instance.setup.assert_called_once()
+    self.mock_socket_instance.write.assert_any_call(b"mode 0\n")
+    written = [call.args[0] for call in self.mock_socket_instance.write.call_args_list]
+    self.assertNotIn(b"hp 1 20\n", written)
+    self.assertNotIn(b"home\n", written)
+
+  async def test_initialize_raises_power_without_homing(self):
+    self.mock_socket_instance.readline.side_effect = [
+      b"0 OK\r\n",  # power_on_robot
+      b"0 OK\r\n",  # attach
+    ]
+    await self.backend.initialize()
+    self.mock_socket_instance.write.assert_any_call(b"hp 1 20\n")
+    self.mock_socket_instance.write.assert_any_call(b"attach 1\n")
+    written = [call.args[0] for call in self.mock_socket_instance.write.call_args_list]
+    self.assertNotIn(b"home\n", written)
+
+  async def test_disconnect_drops_power_and_releases_the_link(self):
+    self.mock_socket_instance.readline.side_effect = [
+      b"0 attach\r\n",  # detach
+      b"0 hp\r\n",  # power_off_robot
+      b"0 exit\r\n",  # exit
+    ]
+    await self.backend.disconnect()
+    self.mock_socket_instance.write.assert_any_call(b"attach 0\n")
+    self.mock_socket_instance.write.assert_any_call(b"hp 0\n")
+    self.mock_socket_instance.write.assert_any_call(b"exit\n")
+    self.mock_socket_instance.stop.assert_called_once()
+
+  async def test_setup_skips_only_the_home_when_asked(self):
+    self.mock_socket_instance.readline.side_effect = [
+      b"0 OK\r\n",  # set_mode
+      b"0 OK\r\n",  # power_on_robot
+      b"0 OK\r\n",  # attach
+    ]
+    await self.backend.setup(skip_home=True)
+    self.mock_socket_instance.write.assert_any_call(b"mode 0\n")
+    self.mock_socket_instance.write.assert_any_call(b"hp 1 20\n")
+    self.mock_socket_instance.write.assert_any_call(b"attach 1\n")
+    written = [call.args[0] for call in self.mock_socket_instance.write.call_args_list]
+    self.assertNotIn(b"home\n", written)
+
   async def test_set_speed(self):
     self.mock_socket_instance.readline.return_value = b"0 Speed 1 50.0\r\n"
     await self.backend.set_speed(50.0)


### PR DESCRIPTION
`setup()` on the PreciseFlex does four things at once: opens the link, agrees the response protocol, raises high power, and sweeps the arm through its whole envelope to home. A caller who only wants to read a position has to accept the sweep, and one who wants the link without high power has no way to ask.

Each step is now its own public method, so the arm can be driven atomically:

- `connect` opens the link and agrees the response protocol. Powers nothing, moves nothing.
- `initialize` raises high power and attaches, so the arm accepts commands. Moves nothing.
- `home` is the only step that moves.
- `disconnect` detaches, drops high power, and releases the link. `initialize` is what raised the power, so this is what drops it.

`setup()` and `stop()` are unchanged in behavior and now just compose these, so existing code keeps working and the PyLabRobot convention still holds: `MachineBackend` declares both abstract, and the tree has 139 `setup` and 163 `stop` definitions. They stay the entry point; the split adds a finer grain underneath rather than replacing it.

Four tests added, covering that `connect` and `initialize` each send their own commands and neither homes, that `disconnect` drops power and releases the link, and that `setup(skip_home=True)` still does everything but home. Existing tests are untouched and pass.

**Tested on PreciseFlex PF400**
