### PR TITLE
`Resource`: notify subscribers when a resource is placed or moved

### DIFF
--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -178,7 +178,7 @@ class Resource(SerializableMixin):
     # need full isolation of mutable metadata values.
     self.metadata: Dict[str, Any] = dict(metadata) if metadata is not None else {}
 
-    self.location: Optional[Coordinate] = None
+    self._location: Optional[Coordinate] = None
     self.parent: Optional[Resource] = None
     self.children: List[Resource] = []
 
@@ -802,6 +802,23 @@ class Resource(SerializableMixin):
     )
     return results[0] if results else None
 
+  @property
+  def location(self) -> Optional[Coordinate]:
+    """Where this resource sits, relative to its parent."""
+    return self._location
+
+  @location.setter
+  def location(self, location: Optional[Coordinate]) -> None:
+    """Record a new position, and notify subscribers.
+
+    Silent when the position does not change, and while the resource is outside a tree, where
+    there is nobody to tell.
+    """
+    changed = location != self._location
+    self._location = location
+    if changed and self.parent is not None:
+      self._state_updated()
+
   def rotate(self, x: float = 0, y: float = 0, z: float = 0):
     """Rotate counter-clockwise by the given number of degrees."""
 
@@ -1062,12 +1079,15 @@ class Resource(SerializableMixin):
     Use :meth:`pylabrobot.resources.resource.Resource.serialize_all_state` to serialize the state of
     this resource and all children.
 
-    The base implementation includes ``"rotation"`` so that subscribers
-    (e.g. the Visualizer) are notified of orientation changes through the
+    The base implementation includes ``"rotation"`` and ``"location"`` so that subscribers
+    (e.g. the Visualizer) are notified of orientation and position changes through the
     standard state channel. Subclasses overriding this method should merge
     in ``super().serialize_state()``.
     """
-    return {"rotation": self.rotation.serialize()}
+    state: Dict[str, Any] = {"rotation": self.rotation.serialize()}
+    if self._location is not None:
+      state["location"] = self._location.serialize()
+    return state
 
   # Developer note: you probably don't need to override this method. Instead, override
   # `serialize_state`.
@@ -1092,11 +1112,13 @@ class Resource(SerializableMixin):
   def load_state(self, state: Dict[str, Any]) -> None:
     """Load state for this resource only.
 
-    The base implementation reads ``"rotation"`` if present. Subclasses
+    The base implementation reads ``"rotation"`` and ``"location"`` if present. Subclasses
     overriding this method should call ``super().load_state(state)``.
     """
     if "rotation" in state:
       self.rotation = deserialize(state["rotation"])
+    if "location" in state:
+      self.location = deserialize(state["location"])
 
   # Developer note: you probably don't need to override this method. Instead, override `load_state`.
   def load_all_state(self, state: Dict[str, Dict[str, Any]]) -> None:


### PR DESCRIPTION
A resource's position changes without anything being told. `location` is a plain attribute, so a resource can be assigned to a deck, moved to another carrier, or handed between machines and nothing reaches the state channel. A subscriber following it has to be notified some other way.

There is no method to hang the notification on, the way `rotate` exists for rotation - position is set by assignment, including inside `assign_child_resource` - so it has to be caught at the attribute itself.

## This PR

- `location` becomes a property over `_location`. The setter records the new position and calls `_state_updated` when the value actually changed and the resource has a parent, so a resource being built or sitting outside a tree stays silent.
- `serialize_state` carries `"location"` alongside `"rotation"`, and `load_state` reads it back.

Behaviour: reads and writes of `.location` are unchanged and no caller has to move. Placing a resource or moving a placed one now emits a state update. Unassigning does not, because the parent is cleared first. `serialize_all_state` gains a `"location"` key per placed resource, so state written now differs from state written before, though older files still load.

`rotate` still notifies as it always has and is not touched here. Rebinding `rotation` outright, or mutating either value in place, still notifies nothing - that gap is unchanged and common to both.
