### PR TITLE
`Resource`: fix a name when the resource is created, and refuse to change it later

### DIFF
--- a/pylabrobot/legacy/liquid_handling/liquid_handler_tests.py
+++ b/pylabrobot/legacy/liquid_handling/liquid_handler_tests.py
@@ -419,6 +419,7 @@ class TestLiquidHandlerLayout(unittest.IsolatedAsyncioTestCase):
             size_x=10,
             size_y=10,
             size_z=10,
+            name_prefix="plate",
           ),
         )
         plate.rotate(z=rotation)

--- a/pylabrobot/legacy/microscopes/molecular_devices/pico/backend_tests.py
+++ b/pylabrobot/legacy/microscopes/molecular_devices/pico/backend_tests.py
@@ -78,6 +78,7 @@ def _test_plate() -> Plate:
       bottom_type=WellBottomType.FLAT,
       material_z_thickness=0.17,
       max_volume=350.0,
+      name_prefix="test_plate",
     ),
   )
 

--- a/pylabrobot/legacy/plate_reading/tecan/infinite_backend_tests.py
+++ b/pylabrobot/legacy/plate_reading/tecan/infinite_backend_tests.py
@@ -74,6 +74,7 @@ def _make_test_plate():
       size_x=4,
       size_y=4,
       size_z=5,
+      name_prefix="plate",
     ),
   )
   plate.location = Coordinate.zero()

--- a/pylabrobot/legacy/plate_washing/biotek/el406/mock_tests.py
+++ b/pylabrobot/legacy/plate_washing/biotek/el406/mock_tests.py
@@ -38,6 +38,7 @@ def _make_plate(name: str, num_wells: int, size_z: float = 14.0) -> Plate:
       size_x=6.0,
       size_y=6.0,
       size_z=10.0,
+      name_prefix=name,
     ),
   )
 

--- a/pylabrobot/molecular_devices/imageXpress/pico/tests/pico_tests.py
+++ b/pylabrobot/molecular_devices/imageXpress/pico/tests/pico_tests.py
@@ -70,6 +70,7 @@ def _test_plate() -> Plate:
       bottom_type=WellBottomType.FLAT,
       material_z_thickness=0.17,
       max_volume=350.0,
+      name_prefix="test_plate",
     ),
   )
 

--- a/pylabrobot/resources/agenbio/plates.py
+++ b/pylabrobot/resources/agenbio/plates.py
@@ -58,6 +58,7 @@ def agenbio_96_wellplate_Ub_2200uL(name: str, lid: Optional[Lid] = None) -> Plat
       dz=3.8,  # measured
       item_dx=9,
       item_dy=9,
+      name_prefix=name,
       **well_kwargs,
     ),
   )
@@ -108,6 +109,7 @@ def agenbio_4_troughplate_75mL_Vb(name: str, lid: Optional[Lid] = None) -> Plate
       dz=0.9,  # measured
       item_dx=INNER_WELL_WIDTH + 1,  # 1 mm wall thickness
       item_dy=INNER_WELL_LENGTH,
+      name_prefix=name,
       **well_kwargs,
     ),
   )
@@ -182,6 +184,7 @@ def agenbio_1_troughplate_190mL_Fl(name: str, lid: Optional[Lid] = None) -> Plat
       dz=5.88,
       item_dx=None,  # single column
       item_dy=None,  # single row
+      name_prefix=name,
       **well_kwargs,
     ),
   )
@@ -232,6 +235,7 @@ def agenbio_1_troughplate_100mL_Fl(name: str, lid: Optional[Lid] = None) -> Plat
       dz=5.88,
       item_dx=None,  # single column
       item_dy=None,  # single row
+      name_prefix=name,
       **well_kwargs,
     ),
   )

--- a/pylabrobot/resources/agilent/plates.py
+++ b/pylabrobot/resources/agilent/plates.py
@@ -97,6 +97,7 @@ def agilent_96_wellplate_150uL_Vb(name: str) -> Plate:
       dz=15.9 - 14.0 - 0.88,  # spec - spec - measured manually
       item_dx=9.0,  # standard
       item_dy=9.0,  # standard
+      name_prefix=name,
       **well_kwargs,
     ),
     plate_type="skirted",
@@ -139,6 +140,7 @@ def agilent_2_reservoir_144mL_Vb(name: str) -> Plate:
       bottom_type=WellBottomType.V,
       cross_section_type=CrossSectionType.RECTANGLE,
       material_z_thickness=1.15,
+      name_prefix=name,
     ),
   )
 

--- a/pylabrobot/resources/alpaqua/tube_racks.py
+++ b/pylabrobot/resources/alpaqua/tube_racks.py
@@ -28,5 +28,6 @@ def alpaqua_12_tuberack_5mL_eppis(name: str) -> ContainerRack:
       size_x=16.7,  # Holder width
       size_y=16.7,  # Holder depth
       size_z=0.0,  # Holder height
+      name_prefix=name,
     ),
   )

--- a/pylabrobot/resources/azenta/plates.py
+++ b/pylabrobot/resources/azenta/plates.py
@@ -57,6 +57,7 @@ def azenta_96_wellplate_200uL_Vb_4titudeframestar(name: str) -> Plate:
       compute_volume_from_height=(
         _compute_volume_from_height_Azenta4titudeFrameStar_96_wellplate_200ul_Vb
       ),
+      name_prefix=name,
     ),
   )
 

--- a/pylabrobot/resources/bioer/plates.py
+++ b/pylabrobot/resources/bioer/plates.py
@@ -62,6 +62,7 @@ def bioer_96_wellplate_2200uL_Vb(name: str) -> Plate:
       dz=6.0,  # calibrated (mounting offset for your deck)
       item_dx=9.0,  # measured
       item_dy=9.0,  # measured
+      name_prefix=name,
       **well_kwargs,
     ),
   )

--- a/pylabrobot/resources/biorad/plates.py
+++ b/pylabrobot/resources/biorad/plates.py
@@ -32,6 +32,7 @@ def biorad_384_wellplate_50uL_Vb(name: str) -> Plate:
       bottom_type=WellBottomType.V,
       material_z_thickness=1,  # measured
       cross_section_type=CrossSectionType.CIRCLE,
+      name_prefix=name,
     ),
   )
 

--- a/pylabrobot/resources/btx/plates.py
+++ b/pylabrobot/resources/btx/plates.py
@@ -62,6 +62,7 @@ def btx_96_wellplate_125uL_Fb_2mm(name: str) -> Plate:
       dz=4.0,  # measured manually
       item_dx=9.0,
       item_dy=9.0,
+      name_prefix=name,
       **well_kwargs,
     ),
   )

--- a/pylabrobot/resources/carrier_tests.py
+++ b/pylabrobot/resources/carrier_tests.py
@@ -331,6 +331,7 @@ class CarrierTests(unittest.TestCase):
         size_x=1,
         size_y=1,
         size_z=1,
+        name_prefix="plate1",
       ),
     )
     plate2 = Plate(
@@ -350,6 +351,7 @@ class CarrierTests(unittest.TestCase):
         size_x=1,
         size_y=1,
         size_z=1,
+        name_prefix="plate2",
       ),
     )
     carrier = PlateCarrier(

--- a/pylabrobot/resources/celltreat/plates.py
+++ b/pylabrobot/resources/celltreat/plates.py
@@ -68,6 +68,7 @@ def celltreat_6_wellplate_16300uL_Fb(name: str, lid: Optional[Lid] = None) -> Pl
       dz=3,  # manually calibrated
       item_dx=39.04,  # from plate specs/drawing
       item_dy=39.04,  # from plate specs/drawing
+      name_prefix=name,
       **well_kwargs,
     ),
   )
@@ -100,6 +101,7 @@ def celltreat_12_troughplate_15mL_Vb(name: str) -> Plate:
       item_dx=9.0,  # standard
       item_dy=9.0,  # standard
       cross_section_type=CrossSectionType.RECTANGLE,
+      name_prefix=name,
       **well_kwargs,
     ),
   )
@@ -146,6 +148,7 @@ def celltreat_24_wellplate_3300uL_Fb(name: str, with_lid: bool = False) -> Plate
       dz=20.2 - 17.2 - 2.3,  # from spec
       item_dx=19.2,  # from spec
       item_dy=19.2,  # from spec
+      name_prefix=name,
       **well_kwargs,
     ),
   )
@@ -202,6 +205,7 @@ def celltreat_96_wellplate_350uL_Ub(name: str, with_lid: bool = False) -> Plate:
       dz=1.92,  # calibrated manually
       item_dx=8.99,
       item_dy=8.99,
+      name_prefix=name,
       **well_kwargs,
     ),
   )
@@ -259,6 +263,7 @@ def celltreat_96_wellplate_350uL_Fb(name: str) -> Plate:
       dz=4.05,  # calibrated manually
       item_dx=9,
       item_dy=9,
+      name_prefix=name,
       **well_kwargs,
     ),
   )

--- a/pylabrobot/resources/cellvis/plates.py
+++ b/pylabrobot/resources/cellvis/plates.py
@@ -50,6 +50,7 @@ def cellvis_24_wellplate_3600uL_Fb(name: str, with_lid: bool = False) -> Plate:
       bottom_type=WellBottomType.FLAT,
       material_z_thickness=0.25,
       cross_section_type=CrossSectionType.CIRCLE,
+      name_prefix=name,
     ),
   )
 
@@ -93,6 +94,7 @@ def cellvis_96_wellplate_350uL_Fb(name: str, with_lid: bool = False) -> Plate:
       bottom_type=WellBottomType.FLAT,
       material_z_thickness=0.17,  # +- 0.005mm
       cross_section_type=CrossSectionType.CIRCLE,
+      name_prefix=name,
     ),
   )
 

--- a/pylabrobot/resources/corning/axygen/plates.py
+++ b/pylabrobot/resources/corning/axygen/plates.py
@@ -47,6 +47,7 @@ def cor_axy_24_wellplate_10mL_Vb(name: str) -> Plate:
       bottom_type=WellBottomType.V,
       compute_volume_from_height=_compute_volume_from_height_Cor_Axy_24_wellplate_10mL_Vb,
       cross_section_type=CrossSectionType.RECTANGLE,
+      name_prefix=name,
     ),
   )
 
@@ -94,6 +95,7 @@ def cor_axy_96_wellplate_500uL_Ub(name: str) -> Plate:
       bottom_type=WellBottomType.U,
       material_z_thickness=1.18,  # measured
       cross_section_type=CrossSectionType.CIRCLE,
+      name_prefix=name,
     ),
   )
 

--- a/pylabrobot/resources/corning/costar/plates.py
+++ b/pylabrobot/resources/corning/costar/plates.py
@@ -62,6 +62,7 @@ def cor_cos_6_wellplate_16800uL_Fb(name: str, lid: Optional[Lid] = None) -> Plat
       item_dx=39.12,  # from Corning Product Description
       item_dy=39.12,  # from Corning Product Description
       material_z_thickness=1.27,  # from Corning Product Description
+      name_prefix=name,
       **well_kwargs,
     ),
   )
@@ -130,6 +131,7 @@ def cor_cos_12_wellplate_6900uL_Fb(name: str, lid: Optional[Lid] = None) -> Plat
       item_dx=26.01,  # from Corning Product Description
       item_dy=26.01,  # from Corning Product Description
       material_z_thickness=1.27,  # from Corning Product Description
+      name_prefix=name,
       **well_kwargs,
     ),
   )
@@ -182,6 +184,7 @@ def cor_cos_24_wellplate_3470uL_Fb(name: str, lid: Optional[Lid] = None) -> Plat
       item_dx=19.3,  # from Corning Product Description
       item_dy=19.3,  # from Corning Product Description
       material_z_thickness=1.27,  # from Corning Product Description
+      name_prefix=name,
       **well_kwargs,
     ),
   )
@@ -238,6 +241,7 @@ def cor_cos_48_wellplate_1620uL_Fb(name: str, lid: Optional[Lid] = None) -> Plat
       item_dx=13.08,  # from Corning Product Description
       item_dy=13.08,  # from Corning Product Description
       material_z_thickness=1.27,  # from Corning Product Description
+      name_prefix=name,
       **well_kwargs,
     ),
   )

--- a/pylabrobot/resources/corning/falcon/plates.py
+++ b/pylabrobot/resources/corning/falcon/plates.py
@@ -57,6 +57,7 @@ def cor_falcon_96_wellplate_275uL_Fb(name: str, lid: Optional[Lid] = None) -> Pl
       compute_height_from_volume=lambda liquid_volume: compute_height_from_volume_conical_frustum(
         liquid_volume, BOTTOM_RADIUS, TOP_RADIUS
       ),
+      name_prefix=name,
     ),
   )
 
@@ -105,6 +106,7 @@ def cor_falcon_96_wellplate_250uL_Rb(name: str, lid: Optional[Lid] = None) -> Pl
       dz=1.80,  # calibrated manually by z-stepping down using a pipette.
       item_dx=8.99,  # measured
       item_dy=8.99,  # measured
+      name_prefix=name,
       **well_kwargs,
     ),
   )
@@ -158,6 +160,7 @@ def cor_falcon_96_wellplate_340uL_Fb_black(name: str, lid: Optional[Lid] = None)
       dz=6.7,  # calculated from spec, manually calibrated
       item_dx=9,
       item_dy=9,
+      name_prefix=name,
       **well_kwargs,
     ),
   )

--- a/pylabrobot/resources/corning/plates.py
+++ b/pylabrobot/resources/corning/plates.py
@@ -75,6 +75,7 @@ def cor_96_wellplate_360uL_Fb(name: str, with_lid: bool = False) -> Plate:
       cross_section_type=CrossSectionType.CIRCLE,
       max_volume=360,
       height_volume_data=_cor_96_wellplate_360uL_Fb_height_volume_data,
+      name_prefix=name,
     ),
   )
 
@@ -134,6 +135,7 @@ def cor_96_wellplate_2mL_Vb(name: str) -> Plate:
       cross_section_type=CrossSectionType.RECTANGLE,
       compute_volume_from_height=_compute_volume_from_height_Cor_96_wellplate_2mL_Vb,
       compute_height_from_volume=_compute_height_from_volume_Cor_96_wellplate_2mL_Vb,
+      name_prefix=name,
     ),
   )
 

--- a/pylabrobot/resources/deck_tests.py
+++ b/pylabrobot/resources/deck_tests.py
@@ -90,6 +90,7 @@ class DeckTests(unittest.TestCase):
         size_x=1,
         size_y=1,
         make_tip=hamilton_tip_300uL_filter,
+        name_prefix="tips",
       ),
     )
     pc = PlateCarrier(
@@ -123,6 +124,7 @@ class DeckTests(unittest.TestCase):
         size_x=1,
         size_y=1,
         size_z=1,
+        name_prefix="plate",
       ),
     )
     custom_1.assign_child_resource(tc, location=Coordinate(0, 0, 0))

--- a/pylabrobot/resources/eppendorf/plates.py
+++ b/pylabrobot/resources/eppendorf/plates.py
@@ -96,6 +96,7 @@ def Eppendorf_96_wellplate_250ul_Vb(name: str, with_lid: bool = False) -> Plate:
       cross_section_type=CrossSectionType.CIRCLE,
       compute_volume_from_height=(_compute_volume_from_height_Eppendorf_96_wellplate_250ul_Vb),
       compute_height_from_volume=(_compute_height_from_volume_Eppendorf_96_wellplate_250ul_Vb),
+      name_prefix=name,
     ),
   )
 
@@ -134,6 +135,7 @@ def eppendorf_96_wellplate_500ul_Vb(name: str) -> Plate:
       cross_section_type=CrossSectionType.CIRCLE,
       compute_volume_from_height=None,
       compute_height_from_volume=None,
+      name_prefix=name,
     ),
   )
 
@@ -172,6 +174,7 @@ def eppendorf_96_wellplate_1000ul_Vb(name: str) -> Plate:
       cross_section_type=CrossSectionType.CIRCLE,
       compute_volume_from_height=None,
       compute_height_from_volume=None,
+      name_prefix=name,
     ),
   )
 
@@ -210,5 +213,6 @@ def eppendorf_96_wellplate_2000ul_vb(name: str) -> Plate:
       cross_section_type=CrossSectionType.RECTANGLE,
       compute_volume_from_height=None,
       compute_height_from_volume=None,
+      name_prefix=name,
     ),
   )

--- a/pylabrobot/resources/greiner/plates.py
+++ b/pylabrobot/resources/greiner/plates.py
@@ -79,6 +79,7 @@ def Greiner_384_wellplate_28ul_Fb(name: str, with_lid: bool = False) -> Plate:
       cross_section_type=CrossSectionType.CIRCLE,
       # compute_volume_from_height=_compute_volume_from_height_Greiner_384_wellplate_28ul_Fb,
       # compute_height_from_volume=_compute_height_from_volume_Greiner_384_wellplate_28ul_Fb,
+      name_prefix=name,
     ),
   )
 
@@ -116,5 +117,6 @@ def greiner_96_wellplate_200uL_Vb(name: str, with_lid: bool = False) -> Plate:
       cross_section_type=CrossSectionType.CIRCLE,
       bottom_type=WellBottomType.V,
       max_volume=200,  # from spec (0.2 mL)
+      name_prefix=name,
     ),
   )

--- a/pylabrobot/resources/hamilton/hamilton_decks.py
+++ b/pylabrobot/resources/hamilton/hamilton_decks.py
@@ -492,7 +492,7 @@ class HamiltonSTARDeck(HamiltonDeck):
       if with_teaching_rack:
         tip_spots = [
           TipSpot(
-            name=f"tip_spot_{i}",
+            name=f"teaching_tip_rack_tip_spot_{i}",
             size_x=9.0,
             size_y=9.0,
             size_z=0,

--- a/pylabrobot/resources/hamilton/tip_racks.py
+++ b/pylabrobot/resources/hamilton/tip_racks.py
@@ -48,6 +48,7 @@ def hamilton_96_tiprack_10uL_filter(name: str, with_tips: bool = True) -> TipRac
       size_x=9.0,
       size_y=9.0,
       make_tip=hamilton_tip_10uL_filter,
+      name_prefix=name,
     ),
     with_tips=with_tips,
   )
@@ -76,6 +77,7 @@ def hamilton_96_tiprack_10uL(name: str, with_tips: bool = True) -> TipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=hamilton_tip_10uL,
+      name_prefix=name,
     ),
     with_tips=with_tips,
   )
@@ -106,6 +108,7 @@ def hamilton_96_tiprack_50uL_filter(name: str, with_tips: bool = True) -> TipRac
       size_x=9.0,
       size_y=9.0,
       make_tip=hamilton_tip_50uL_filter,
+      name_prefix=name,
     ),
     with_tips=with_tips,
   )
@@ -133,6 +136,7 @@ def hamilton_96_tiprack_50uL(name: str, with_tips: bool = True) -> TipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=hamilton_tip_50uL,
+      name_prefix=name,
     ),
     with_tips=with_tips,
   )
@@ -163,6 +167,7 @@ def hamilton_96_tiprack_50uL_NTR(name: str, with_tips: bool = True) -> NestedTip
       size_x=8.15,
       size_y=8.15,
       make_tip=hamilton_tip_50uL,
+      name_prefix=name,
     ),
     with_tips=with_tips,
   )
@@ -193,6 +198,7 @@ def hamilton_96_tiprack_300uL_filter(name: str, with_tips: bool = True) -> TipRa
       size_x=9.0,
       size_y=9.0,
       make_tip=hamilton_tip_300uL_filter,
+      name_prefix=name,
     ),
     with_tips=with_tips,
   )
@@ -220,6 +226,7 @@ def hamilton_96_tiprack_300uL(name: str, with_tips: bool = True) -> TipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=hamilton_tip_300uL,
+      name_prefix=name,
     ),
     with_tips=with_tips,
   )
@@ -247,6 +254,7 @@ def hamilton_96_tiprack_300uL_filter_slim(name: str, with_tips: bool = True) -> 
       size_x=9.0,
       size_y=9.0,
       make_tip=hamilton_tip_300uL_filter_slim,
+      name_prefix=name,
     ),
     with_tips=with_tips,
   )
@@ -274,6 +282,7 @@ def hamilton_96_tiprack_300uL_filter_ultrawide(name: str, with_tips: bool = True
       size_x=9.0,
       size_y=9.0,
       make_tip=hamilton_tip_300uL_filter_ultrawide,
+      name_prefix=name,
     ),
     with_tips=with_tips,
   )
@@ -305,6 +314,7 @@ def hamilton_96_tiprack_1000uL_filter(name: str, with_tips: bool = True) -> TipR
       size_x=9.0,
       size_y=9.0,
       make_tip=hamilton_tip_1000uL_filter,
+      name_prefix=name,
     ),
     with_tips=with_tips,
   )
@@ -332,6 +342,7 @@ def hamilton_96_tiprack_1000uL(name: str, with_tips: bool = True) -> TipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=hamilton_tip_1000uL,
+      name_prefix=name,
     ),
     with_tips=with_tips,
   )
@@ -370,6 +381,7 @@ def hamilton_96_tiprack_1000uL_filter_wide(name: str, with_tips: bool = True) ->
       size_x=9.0,
       size_y=9.0,
       make_tip=hamilton_tip_1000uL_filter_wide,
+      name_prefix=name,
     ),
     with_tips=with_tips,
   )
@@ -408,6 +420,7 @@ def hamilton_96_tiprack_1000uL_filter_ultrawide(name: str, with_tips: bool = Tru
       size_x=9.0,
       size_y=9.0,
       make_tip=hamilton_tip_1000uL_filter_ultrawide,
+      name_prefix=name,
     ),
     with_tips=with_tips,
   )
@@ -438,6 +451,7 @@ def hamilton_24_tiprack_4000uL_filter(name: str, with_tips: bool = True) -> TipR
       size_x=18.0,
       size_y=18.0,
       make_tip=hamilton_tip_4000uL_filter,
+      name_prefix=name,
     ),
     with_tips=with_tips,
   )
@@ -468,6 +482,7 @@ def hamilton_24_tiprack_5000uL(name: str, with_tips: bool = True) -> TipRack:
       size_x=18.0,
       size_y=18.0,
       make_tip=hamilton_tip_5000uL,
+      name_prefix=name,
     ),
     with_tips=with_tips,
   )

--- a/pylabrobot/resources/imcs/tip_racks.py
+++ b/pylabrobot/resources/imcs/tip_racks.py
@@ -43,6 +43,7 @@ def imcs_96_tiprack_1000uL_filter(name: str, with_tips: bool = True) -> TipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=imcs_tip_1000uL,
+      name_prefix=name,
     ),
     with_tips=with_tips,
   )
@@ -117,6 +118,7 @@ def imcs_96_tiprack_300uL_filter(name: str, with_tips: bool = True) -> TipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=imcs_tip_300uL,
+      name_prefix=name,
     ),
     with_tips=with_tips,
   )

--- a/pylabrobot/resources/itemized_resource.py
+++ b/pylabrobot/resources/itemized_resource.py
@@ -90,6 +90,7 @@ class ItemizedResource(Resource, Generic[T], metaclass=ABCMeta):
       Creating a plate with 1 Well in a dict:
 
         >>> from pylabrobot.resources import Plate
+          name_prefix=name,
         >>> plate = Plate("plate", size_x=1, size_y=1, size_z=1,
         ...   ordered_items={"A1": Well("well", size_x=1, size_y=1, size_z=1)})
     """
@@ -104,7 +105,6 @@ class ItemizedResource(Resource, Generic[T], metaclass=ABCMeta):
       for item in ordered_items.values():
         if item.location is None:
           raise ValueError("Item location must be specified if supplied at initialization.")
-        item.name = f"{self.name}_{item.name}"  # prefix item name with resource name
         self.assign_child_resource(item, location=item.location)
       self._ordering = OrderedDict(
         (identifier, item.name) for identifier, item in ordered_items.items()

--- a/pylabrobot/resources/itemized_resource_tests.py
+++ b/pylabrobot/resources/itemized_resource_tests.py
@@ -38,6 +38,7 @@ class TestItemizedResource(unittest.TestCase):
         size_x=9,
         size_y=9,
         size_z=9,
+        name_prefix="plate",
       ),
     )
     self.plate.location = Coordinate.zero()
@@ -254,6 +255,7 @@ class TestItemizedResource1536(unittest.TestCase):
         size_x=2.3,
         size_y=2.3,
         size_z=8.6,
+        name_prefix="plate_1536",
       ),
     )
 
@@ -324,6 +326,7 @@ class TestItemizedResourceWithLid(unittest.TestCase):
         size_x=9,
         size_y=9,
         size_z=9,
+        name_prefix="plate",
       ),
     )
 
@@ -394,14 +397,16 @@ class TestItemizedResourceTraversal(unittest.TestCase):
     def item_id(row, column):
       return "ABC"[row] + str(column + 1)
 
-    items = [
-      Resource(name=item_id(row, col), size_x=1, size_y=1, size_z=1).at(Coordinate(col, row, 0))
+    items = {
+      item_id(row, col): Resource(
+        name=f"test_resource_{item_id(row, col)}", size_x=1, size_y=1, size_z=1
+      ).at(Coordinate(col, row, 0))
       for col in range(3)
       for row in range(3)
-    ]
+    }
     self.ir = ItemizedResource(
       "test_resource",
-      ordered_items={item.name: item for item in items},
+      ordered_items=items,
       size_x=3,
       size_y=3,
       size_z=1,

--- a/pylabrobot/resources/nest/plates.py
+++ b/pylabrobot/resources/nest/plates.py
@@ -48,6 +48,7 @@ def nest_1_troughplate_195000uL_Vb(name: str) -> Plate:
       dz=3.55,  # from datasheet
       item_dx=9.0,  # from datasheet
       item_dy=9.0,  # from datasheet
+      name_prefix=name,
       **well_kwargs,
     ),
   )
@@ -96,6 +97,7 @@ def nest_1_troughplate_185000uL_Vb(name: str) -> Plate:
       dz=3.55,  # from datasheet
       item_dx=9.0,  # from datasheet
       item_dy=9.0,  # from datasheet
+      name_prefix=name,
       **well_kwargs,
     ),
   )
@@ -142,6 +144,7 @@ def nest_8_troughplate_22000uL_Vb(name: str) -> Plate:
       dz=3.55,  # from datasheet
       item_dx=9.0,  # from datasheet
       item_dy=9.0,  # from datasheet
+      name_prefix=name,
       **well_kwargs,
     ),
   )
@@ -186,6 +189,7 @@ def nest_12_troughplate_15000uL_Vb(name: str) -> Plate:
       dz=3.55,  # from datasheet
       item_dx=9.0,  # from datasheet
       item_dy=9.0,  # from datasheet
+      name_prefix=name,
       **well_kwargs,
     ),
   )
@@ -218,5 +222,6 @@ def NEST_96_wellplate_2200uL_Ub(name: str) -> Plate:
       cross_section_type=CrossSectionType.RECTANGLE,
       bottom_type=WellBottomType.U,
       max_volume=2200,  # from spec (2.2 mL)
+      name_prefix=name,
     ),
   )

--- a/pylabrobot/resources/opentrons/load.py
+++ b/pylabrobot/resources/opentrons/load.py
@@ -72,7 +72,7 @@ def load_ot_tip_rack(
         )
 
       tip_spot = TipSpot(
-        name=item,
+        name=f"{plr_resource_name}_{item}",
         size_x=well_size_x,
         size_y=well_size_y,
         make_tip=make_tip,
@@ -127,7 +127,7 @@ def load_ot_tube_rack(
       well_size_z = well_data["depth"]
 
       resource_holder = ResourceHolder(
-        name=item,
+        name=f"{plr_resource_name}_{item}",
         size_x=well_size_x,
         size_y=well_size_y,
         size_z=well_size_z,

--- a/pylabrobot/resources/opentrons/tube_racks.py
+++ b/pylabrobot/resources/opentrons/tube_racks.py
@@ -34,6 +34,7 @@ def opentrons_24_tuberack_generic_1point5ml_snapcap_short(name: str) -> TubeRack
       size_x=well_size_x,
       size_y=well_size_y,
       size_z=WELL_DEPTH,
+      name_prefix=name,
     ),
   )
 

--- a/pylabrobot/resources/perkin_elmer/plates.py
+++ b/pylabrobot/resources/perkin_elmer/plates.py
@@ -38,6 +38,7 @@ def PerkinElmer_96_wellplate_400ul_Fb(name: str) -> Plate:
       dz=2.88,  # caliper
       item_dx=9,
       item_dy=9,
+      name_prefix=name,
       **well_kwargs,
     ),
   )

--- a/pylabrobot/resources/porvair/plates.py
+++ b/pylabrobot/resources/porvair/plates.py
@@ -90,6 +90,7 @@ def Porvair_6_reservoir_47ml_Vb(name: str, with_lid: bool = False) -> Plate:
       cross_section_type=CrossSectionType.RECTANGLE,
       compute_volume_from_height=_compute_volume_from_height_Porvair_6_reservoir_47ml_Vb,
       compute_height_from_volume=_compute_height_from_volume_Porvair_6_reservoir_47ml_Vb,
+      name_prefix=name,
     ),
   )
 
@@ -150,6 +151,7 @@ def Porvair_24_wellplate_Vb(name: str, lid: Optional[Lid] = None) -> Plate:
       dz=5.8,  # measured and calibrated manually
       item_dx=9.05,
       item_dy=36,
+      name_prefix=name,
       **well_kwargs,
     ),
   )

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -833,7 +833,8 @@ class Resource(SerializableMixin):
   def named(self, name: str) -> Self:
     """Return a copy of this resource with the given name."""
     new_resource = self.copy()
-    new_resource.name = name
+    # The copy is new and in no tree, so this finishes building it rather than renaming anything.
+    new_resource._name = name
     return new_resource
 
   def center(self, x: bool = True, y: bool = True, z: bool = False) -> Coordinate:

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -235,14 +235,18 @@ class Resource(SerializableMixin):
 
   @name.setter
   def name(self, name: str):
-    """Set the name of this resource.
+    """Refuse the change: a resource's name is how it is identified.
 
-    Will raise a `RuntimeError` if the resource is assigned to another resource.
+    Raises:
+      AttributeError: Always. The name is the resource's identifier - it is unique across the tree,
+        it is what `get_resource` finds a resource by, and it is the key state is serialized under.
+        Anything built from it, such as the wells of a plate, takes it at construction, so a name
+        that changed afterwards would leave those disagreeing with it.
     """
-
-    if self.parent is not None:
-      raise RuntimeError("Cannot change the name of a resource that is assigned.")
-    self._name = name
+    raise AttributeError(
+      f"cannot rename {self._name!r} to {name!r}: a resource's name is its identifier and is fixed "
+      "when it is created. Create the resource with the name you want instead."
+    )
 
   def __eq__(self, other):
     return (

--- a/pylabrobot/resources/revvity/plates.py
+++ b/pylabrobot/resources/revvity/plates.py
@@ -76,5 +76,6 @@ def Revvity_384_wellplate_28ul_Ub(name: str, with_lid: bool = False) -> Plate:
       material_z_thickness=1.0,
       cross_section_type=CrossSectionType.CIRCLE,
       compute_volume_from_height=_compute_volume_from_height_Revvity_384_wellplate_28ul_Ub,
+      name_prefix=name,
     ),
   )

--- a/pylabrobot/resources/tecan/plates.py
+++ b/pylabrobot/resources/tecan/plates.py
@@ -90,6 +90,7 @@ def Microplate_96_Well(name: str, with_lid: bool = False) -> TecanPlate:
           size_x=9.0,
           size_y=9.0,
           size_z=22.6,
+          name_prefix=name,
         ),
       )
   """
@@ -117,6 +118,7 @@ def Microplate_96_Well(name: str, with_lid: bool = False) -> TecanPlate:
       size_x=9.0,
       size_y=9.0,
       size_z=22.6,
+      name_prefix=name,
     ),
   )
 
@@ -158,6 +160,7 @@ def Microplate_portrait_96_Well(name: str, with_lid: bool = False) -> TecanPlate
       size_x=9.0,
       size_y=9.0,
       size_z=11.0,
+      name_prefix=name,
     ),
   )
 
@@ -199,6 +202,7 @@ def DeepWell_96_Well(name: str, with_lid: bool = False) -> TecanPlate:
       size_x=9.0,
       size_y=9.0,
       size_z=39.0,
+      name_prefix=name,
     ),
   )
 
@@ -240,6 +244,7 @@ def HalfDeepWell_384_Well(name: str, with_lid: bool = False) -> TecanPlate:
       size_x=4.5,
       size_y=4.5,
       size_z=18.8,
+      name_prefix=name,
     ),
   )
 
@@ -281,6 +286,7 @@ def DeepWell_portrait_96_Well(name: str, with_lid: bool = False) -> TecanPlate:
       size_x=9.0,
       size_y=9.0,
       size_z=38.0,
+      name_prefix=name,
     ),
   )
 
@@ -322,6 +328,7 @@ def Plate_portrait_384_Well(name: str, with_lid: bool = False) -> TecanPlate:
       size_x=4.5,
       size_y=4.5,
       size_z=11.0,
+      name_prefix=name,
     ),
   )
 
@@ -363,6 +370,7 @@ def Macherey_Nagel_Plate_96_Well(name: str, with_lid: bool = False) -> TecanPlat
       size_x=8.9,
       size_y=8.9,
       size_z=29.9,
+      name_prefix=name,
     ),
   )
 
@@ -404,6 +412,7 @@ def Qiagen_Plate_96_Well(name: str, with_lid: bool = False) -> TecanPlate:
       size_x=8.9,
       size_y=8.9,
       size_z=26.6,
+      name_prefix=name,
     ),
   )
 
@@ -445,6 +454,7 @@ def AB_Plate_96_Well(name: str, with_lid: bool = False) -> TecanPlate:
       size_x=9.0,
       size_y=9.0,
       size_z=19.5,
+      name_prefix=name,
     ),
   )
 
@@ -486,6 +496,7 @@ def PCR_Plate_96_Well(name: str, with_lid: bool = False) -> TecanPlate:
       size_x=9.0,
       size_y=9.0,
       size_z=19.5,
+      name_prefix=name,
     ),
   )
 
@@ -527,6 +538,7 @@ def DeepWell_Greiner_1536_Well(name: str, with_lid: bool = False) -> TecanPlate:
       size_x=2.3,
       size_y=2.3,
       size_z=8.6,
+      name_prefix=name,
     ),
   )
 
@@ -568,6 +580,7 @@ def Hibase_Greiner_1536_Well(name: str, with_lid: bool = False) -> TecanPlate:
       size_x=2.3,
       size_y=2.3,
       size_z=5.4,
+      name_prefix=name,
     ),
   )
 
@@ -609,6 +622,7 @@ def Lowbase_Greiner_1536_Well(name: str, with_lid: bool = False) -> TecanPlate:
       size_x=2.3,
       size_y=2.3,
       size_z=6.2,
+      name_prefix=name,
     ),
   )
 
@@ -650,6 +664,7 @@ def Separation_Plate_96_Well(name: str, with_lid: bool = False) -> TecanPlate:
       size_x=8.9,
       size_y=8.9,
       size_z=26.6,
+      name_prefix=name,
     ),
   )
 
@@ -691,6 +706,7 @@ def DeepWell_square_96_Well(name: str, with_lid: bool = False) -> TecanPlate:
       size_x=9.0,
       size_y=9.0,
       size_z=39.0,
+      name_prefix=name,
     ),
   )
 
@@ -732,6 +748,7 @@ def CaCo2_Plate_24_Well(name: str, with_lid: bool = False) -> TecanPlate:
       size_x=19.3,
       size_y=19.3,
       size_z=6.5,
+      name_prefix=name,
     ),
   )
 
@@ -774,6 +791,7 @@ def Plate_384_Well(name: str, with_lid: bool = False) -> TecanPlate:
       size_x=4.5,
       size_y=4.5,
       size_z=12.1,
+      name_prefix=name,
     ),
   )
 
@@ -816,6 +834,7 @@ def Microplate_24_Well(name: str, with_lid: bool = False) -> TecanPlate:
       size_x=19.6,
       size_y=19.6,
       size_z=17.6,
+      name_prefix=name,
     ),
   )
 
@@ -857,6 +876,7 @@ def TecanExtractionPlate_96_Well(name: str, with_lid: bool = False) -> TecanPlat
       size_x=9.0,
       size_y=9.0,
       size_z=23.0,
+      name_prefix=name,
     ),
   )
 
@@ -899,5 +919,6 @@ def Microplate_48_Well(name: str, with_lid: bool = False) -> TecanPlate:
       size_x=13.0,
       size_y=13.0,
       size_z=17.3,
+      name_prefix=name,
     ),
   )

--- a/pylabrobot/resources/tecan/tip_racks.py
+++ b/pylabrobot/resources/tecan/tip_racks.py
@@ -120,6 +120,7 @@ def DiTi_100ul_Te_MO(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_100ul_Te_MO_tip,
+      name_prefix=name,
     ),
   )
 
@@ -147,6 +148,7 @@ def DiTi_50ul_Te_MO(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_50ul_Te_MO_tip,
+      name_prefix=name,
     ),
   )
 
@@ -174,6 +176,7 @@ def DiTi_200ul_Te_MO(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_200ul_Te_MO_tip,
+      name_prefix=name,
     ),
   )
 
@@ -201,6 +204,7 @@ def DiTi_100ul_Filter_Te_MO(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_100ul_Filter_Te_MO_tip,
+      name_prefix=name,
     ),
   )
 
@@ -228,6 +232,7 @@ def DiTi_200ul_Filter_Te_MO(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_200ul_Filter_Te_MO_tip,
+      name_prefix=name,
     ),
   )
 
@@ -256,6 +261,7 @@ def Adapter_96_DiTi_MCA384(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=Adapter_96_DiTi_MCA384_tip,
+      name_prefix=name,
     ),
   )
 
@@ -284,6 +290,7 @@ def Adapter_DiTi_Combo_MCA384(name: str) -> TecanTipRack:
       size_x=4.5,
       size_y=4.5,
       make_tip=Adapter_DiTi_Combo_MCA384_tip,
+      name_prefix=name,
     ),
   )
 
@@ -312,6 +319,7 @@ def Adapter_DiTi_MCA384(name: str) -> TecanTipRack:
       size_x=4.5,
       size_y=4.5,
       make_tip=Adapter_DiTi_MCA384_tip,
+      name_prefix=name,
     ),
   )
 
@@ -340,6 +348,7 @@ def DiTi_100ul_Filter_MCA96(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_100ul_Filter_MCA96_tip,
+      name_prefix=name,
     ),
   )
 
@@ -368,6 +377,7 @@ def DiTi_100ul_MCA96(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_100ul_MCA96_tip,
+      name_prefix=name,
     ),
   )
 
@@ -396,6 +406,7 @@ def DiTi_200ul_Filter_MCA96(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_200ul_Filter_MCA96_tip,
+      name_prefix=name,
     ),
   )
 
@@ -424,6 +435,7 @@ def DiTi_200ul_MCA96(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_200ul_MCA96_tip,
+      name_prefix=name,
     ),
   )
 
@@ -452,6 +464,7 @@ def DiTi_50ul_MCA96(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_50ul_MCA96_tip,
+      name_prefix=name,
     ),
   )
 
@@ -480,6 +493,7 @@ def Base_Nested_DiTi_MCA96(name: str) -> TecanTipRack:
       size_x=33.0,
       size_y=33.0,
       make_tip=Base_Nested_DiTi_MCA96_tip,
+      name_prefix=name,
     ),
   )
 
@@ -508,6 +522,7 @@ def DiTi_100ul_Nested_MCA96(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_100ul_Nested_MCA96_tip,
+      name_prefix=name,
     ),
   )
 
@@ -535,6 +550,7 @@ def DiTi_100ul_SBS_MCA96(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_100ul_SBS_MCA96_tip,
+      name_prefix=name,
     ),
   )
 
@@ -562,6 +578,7 @@ def DiTi_200ul_SBS_MCA96(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_200ul_SBS_MCA96_tip,
+      name_prefix=name,
     ),
   )
 
@@ -589,6 +606,7 @@ def DiTi_50ul_SBS_MCA96(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_50ul_SBS_MCA96_tip,
+      name_prefix=name,
     ),
   )
 
@@ -617,6 +635,7 @@ def DiTi_50ul_Nested_MCA96(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_50ul_Nested_MCA96_tip,
+      name_prefix=name,
     ),
   )
 
@@ -645,6 +664,7 @@ def Adapter_96_DiTi_1to1_MCA384(name: str) -> TecanTipRack:
       size_x=9.5,
       size_y=9.5,
       make_tip=Adapter_96_DiTi_1to1_MCA384_tip,
+      name_prefix=name,
     ),
   )
 
@@ -673,6 +693,7 @@ def DiTi_200ul_Nested_MCA96(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_200ul_Nested_MCA96_tip,
+      name_prefix=name,
     ),
   )
 
@@ -701,6 +722,7 @@ def DiTi_200ul_w_b_filter_MCA96(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_200ul_w_b_filter_MCA96_tip,
+      name_prefix=name,
     ),
   )
 
@@ -729,6 +751,7 @@ def DiTi_200ul_wide_bore_MCA96(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_200ul_wide_bore_MCA96_tip,
+      name_prefix=name,
     ),
   )
 
@@ -757,6 +780,7 @@ def Adapter_96_DiTi_4to1_MCA384(name: str) -> TecanTipRack:
       size_x=9.5,
       size_y=9.5,
       make_tip=Adapter_96_DiTi_4to1_MCA384_tip,
+      name_prefix=name,
     ),
   )
 
@@ -784,6 +808,7 @@ def DiTi_500ul_Filter_SBS_MCA96(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_500ul_Filter_SBS_MCA96_tip,
+      name_prefix=name,
     ),
   )
 
@@ -811,6 +836,7 @@ def DiTi_500ul_SBS_MCA96(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_500ul_SBS_MCA96_tip,
+      name_prefix=name,
     ),
   )
 
@@ -839,6 +865,7 @@ def DiTi_Nested_Waste_MCA384(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_Nested_Waste_MCA384_tip,
+      name_prefix=name,
     ),
   )
 
@@ -866,6 +893,7 @@ def DiTi_1000ul_SBS_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_1000ul_SBS_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -893,6 +921,7 @@ def DiTi_200ul_SBS_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_200ul_SBS_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -920,6 +949,7 @@ def DiTi_50ul_SBS_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_50ul_SBS_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -948,6 +978,7 @@ def DiTi_5000ul_LiHa(name: str) -> TecanTipRack:
       size_x=18.0,
       size_y=18.0,
       make_tip=DiTi_5000ul_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -976,6 +1007,7 @@ def DiTi_5000ul_Filter_LiHa(name: str) -> TecanTipRack:
       size_x=18.0,
       size_y=18.0,
       make_tip=DiTi_5000ul_Filter_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1004,6 +1036,7 @@ def DiTi_125ul_Filter_MCA384(name: str) -> TecanTipRack:
       size_x=4.5,
       size_y=4.5,
       make_tip=DiTi_125ul_Filter_MCA384_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1032,6 +1065,7 @@ def DiTi_125ul_MCA384(name: str) -> TecanTipRack:
       size_x=4.5,
       size_y=4.5,
       make_tip=DiTi_125ul_MCA384_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1060,6 +1094,7 @@ def DiTi_15ul_Filter_MCA384(name: str) -> TecanTipRack:
       size_x=4.5,
       size_y=4.5,
       make_tip=DiTi_15ul_Filter_MCA384_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1088,6 +1123,7 @@ def DiTi_15ul_MCA384(name: str) -> TecanTipRack:
       size_x=4.5,
       size_y=4.5,
       make_tip=DiTi_15ul_MCA384_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1116,6 +1152,7 @@ def DiTi_50ul_Filter_MCA384(name: str) -> TecanTipRack:
       size_x=4.5,
       size_y=4.5,
       make_tip=DiTi_50ul_Filter_MCA384_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1144,6 +1181,7 @@ def DiTi_50ul_MCA384(name: str) -> TecanTipRack:
       size_x=4.5,
       size_y=4.5,
       make_tip=DiTi_50ul_MCA384_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1172,6 +1210,7 @@ def DiTi_1000ul_Filter_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_1000ul_Filter_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1200,6 +1239,7 @@ def DiTi_1000ul_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_1000ul_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1228,6 +1268,7 @@ def DiTi_10ul_Filter_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_10ul_Filter_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1256,6 +1297,7 @@ def DiTi_10ul_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_10ul_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1284,6 +1326,7 @@ def DiTi_200ul_Filter_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_200ul_Filter_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1312,6 +1355,7 @@ def DiTi_200ul_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_200ul_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1340,6 +1384,7 @@ def DiTi_50ul_Filter_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_50ul_Filter_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1368,6 +1413,7 @@ def DiTi_50ul_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_50ul_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1396,6 +1442,7 @@ def DiTi_350ul_Nested_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_350ul_Nested_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1424,6 +1471,7 @@ def DiTi_10ul_Filter_LiHa_L(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_10ul_Filter_LiHa_L_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1452,6 +1500,7 @@ def DiTi_10ul_Filter_Nested_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_10ul_Filter_Nested_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1480,6 +1529,7 @@ def DiTi_10ul_LiHa_L(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_10ul_LiHa_L_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1508,6 +1558,7 @@ def DiTi_10ul_Nested_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_10ul_Nested_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1536,6 +1587,7 @@ def DiTi_10ul_SBS_Filter_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_10ul_SBS_Filter_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1564,6 +1616,7 @@ def DiTi_10ul_SBS_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_10ul_SBS_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1592,6 +1645,7 @@ def DiTi_1000ul_W_B_Filter_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_1000ul_W_B_Filter_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1620,6 +1674,7 @@ def DiTi_1000ul_CL_Filter_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_1000ul_CL_Filter_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1648,6 +1703,7 @@ def DiTi_1000ul_CL_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_1000ul_CL_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1676,6 +1732,7 @@ def DiTi_200ul_CL_Filter_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_200ul_CL_Filter_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1704,6 +1761,7 @@ def DiTi_200ul_CL_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_200ul_CL_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1732,6 +1790,7 @@ def DiTi_50ul_CL_Filter_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_50ul_CL_Filter_LiHa_tip,
+      name_prefix=name,
     ),
   )
 
@@ -1760,5 +1819,6 @@ def DiTi_50ul_CL_LiHa(name: str) -> TecanTipRack:
       size_x=9.0,
       size_y=9.0,
       make_tip=DiTi_50ul_CL_LiHa_tip,
+      name_prefix=name,
     ),
   )

--- a/pylabrobot/resources/thermo_fisher/plates.py
+++ b/pylabrobot/resources/thermo_fisher/plates.py
@@ -115,6 +115,7 @@ def Thermo_TS_96_wellplate_1200ul_Rb(name: str, with_lid: bool = False) -> Plate
       cross_section_type=CrossSectionType.RECTANGLE,
       compute_volume_from_height=(_compute_volume_from_height_Thermo_TS_96_wellplate_1200ul_Rb),
       compute_height_from_volume=(_compute_height_from_volume_Thermo_TS_96_wellplate_1200ul_Rb),
+      name_prefix=name,
     ),
   )
 
@@ -213,6 +214,7 @@ def Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate(name: str, with_lid: bool = Fals
       compute_height_from_volume=(
         _compute_height_from_volume_Thermo_AB_96_wellplate_300ul_Vb_EnduraPlate
       ),
+      name_prefix=name,
     ),
   )
 
@@ -252,6 +254,7 @@ def Thermo_Nunc_96_well_plate_1300uL_Rb(name: str) -> Plate:
       compute_height_from_volume=lambda liquid_volume: (
         liquid_volume / (math.pi * ((well_diameter / 2) ** 2))
       ),
+      name_prefix=name,
     ),
   )
 
@@ -345,6 +348,7 @@ def thermo_AB_96_wellplate_300ul_Vb_MicroAmp(name: str, with_lid: bool = False) 
       compute_height_from_volume=(
         _compute_height_from_volume_thermo_AB_96_wellplate_300ul_Vb_MicroAmp
       ),
+      name_prefix=name,
     ),
   )
 
@@ -378,6 +382,7 @@ def thermo_AB_384_wellplate_40uL_Vb_MicroAmp(name: str) -> Plate:
       bottom_type=WellBottomType.V,
       material_z_thickness=0.61,
       cross_section_type=CrossSectionType.CIRCLE,
+      name_prefix=name,
     ),
   )
 
@@ -417,6 +422,7 @@ def thermo_nunc_1_troughplate_90000uL_Fb_omnitray(name: str) -> Plate:
       cross_section_type=CrossSectionType.RECTANGLE,
       # compute_volume_from_height=None,
       # compute_height_from_volume=None,
+      name_prefix=name,
     ),
   )
 
@@ -453,6 +459,7 @@ def Thermo_TS_Nunc_96_wellplate_300uL_Fb(name: str, with_lid: bool = False) -> P
       size_z=12.1,  # from spec
       bottom_type=WellBottomType.FLAT,  # flat bottom wells
       material_z_thickness=2.2,  # from spec
+      name_prefix=name,
     ),
   )
 
@@ -500,5 +507,6 @@ def thermo_TS_nalgene_1_troughplate_300mL_Fb(name: str) -> Plate:
       bottom_type=WellBottomType.FLAT,  # from spec
       cross_section_type=CrossSectionType.RECTANGLE,  # rectangle wells
       material_z_thickness=1.15,  # measured.
+      name_prefix=name,
     ),
   )

--- a/pylabrobot/resources/utils.py
+++ b/pylabrobot/resources/utils.py
@@ -221,6 +221,7 @@ def create_ordered_items_2d(
   dz: float,
   item_dx: Optional[float],
   item_dy: Optional[float],
+  name_prefix: Optional[str] = None,
   **kwargs,
 ) -> Dict[str, T]:
   """Make ordered resources in a 2D grid, with the keys being the identifiers in transposed
@@ -235,12 +236,19 @@ def create_ordered_items_2d(
     dz: The z coordinate for all items
     item_dx: The spacing of the items in the x direction (origin to origin), or None when num_items_x is 1
     item_dy: The spacing of the items in the y direction (origin to origin), or None when num_items_y is 1
+    name_prefix: What the resource holding these items is called. Every item is named after it, so
+      a well of the plate `plate` is `plate_well_A1`. Pass the name the holder is being created
+      with; an item cannot be renamed once it exists.
     **kwargs: Additional keyword arguments to pass to the resource constructor
 
   Returns:
     A dict of resources. The keys are the identifiers in transposed MS-Excel format, so the top
     left item is "A1", the item to the bottom is "B1", the item to the right is "A2", and so on.
   """
+
+  def name_for(i: int, j: int) -> str:
+    item = f"{klass.__name__.lower()}_{row_index_to_label(j)}{i + 1}"
+    return item if name_prefix is None else f"{name_prefix}_{item}"
 
   items = create_equally_spaced_2d(
     klass=klass,
@@ -252,7 +260,7 @@ def create_ordered_items_2d(
     item_dx=item_dx,
     item_dy=item_dy,
     # Named here rather than renamed afterwards: a name is fixed when a resource is created.
-    name_for=lambda i, j: f"{klass.__name__.lower()}_{row_index_to_label(j)}{i + 1}",
+    name_for=name_for,
     **kwargs,
   )
   keys = [f"{row_index_to_label(j)}{i + 1}" for i in range(num_items_x) for j in range(num_items_y)]

--- a/pylabrobot/resources/utils.py
+++ b/pylabrobot/resources/utils.py
@@ -1,6 +1,6 @@
 import re
 from itertools import groupby
-from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar
 
 from pylabrobot.resources.coordinate import Coordinate
 from pylabrobot.resources.resource import Resource
@@ -86,6 +86,7 @@ def create_equally_spaced_2d(
   dz: float,
   item_dx: Optional[float],
   item_dy: Optional[float],
+  name_for: Optional[Callable[[int, int], str]] = None,
   **kwargs,
 ) -> List[List[T]]:
   """Make equally spaced resources in a 2D grid. Also see :meth:`create_equally_spaced_x` and
@@ -100,6 +101,7 @@ def create_equally_spaced_2d(
     dz: The z coordinate for all items
     item_dx: The spacing of the items in the x direction (origin to origin), or None when num_items_x is 1
     item_dy: The spacing of the items in the y direction (origin to origin), or None when num_items_y is 1
+    name_for: What to call the item at a grid position. Defaults to the class name and the position.
     **kwargs: Additional keyword arguments to pass to the resource constructor
 
   Returns:
@@ -120,7 +122,7 @@ def create_equally_spaced_2d(
   for i in range(num_items_x):
     items.append([])
     for j in range(num_items_y):
-      name = f"{klass.__name__.lower()}_{i}_{j}"
+      name = name_for(i, j) if name_for is not None else f"{klass.__name__.lower()}_{i}_{j}"
       item = klass(name=name, **kwargs)
       item.location = Coordinate(
         x=dx + i * spacing_x,
@@ -249,11 +251,11 @@ def create_ordered_items_2d(
     dz=dz,
     item_dx=item_dx,
     item_dy=item_dy,
+    # Named here rather than renamed afterwards: a name is fixed when a resource is created.
+    name_for=lambda i, j: f"{klass.__name__.lower()}_{row_index_to_label(j)}{i + 1}",
     **kwargs,
   )
   keys = [f"{row_index_to_label(j)}{i + 1}" for i in range(num_items_x) for j in range(num_items_y)]
-  for key, item in zip(keys, (item for sublist in items for item in sublist)):
-    item.name = f"{klass.__name__.lower()}_{key}"
   return dict(zip(keys, [item for sublist in items for item in sublist]))
 
 

--- a/pylabrobot/resources/vwr/plates.py
+++ b/pylabrobot/resources/vwr/plates.py
@@ -38,6 +38,7 @@ def VWR_1_troughplate_195000uL_Ub(name: str) -> Plate:
       cross_section_type=CrossSectionType.RECTANGLE,
       bottom_type=WellBottomType.U,
       max_volume=195000,  # from spec 195 mL
+      name_prefix=name,
     ),
   )
 
@@ -72,5 +73,6 @@ def VWR_96_wellplate_2mL_Vb(name: str) -> Plate:
       cross_section_type=CrossSectionType.RECTANGLE,
       bottom_type=WellBottomType.V,
       max_volume=2200,  # from spec 2.2 ml
+      name_prefix=name,
     ),
   )

--- a/pylabrobot/resources/well_tests.py
+++ b/pylabrobot/resources/well_tests.py
@@ -57,6 +57,7 @@ class TestWell(unittest.TestCase):
         size_x=1,
         size_y=1,
         size_z=1,
+        name_prefix="plate",
       ),
     )
     well = plate.get_well("A1")


### PR DESCRIPTION
A resource's name is its identifier: it is unique across the tree, it is what `get_resource` looks a resource up by, and it is the key `serialize_all_state` writes state under. Until now it could still be reassigned after the resource existed, and anything already named after it was left behind.

## The problem

A well is named three times before it is usable - `well_0_0` when it is constructed, `well_A1` by `create_ordered_items_2d`, and finally `plate_well_A1` by `ItemizedResource.__init__`, which prefixes every item it is handed with its own name. The last two are renames, and the last one writes the plate's name into all 96 of its wells.

Because the plate itself can still be renamed, those wells can be left describing a plate that no longer exists:

```python
plate = Cor_96_wellplate_360ul_Fb(name="plate")   # wells: plate_well_A1 ...
plate.name = "sample_plate"                       # wells: plate_well_A1 ...
```

Nothing raises, but `get_resource("sample_plate_well_A1")` finds nothing and the plate's state is serialized under keys that no longer correspond to anything in the tree.

## This PR

- the `name` setter now refuses, raising `AttributeError` rather than `RuntimeError` - that is what Python raises for a read-only property, so `setattr` and anything catching attribute errors behave as they would for any other immutable attribute.
- `create_equally_spaced_2d` takes a `name_for` callable, so each item is constructed with the name it will keep rather than renamed afterwards.
- `create_ordered_items_2d` takes `name_prefix`, the name of the resource that will hold the items, and passes it down. This matches `create_homogeneous_resources`, which already takes a `name_prefix` and already constructs each site with its final name. Carriers have named their children this way all along; this brings the plate side onto the same convention. The two differ only in separator - carriers join with `-`, items with `_`, which is what `ItemizedResource` used and what keeps every name unchanged.
- `ItemizedResource.__init__` no longer renames what it is given.
- the 167 call sites pass `name_prefix`: 155 pass `name_prefix=name`, the name their holder is being created with, and 12 in tests pass a literal. Four sites that build items by hand - two Opentrons loaders, the STAR teaching rack, and one test - name them after their holder directly.
- `named()` writes the field rather than going through the setter, since the copy it returns did not exist a moment ago and belongs to no tree; it is being built, not renamed.

Behaviour: names are unchanged, verified byte for byte across 342 resources on a loaded STARlet deck, and `named()` returns what it always did. The only change a caller can see is that assigning to `name` now raises.

