### PR TITLE
Add model grouping to device registry

### DIFF
--- a/docs/_exts/plr_devices/data.py
+++ b/docs/_exts/plr_devices/data.py
@@ -191,8 +191,24 @@ def _validate(device: Any, index: int, seen_ids: Dict[str, int], path: Path) -> 
     )
 
   models = device.get("models", [])
-  if not isinstance(models, list) or not all(isinstance(model, str) for model in models):
-    raise DeviceRegistryError(f"{where} ({device_id}): models must be a list of strings")
+  if not isinstance(models, list):
+    raise DeviceRegistryError(f"{where} ({device_id}): models must be a list of objects")
+  for model_index, model in enumerate(models):
+    model_where = f"{where} ({device_id}) models[{model_index}]"
+    if not isinstance(model, dict):
+      raise DeviceRegistryError(f"{model_where}: model must be an object")
+    unknown_model_fields = sorted(set(model) - {"name", "status"})
+    if unknown_model_fields:
+      raise DeviceRegistryError(
+        f"{model_where}: unknown field(s): {', '.join(unknown_model_fields)}"
+      )
+    if not isinstance(model.get("name"), str) or not model["name"]:
+      raise DeviceRegistryError(f"{model_where}: name must be a non-empty string")
+    model_status = model.get("status")
+    if model_status is not None and model_status not in STATUSES:
+      raise DeviceRegistryError(
+        f"{model_where}: status {model_status!r} is not one of {', '.join(STATUSES)}"
+      )
 
   return Device(device)
 

--- a/docs/_exts/plr_devices/data.py
+++ b/docs/_exts/plr_devices/data.py
@@ -100,6 +100,7 @@ REQUIRED_FIELDS = ("id", "vendor", "name", "kind", "status")
 
 OPTIONAL_FIELDS = (
   "capabilities",
+  "models",
   "api",
   "api_version",
   "code_slug",
@@ -188,6 +189,10 @@ def _validate(device: Any, index: int, seen_ids: Dict[str, int], path: Path) -> 
       f"{where} ({device_id}): unknown capability/capabilities: {', '.join(unknown_capabilities)}. "
       f"Add to CAPABILITIES in {Path(__file__).name} if genuinely new."
     )
+
+  models = device.get("models", [])
+  if not isinstance(models, list) or not all(isinstance(model, str) for model in models):
+    raise DeviceRegistryError(f"{where} ({device_id}): models must be a list of strings")
 
   return Device(device)
 

--- a/docs/_exts/plr_devices/html.py
+++ b/docs/_exts/plr_devices/html.py
@@ -371,11 +371,9 @@ def render_table(
       rows.append(
         f'<tr class="plr-device-model-row" data-device-id="{escape(device_id)}"'
         f' data-search="{escape(_search_index(device, model))}" hidden>'
-        '<td aria-hidden="true"></td>'
-        '<td class="plr-device-model-name"><span class="plr-device-model">'
+        '<td class="plr-device-model-name" colspan="6"><span class="plr-device-model">'
         '<span class="plr-device-model__arrow" aria-hidden="true">↳</span>'
         f'<span class="plr-device-model__label">{escape(model)}</span></span></td>'
-        '<td colspan="4"></td>'
         "</tr>"
       )
 

--- a/docs/_exts/plr_devices/html.py
+++ b/docs/_exts/plr_devices/html.py
@@ -105,13 +105,31 @@ def _capability_badge(capability: str, styles: Optional[Dict[str, str]] = None) 
 
 
 def _status_badge(device: Device, styles: Optional[Dict[str, str]] = None) -> str:
-  status = str(device["status"])
+  return _status_badge_for_status(str(device["status"]), styles)
+
+
+def _status_badge_for_status(
+  status: str, styles: Optional[Dict[str, str]] = None
+) -> str:
   label = STATUS_LABELS.get(status, status)
   extra = _tint(STATUS_HUES.get(status)) if styles else ""
   return (
     f'<span class="plr-device-status plr-device-status--{escape(status)}"'
     f"{_style(styles, 'status', extra)}>{escape(label)}</span>"
   )
+
+
+def _model_name(model: Dict[str, str]) -> str:
+  return str(model["name"])
+
+
+def _model_status(device: Device, model: Dict[str, str]) -> str:
+  return str(model.get("status", device["status"]))
+
+
+def _model_status_label(device: Device, model: Dict[str, str]) -> str:
+  status = _model_status(device, model)
+  return STATUS_LABELS.get(status, status)
 
 
 def _api_version_badge(device: Device, styles: Optional[Dict[str, str]] = None) -> str:
@@ -193,7 +211,7 @@ def _link_slots(device: Device, doc_uri: DocURI, code_uri: CodeURI) -> str:
   return "".join(rendered)
 
 
-def _search_index(device: Device, model: Optional[str] = None) -> str:
+def _search_index(device: Device, model: Optional[Dict[str, str]] = None) -> str:
   """Everything the search box matches against, lowercased.
 
   A device row indexes every model. A model sub-row indexes only itself, so a specific model
@@ -208,11 +226,19 @@ def _search_index(device: Device, model: Optional[str] = None) -> str:
         device.get("notes", ""),
         str(device.get("manager", "")).rstrip("/").rsplit("/", 1)[-1],
         *device.get("capabilities", []),
-        *device.get("models", []),
+        *(_model_name(entry) for entry in device.get("models", [])),
+        *(_model_status_label(device, entry) for entry in device.get("models", [])),
       ]
     )
   else:
-    parts.extend([*device.get("capabilities", []), model])
+    status = _model_status(device, model)
+    parts.extend(
+      [
+        *device.get("capabilities", []),
+        _model_name(model),
+        STATUS_LABELS.get(status, status),
+      ]
+    )
   return " ".join(str(p) for p in parts if p).lower()
 
 
@@ -231,7 +257,16 @@ def render_card(
 
   rows = []
   if device.get("models"):
-    rows.append(("Models", ", ".join(escape(str(model)) for model in device["models"])))
+    rows.append(
+      (
+        "Models",
+        ", ".join(
+          f"{escape(_model_name(model))} "
+          f"({escape(_model_status_label(device, model))})"
+          for model in device["models"]
+        ),
+      )
+    )
   if device.get("api"):
     api = escape(str(device["api"]))
     rows.append(("API", f'<code class="plr-device-api"{_style(styles, "api")}>{api}</code>'))
@@ -277,7 +312,13 @@ def render_card_markdown(device: Device, doc_uri: DocURI, code_uri: CodeURI) -> 
 
   lines = [head]
   if device.get("models"):
-    lines.append(f"Models: {', '.join(device['models'])}")
+    lines.append(
+      "Models: "
+      + ", ".join(
+        f"{_model_name(model)} ({_model_status_label(device, model)})"
+        for model in device["models"]
+      )
+    )
   if device.get("capabilities"):
     lines.append(f"Capabilities: {', '.join(device['capabilities'])}")
 
@@ -342,7 +383,7 @@ def render_table(
   for device in devices:
     capabilities = "".join(_capability_badge(c) for c in device.get("capabilities", []))
     device_id = str(device["id"])
-    models = [str(model) for model in device.get("models", [])]
+    models = list(device.get("models", []))
 
     name_cell = _cell_link(
       str(device["name"]),
@@ -378,12 +419,17 @@ def render_table(
       "</tr>"
     )
     for model in models:
+      model_name = _model_name(model)
+      model_status = _model_status(device, model)
       rows.append(
         f'<tr class="plr-device-model-row" data-device-id="{escape(device_id)}"'
         f' data-search="{escape(_search_index(device, model))}" hidden>'
-        '<td class="plr-device-model-name" colspan="6"><span class="plr-device-model">'
+        '<td class="plr-device-model-name" colspan="3"><span class="plr-device-model">'
         '<span class="plr-device-model__arrow" aria-hidden="true">↳</span>'
-        f'<span class="plr-device-model__label">{escape(model)}</span></span></td>'
+        f'<span class="plr-device-model__label">{escape(model_name)}</span></span></td>'
+        f'<td class="plr-device-model-status">'
+        f'{_tooltip(_status_badge_for_status(model_status), STATUS_DESCRIPTIONS.get(model_status, ""))}'
+        '</td><td colspan="2"></td>'
         "</tr>"
       )
 

--- a/docs/_exts/plr_devices/html.py
+++ b/docs/_exts/plr_devices/html.py
@@ -342,18 +342,29 @@ def render_table(
   for device in devices:
     capabilities = "".join(_capability_badge(c) for c in device.get("capabilities", []))
     device_id = str(device["id"])
+    models = [str(model) for model in device.get("models", [])]
 
     name_cell = _cell_link(
       str(device["name"]),
       doc_uri(str(device["doc_slug"])) if device.get("doc_slug") else None,
     )
+    if models:
+      device_label = f'{device["vendor"]} {device["name"]}'
+      name_cell = (
+        '<button type="button" class="plr-device-row-toggle" aria-expanded="false"'
+        f' data-device-label="{escape(device_label)}"'
+        f' aria-label="Show models for {escape(device_label)}">'
+        '<span aria-hidden="true">›</span></button>' + name_cell
+      )
     if device.get("notes"):
       name_cell += _tooltip(
         '<span class="plr-device-note">*</span>', str(device["notes"])
       )
+    models_attr = ' data-has-models="true"' if models else ""
     rows.append(
       f'<tr class="plr-device-row" id="device-{escape(device_id)}"'
       f' data-device-id="{escape(device_id)}"'
+      f"{models_attr}"
       f' data-search="{escape(_search_index(device))}"'
       f' data-vendor="{escape(str(device["vendor"]))}"'
       f' data-status="{escape(str(device["status"]))}"'
@@ -366,8 +377,7 @@ def render_table(
       f"<td>{_manager(device)}</td>"
       "</tr>"
     )
-    for model in device.get("models", []):
-      model = str(model)
+    for model in models:
       rows.append(
         f'<tr class="plr-device-model-row" data-device-id="{escape(device_id)}"'
         f' data-search="{escape(_search_index(device, model))}" hidden>'

--- a/docs/_exts/plr_devices/html.py
+++ b/docs/_exts/plr_devices/html.py
@@ -193,18 +193,26 @@ def _link_slots(device: Device, doc_uri: DocURI, code_uri: CodeURI) -> str:
   return "".join(rendered)
 
 
-def _search_index(device: Device) -> str:
-  """Everything the search box matches against, lowercased."""
-  parts = [
-    device["vendor"],
-    device["name"],
-    device["kind"],
-    STATUS_LABELS.get(str(device["status"]), str(device["status"])),
-    device.get("api", ""),
-    device.get("notes", ""),
-    str(device.get("manager", "")).rstrip("/").rsplit("/", 1)[-1],
-    *device.get("capabilities", []),
-  ]
+def _search_index(device: Device, model: Optional[str] = None) -> str:
+  """Everything the search box matches against, lowercased.
+
+  A device row indexes every model. A model sub-row indexes only itself, so a specific model
+  search can hide its potentially hundreds of siblings.
+  """
+  parts = [device["vendor"], device["name"], device["kind"]]
+  if model is None:
+    parts.extend(
+      [
+        STATUS_LABELS.get(str(device["status"]), str(device["status"])),
+        device.get("api", ""),
+        device.get("notes", ""),
+        str(device.get("manager", "")).rstrip("/").rsplit("/", 1)[-1],
+        *device.get("capabilities", []),
+        *device.get("models", []),
+      ]
+    )
+  else:
+    parts.extend([*device.get("capabilities", []), model])
   return " ".join(str(p) for p in parts if p).lower()
 
 
@@ -222,6 +230,8 @@ def render_card(
   links = _links(device, doc_uri, code_uri, styles)
 
   rows = []
+  if device.get("models"):
+    rows.append(("Models", ", ".join(escape(str(model)) for model in device["models"])))
   if device.get("api"):
     api = escape(str(device["api"]))
     rows.append(("API", f'<code class="plr-device-api"{_style(styles, "api")}>{api}</code>'))
@@ -266,6 +276,8 @@ def render_card_markdown(device: Device, doc_uri: DocURI, code_uri: CodeURI) -> 
     head += f" ({device['api_version']})"
 
   lines = [head]
+  if device.get("models"):
+    lines.append(f"Models: {', '.join(device['models'])}")
   if device.get("capabilities"):
     lines.append(f"Capabilities: {', '.join(device['capabilities'])}")
 
@@ -329,6 +341,7 @@ def render_table(
   rows = []
   for device in devices:
     capabilities = "".join(_capability_badge(c) for c in device.get("capabilities", []))
+    device_id = str(device["id"])
 
     name_cell = _cell_link(
       str(device["name"]),
@@ -339,7 +352,8 @@ def render_table(
         '<span class="plr-device-note">*</span>', str(device["notes"])
       )
     rows.append(
-      f'<tr class="plr-device-row" id="device-{escape(str(device["id"]))}"'
+      f'<tr class="plr-device-row" id="device-{escape(device_id)}"'
+      f' data-device-id="{escape(device_id)}"'
       f' data-search="{escape(_search_index(device))}"'
       f' data-vendor="{escape(str(device["vendor"]))}"'
       f' data-status="{escape(str(device["status"]))}"'
@@ -352,16 +366,36 @@ def render_table(
       f"<td>{_manager(device)}</td>"
       "</tr>"
     )
+    for model in device.get("models", []):
+      model = str(model)
+      rows.append(
+        f'<tr class="plr-device-model-row" data-device-id="{escape(device_id)}"'
+        f' data-search="{escape(_search_index(device, model))}" hidden>'
+        '<td aria-hidden="true"></td>'
+        '<td class="plr-device-model-name"><span class="plr-device-model">'
+        '<span class="plr-device-model__arrow" aria-hidden="true">↳</span>'
+        f'<span class="plr-device-model__label">{escape(model)}</span></span></td>'
+        '<td colspan="4"></td>'
+        "</tr>"
+      )
 
   controls = ""
-  if search:
-    controls += (
-      f'<div class="plr-device-search">'
-      f'<input type="search" id="{escape(table_id)}-search" class="plr-device-search__input" '
-      f'placeholder="Search {len(devices)} devices by vendor, model, type or capability…" '
-      f'aria-label="Search devices" autocomplete="off">'
-      f"</div>"
-    )
+  has_models = any(device.get("models") for device in devices)
+  model_count = sum(max(1, len(device.get("models", []))) for device in devices)
+  if search or has_models:
+    controls = '<div class="plr-device-search">'
+    if search:
+      controls += (
+        f'<input type="search" id="{escape(table_id)}-search" class="plr-device-search__input" '
+        f'placeholder="Search {model_count} models by vendor, model, type or capability…" '
+        f'aria-label="Search models" autocomplete="off">'
+      )
+    if has_models:
+      controls += (
+        f'<button type="button" class="plr-device-model-toggle" aria-pressed="false" '
+        f'aria-controls="{escape(table_id)}-table">Show models</button>'
+      )
+    controls += "</div>"
   if filters:
     capabilities_all = [
       (c, c) for c in sorted({c for d in devices for c in d.get("capabilities", [])})
@@ -375,7 +409,7 @@ def render_table(
   return f"""<div class="plr-devices" id="{escape(table_id)}" data-plr-devices>
 {controls}
 <div class="plr-device-table-wrapper">
-<table class="plr-device-table">
+<table class="plr-device-table" id="{escape(table_id)}-table">
   <thead><tr>
     <th>Vendor</th><th>Device</th><th>Capabilities</th><th>Support</th>
     <th>Links</th><th>Manager</th>

--- a/docs/_exts/plr_devices/registry_tests.py
+++ b/docs/_exts/plr_devices/registry_tests.py
@@ -229,6 +229,9 @@ class TestRendering(unittest.TestCase):
     model_count = sum(max(1, len(device.get("models", []))) for device in self.devices)
     self.assertIn(f"Search {model_count} models", html)
     self.assertIn("Show models", html)
+    self.assertIn('class="plr-device-row-toggle"', html)
+    self.assertIn('aria-expanded="false"', html)
+    self.assertIn('data-has-models="true"', html)
     self.assertIn('<tr class="plr-device-model-row" data-device-id="cole-parmer-masterflex"', html)
     self.assertIn(
       '<td class="plr-device-model-name" colspan="6"><span class="plr-device-model">'

--- a/docs/_exts/plr_devices/registry_tests.py
+++ b/docs/_exts/plr_devices/registry_tests.py
@@ -109,6 +109,8 @@ class TestRegistry(unittest.TestCase):
       [{**MINIMAL, "api_version": "v9"}],
       [{**MINIMAL, "capabilities": "shaking"}],
       [{**MINIMAL, "capabilities": ["teleportation"]}],
+      [{**MINIMAL, "models": "model-a"}],
+      [{**MINIMAL, "models": [1]}],
       [{**MINIMAL, "manager": "rickwierenga"}],
       [{**MINIMAL, "bogus": 1}],
       ["not an object"],
@@ -136,6 +138,12 @@ class TestRendering(unittest.TestCase):
     self.assertIn("Curiox", html)
     self.assertIn("HT2000", html)
     self.assertIn("plate washing", html)
+
+  def test_card_contains_models(self):
+    device = Device({**self.device, "models": ["HT2000", "HT2100"]})
+    html = render_card(device, _no_link, _no_link)
+    self.assertIn("Models", html)
+    self.assertIn("HT2000, HT2100", html)
 
   def test_card_links_only_what_resolves(self):
     html = render_card(self.device, _no_link, _no_link)
@@ -176,6 +184,11 @@ class TestRendering(unittest.TestCase):
     self.assertNotIn("[docs]", md)
     self.assertNotIn("[code]", md)
 
+  def test_markdown_card_contains_models(self):
+    device = Device({**self.device, "models": ["HT2000", "HT2100"]})
+    md = render_card_markdown(device, _no_link, _no_link)
+    self.assertIn("Models: HT2000, HT2100", md)
+
   def test_inline_styles_only_when_asked(self):
     self.assertNotIn("padding:0.9rem", render_card(self.device, _no_link, _no_link))
     self.assertIn("padding:0.9rem", render_card(self.device, _no_link, _no_link, INLINE))
@@ -210,6 +223,31 @@ class TestRendering(unittest.TestCase):
     html = render_table(self.devices, _no_link, _no_link, "t")
     for field in set(re.findall(r'data-field="(\w+)"', html)):
       self.assertIn(f'data-{field}="', html)
+
+  def test_table_models_are_searchable_and_toggleable(self):
+    html = render_table(self.devices, _no_link, _no_link, "t")
+    model_count = sum(max(1, len(device.get("models", []))) for device in self.devices)
+    self.assertIn(f"Search {model_count} models", html)
+    self.assertIn("Show models", html)
+    self.assertIn('<tr class="plr-device-model-row" data-device-id="cole-parmer-masterflex"', html)
+    self.assertIn(
+      '<span class="plr-device-model__arrow" aria-hidden="true">↳</span>'
+      '<span class="plr-device-model__label">07522-20</span>',
+      html,
+    )
+    masterflex_row = next(
+      line for line in html.splitlines() if 'id="device-cole-parmer-masterflex"' in line
+    )
+    self.assertIn("07522-20", masterflex_row.split('data-search="', 1)[1].split('"', 1)[0])
+
+    model_row = next(
+      line
+      for line in html.splitlines()
+      if 'data-device-id="cole-parmer-masterflex"' in line and ">07522-20</span>" in line
+    )
+    model_search = model_row.split('data-search="', 1)[1].split('"', 1)[0]
+    self.assertIn("07522-20", model_search)
+    self.assertNotIn("07522-30", model_search)
 
   def test_empty_table(self):
     self.assertIn("No devices match", render_table([], _no_link, _no_link, "t"))

--- a/docs/_exts/plr_devices/registry_tests.py
+++ b/docs/_exts/plr_devices/registry_tests.py
@@ -111,6 +111,9 @@ class TestRegistry(unittest.TestCase):
       [{**MINIMAL, "capabilities": ["teleportation"]}],
       [{**MINIMAL, "models": "model-a"}],
       [{**MINIMAL, "models": [1]}],
+      [{**MINIMAL, "models": [{"name": ""}]}],
+      [{**MINIMAL, "models": [{"name": "model-a", "status": "nope"}]}],
+      [{**MINIMAL, "models": [{"name": "model-a", "bogus": True}]}],
       [{**MINIMAL, "manager": "rickwierenga"}],
       [{**MINIMAL, "bogus": 1}],
       ["not an object"],
@@ -140,10 +143,15 @@ class TestRendering(unittest.TestCase):
     self.assertIn("plate washing", html)
 
   def test_card_contains_models(self):
-    device = Device({**self.device, "models": ["HT2000", "HT2100"]})
+    device = Device(
+      {
+        **self.device,
+        "models": [{"name": "HT2000"}, {"name": "HT2100", "status": "wip"}],
+      }
+    )
     html = render_card(device, _no_link, _no_link)
     self.assertIn("Models", html)
-    self.assertIn("HT2000, HT2100", html)
+    self.assertIn("HT2000 (Mostly), HT2100 (WIP)", html)
 
   def test_card_links_only_what_resolves(self):
     html = render_card(self.device, _no_link, _no_link)
@@ -185,9 +193,14 @@ class TestRendering(unittest.TestCase):
     self.assertNotIn("[code]", md)
 
   def test_markdown_card_contains_models(self):
-    device = Device({**self.device, "models": ["HT2000", "HT2100"]})
+    device = Device(
+      {
+        **self.device,
+        "models": [{"name": "HT2000"}, {"name": "HT2100", "status": "wip"}],
+      }
+    )
     md = render_card_markdown(device, _no_link, _no_link)
-    self.assertIn("Models: HT2000, HT2100", md)
+    self.assertIn("Models: HT2000 (Mostly), HT2100 (WIP)", md)
 
   def test_inline_styles_only_when_asked(self):
     self.assertNotIn("padding:0.9rem", render_card(self.device, _no_link, _no_link))
@@ -227,31 +240,44 @@ class TestRendering(unittest.TestCase):
   def test_table_models_are_searchable_and_toggleable(self):
     html = render_table(self.devices, _no_link, _no_link, "t")
     model_count = sum(max(1, len(device.get("models", []))) for device in self.devices)
+    device = next(device for device in self.devices if device.get("models"))
+    model = device["models"][0]
+    device_id = device["id"]
+    model_name = model["name"]
+    model_status = model.get("status", device["status"])
     self.assertIn(f"Search {model_count} models", html)
     self.assertIn("Show models", html)
     self.assertIn('class="plr-device-row-toggle"', html)
     self.assertIn('aria-expanded="false"', html)
     self.assertIn('data-has-models="true"', html)
-    self.assertIn('<tr class="plr-device-model-row" data-device-id="cole-parmer-masterflex"', html)
     self.assertIn(
-      '<td class="plr-device-model-name" colspan="6"><span class="plr-device-model">'
+      f'<tr class="plr-device-model-row" data-device-id="{device_id}"', html
+    )
+    self.assertIn(
+      '<td class="plr-device-model-name" colspan="3"><span class="plr-device-model">'
       '<span class="plr-device-model__arrow" aria-hidden="true">↳</span>'
-      '<span class="plr-device-model__label">07522-20</span>',
+      f'<span class="plr-device-model__label">{model_name}</span>',
       html,
     )
-    masterflex_row = next(
-      line for line in html.splitlines() if 'id="device-cole-parmer-masterflex"' in line
+    self.assertIn(
+      '<td class="plr-device-model-status"><span class="plr-tip"', html
     )
-    self.assertIn("07522-20", masterflex_row.split('data-search="', 1)[1].split('"', 1)[0])
+    device_row = next(
+      line for line in html.splitlines() if f'id="device-{device_id}"' in line
+    )
+    self.assertIn(model_name.lower(), device_row.split('data-search="', 1)[1].split('"', 1)[0])
 
     model_row = next(
       line
       for line in html.splitlines()
-      if 'data-device-id="cole-parmer-masterflex"' in line and ">07522-20</span>" in line
+      if f'data-device-id="{device_id}"' in line and f">{model_name}</span>" in line
     )
     model_search = model_row.split('data-search="', 1)[1].split('"', 1)[0]
-    self.assertIn("07522-20", model_search)
-    self.assertNotIn("07522-30", model_search)
+    self.assertIn(f"plr-device-status--{model_status}", model_row)
+    self.assertIn(model_name.lower(), model_search)
+    self.assertIn(model_status.lower(), model_search)
+    if len(device["models"]) > 1:
+      self.assertNotIn(device["models"][1]["name"].lower(), model_search)
 
   def test_empty_table(self):
     self.assertIn("No devices match", render_table([], _no_link, _no_link, "t"))

--- a/docs/_exts/plr_devices/registry_tests.py
+++ b/docs/_exts/plr_devices/registry_tests.py
@@ -231,6 +231,7 @@ class TestRendering(unittest.TestCase):
     self.assertIn("Show models", html)
     self.assertIn('<tr class="plr-device-model-row" data-device-id="cole-parmer-masterflex"', html)
     self.assertIn(
+      '<td class="plr-device-model-name" colspan="6"><span class="plr-device-model">'
       '<span class="plr-device-model__arrow" aria-hidden="true">↳</span>'
       '<span class="plr-device-model__label">07522-20</span>',
       html,

--- a/docs/_static/devices.json
+++ b/docs/_static/devices.json
@@ -66,9 +66,6 @@
     "name": "Cytation 1",
     "kind": "plate reader",
     "capabilities": [
-      "absorbance",
-      "fluorescence",
-      "luminescence",
       "microscopy"
     ],
     "status": "full",

--- a/docs/_static/devices.json
+++ b/docs/_static/devices.json
@@ -262,9 +262,13 @@
     "oem": "https://www.bmglabtech.com/en/clariostar-plus/"
   },
   {
-    "id": "brooks-preciseflex-pf3400",
+    "id": "brooks-preciseflex",
     "vendor": "Brooks",
-    "name": "PreciseFlex PF3400",
+    "name": "PreciseFlex",
+    "models": [
+      "PreciseFlex PF3400",
+      "PreciseFlex PF400"
+    ],
     "kind": "arm",
     "capabilities": [
       "arm"
@@ -275,23 +279,7 @@
     "code_slug": "brooks/precise_flex",
     "doc_slug": "brooks/precise_flex/hello-world",
     "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.preciseflexrobots.com/lab-automation-applicable-products#preciseflex3400-labproducts"
-  },
-  {
-    "id": "brooks-preciseflex-pf400",
-    "vendor": "Brooks",
-    "name": "PreciseFlex PF400",
-    "kind": "arm",
-    "capabilities": [
-      "arm"
-    ],
-    "status": "full",
-    "api": "pylabrobot.brooks.precise_flex.PreciseFlex",
-    "api_version": "v1",
-    "code_slug": "brooks/precise_flex",
-    "doc_slug": "brooks/precise_flex/hello-world",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.preciseflexrobots.com/lab-automation-applicable-products#preciseflex400_labproducts"
+    "oem": "https://www.preciseflexrobots.com/lab-automation-applicable-products"
   },
   {
     "id": "byonoy-absorbance-96",
@@ -481,23 +469,10 @@
     "id": "hamilton-star",
     "vendor": "Hamilton",
     "name": "STAR",
-    "kind": "liquid handler",
-    "capabilities": [
-      "liquid handling",
-      "arm"
+    "models": [
+      "STAR",
+      "STARlet"
     ],
-    "status": "full",
-    "api": "pylabrobot.legacy.liquid_handling.backends.STARBackend",
-    "api_version": "v0",
-    "code_slug": "legacy/liquid_handling/backends/hamilton/STAR_backend",
-    "doc_slug": "hamilton/star/index",
-    "manager": "https://discuss.pylabrobot.org/u/camillomoschner",
-    "oem": "https://www.hamiltoncompany.com/microlab-star"
-  },
-  {
-    "id": "hamilton-starlet",
-    "vendor": "Hamilton",
-    "name": "STARlet",
     "kind": "liquid handler",
     "capabilities": [
       "liquid handling",
@@ -753,52 +728,26 @@
     "oem": "https://www.biosearchtech.com/products/pcr-reagents-kits-and-instruments/pcr-instruments-and-software/snpline-genotyping-automation/kube-plate-sealer"
   },
   {
-    "id": "kbiosystems-ultraseal-epro",
+    "id": "kbiosystems-ultraseal",
     "vendor": "KBiosystems",
-    "name": "Ultraseal ePRO",
+    "name": "Ultraseal",
+    "models": [
+      "Ultraseal ePRO",
+      "Ultraseal PRO",
+      "Ultraseal XT PRO"
+    ],
     "kind": "sealer",
     "capabilities": [
       "sealing"
     ],
     "status": "mostly",
-    "api": "pylabrobot.kbiosystems.KBiosystemsUltrasealEPRO",
+    "api": "pylabrobot.kbiosystems",
     "api_version": "v1",
     "code_slug": "kbiosystems",
-    "doc_slug": "kbiosystems/ultraseal-epro/hello-world",
+    "doc_slug": "kbiosystems/index",
     "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://kbiosystems.com/product/ultraseal-epro"
-  },
-  {
-    "id": "kbiosystems-ultraseal-pro",
-    "vendor": "KBiosystems",
-    "name": "Ultraseal PRO",
-    "kind": "sealer",
-    "capabilities": [
-      "sealing"
-    ],
-    "status": "mostly",
-    "api": "pylabrobot.kbiosystems.KBiosystemsUltrasealPRO",
-    "api_version": "v1",
-    "code_slug": "kbiosystems",
-    "doc_slug": "kbiosystems/ultraseal-pro/hello-world",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://kbiosystems.com/product/ultraseal-pro"
-  },
-  {
-    "id": "kbiosystems-ultraseal-xt-pro",
-    "vendor": "KBiosystems",
-    "name": "Ultraseal XT PRO",
-    "kind": "sealer",
-    "capabilities": [
-      "sealing"
-    ],
-    "status": "mostly",
-    "api": "pylabrobot.kbiosystems.KBiosystemsUltrasealXTPro",
-    "api_version": "v1",
-    "code_slug": "kbiosystems",
-    "doc_slug": "kbiosystems/ultraseal-xt-pro/hello-world",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://kbiosystems.com/product/ultraseal-xt-pro"
+    "notes": "Each model has its own driver class and hello-world guide.",
+    "oem": "https://kbiosystems.com/"
   },
   {
     "id": "keyence-barcode-scanner",
@@ -1022,140 +971,21 @@
     "manager": "https://discuss.pylabrobot.org/u/rickwierenga"
   },
   {
-    "id": "qinstruments-bioshake-3000",
+    "id": "qinstruments-bioshake",
     "vendor": "QInstruments",
-    "name": "BioShake 3000",
-    "kind": "shaker",
-    "capabilities": [
-      "shaking"
+    "name": "BioShake",
+    "models": [
+      "BioShake 3000",
+      "BioShake 3000 elm",
+      "BioShake 3000 elm DWP",
+      "BioShake 3000-T",
+      "BioShake 3000-T elm",
+      "BioShake 5000 elm",
+      "BioShake D30 elm",
+      "BioShake D30-T elm",
+      "BioShake Q1",
+      "BioShake Q2"
     ],
-    "status": "full",
-    "api": "pylabrobot.qinstruments.BioShake3000",
-    "api_version": "v1",
-    "code_slug": "qinstruments",
-    "doc_slug": "qinstruments/bioshake/hello-world",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.qinstruments.com/automation/bioshake-3000/"
-  },
-  {
-    "id": "qinstruments-bioshake-3000-elm",
-    "vendor": "QInstruments",
-    "name": "BioShake 3000 elm",
-    "kind": "shaker",
-    "capabilities": [
-      "shaking"
-    ],
-    "status": "full",
-    "api": "pylabrobot.qinstruments.BioShake3000Elm",
-    "api_version": "v1",
-    "code_slug": "qinstruments",
-    "doc_slug": "qinstruments/bioshake/hello-world",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.qinstruments.com/automation/bioshake-3000-elm/"
-  },
-  {
-    "id": "qinstruments-bioshake-3000-elm-dwp",
-    "vendor": "QInstruments",
-    "name": "BioShake 3000 elm DWP",
-    "kind": "shaker",
-    "capabilities": [
-      "shaking"
-    ],
-    "status": "full",
-    "api": "pylabrobot.qinstruments.BioShake3000ElmDWP",
-    "api_version": "v1",
-    "code_slug": "qinstruments",
-    "doc_slug": "qinstruments/bioshake/hello-world",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.qinstruments.com/automation/bioshake-3000-elm-dwp/"
-  },
-  {
-    "id": "qinstruments-bioshake-3000-t",
-    "vendor": "QInstruments",
-    "name": "BioShake 3000-T",
-    "kind": "heater shaker",
-    "capabilities": [
-      "shaking",
-      "heating"
-    ],
-    "status": "wip",
-    "api": "pylabrobot.qinstruments.BioShake3000T",
-    "api_version": "v1",
-    "code_slug": "qinstruments",
-    "doc_slug": "qinstruments/bioshake/hello-world",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.qinstruments.com/automation/bioshake-3000-t/"
-  },
-  {
-    "id": "qinstruments-bioshake-3000-t-elm",
-    "vendor": "QInstruments",
-    "name": "BioShake 3000-T elm",
-    "kind": "heater shaker",
-    "capabilities": [
-      "shaking",
-      "heating"
-    ],
-    "status": "wip",
-    "api": "pylabrobot.qinstruments.BioShake3000TElm",
-    "api_version": "v1",
-    "code_slug": "qinstruments",
-    "doc_slug": "qinstruments/bioshake/hello-world",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.qinstruments.com/automation/bioshake-3000-t-elm/"
-  },
-  {
-    "id": "qinstruments-bioshake-5000-elm",
-    "vendor": "QInstruments",
-    "name": "BioShake 5000 elm",
-    "kind": "shaker",
-    "capabilities": [
-      "shaking"
-    ],
-    "status": "wip",
-    "api": "pylabrobot.qinstruments.BioShake5000Elm",
-    "api_version": "v1",
-    "code_slug": "qinstruments",
-    "doc_slug": "qinstruments/bioshake/hello-world",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.qinstruments.com/automation/bioshake-5000-elm/"
-  },
-  {
-    "id": "qinstruments-bioshake-d30-elm",
-    "vendor": "QInstruments",
-    "name": "BioShake D30 elm",
-    "kind": "shaker",
-    "capabilities": [
-      "shaking"
-    ],
-    "status": "wip",
-    "api": "pylabrobot.qinstruments.BioShakeD30Elm",
-    "api_version": "v1",
-    "code_slug": "qinstruments",
-    "doc_slug": "qinstruments/bioshake/hello-world",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.qinstruments.com/automation/bioshake-d30-elm/"
-  },
-  {
-    "id": "qinstruments-bioshake-d30-t-elm",
-    "vendor": "QInstruments",
-    "name": "BioShake D30-T elm",
-    "kind": "heater shaker",
-    "capabilities": [
-      "shaking",
-      "heating"
-    ],
-    "status": "wip",
-    "api": "pylabrobot.qinstruments.BioShakeD30TElm",
-    "api_version": "v1",
-    "code_slug": "qinstruments",
-    "doc_slug": "qinstruments/bioshake/hello-world",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.qinstruments.com/automation/bioshake-d30-t-elm/"
-  },
-  {
-    "id": "qinstruments-bioshake-q1",
-    "vendor": "QInstruments",
-    "name": "BioShake Q1",
     "kind": "heater shaker",
     "capabilities": [
       "shaking",
@@ -1163,30 +993,13 @@
       "active cooling"
     ],
     "status": "full",
-    "api": "pylabrobot.qinstruments.BioShakeQ1",
+    "api": "pylabrobot.qinstruments.BioShake",
     "api_version": "v1",
     "code_slug": "qinstruments",
     "doc_slug": "qinstruments/bioshake/hello-world",
     "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.qinstruments.com/automation/bioshake-q1/"
-  },
-  {
-    "id": "qinstruments-bioshake-q2",
-    "vendor": "QInstruments",
-    "name": "BioShake Q2",
-    "kind": "heater shaker",
-    "capabilities": [
-      "shaking",
-      "heating",
-      "active cooling"
-    ],
-    "status": "wip",
-    "api": "pylabrobot.qinstruments.BioShakeQ2",
-    "api_version": "v1",
-    "code_slug": "qinstruments",
-    "doc_slug": "qinstruments/bioshake/hello-world",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.qinstruments.com/automation/bioshake-q2/"
+    "notes": "Capabilities and support completeness vary by model; use a model-specific factory function.",
+    "oem": "https://www.qinstruments.com/"
   },
   {
     "id": "qinstruments-coldplate",

--- a/docs/_static/devices.json
+++ b/docs/_static/devices.json
@@ -362,6 +362,14 @@
     "id": "cole-parmer-masterflex",
     "vendor": "Cole Parmer",
     "name": "Masterflex L/S",
+    "models": [
+      "07522-20",
+      "07522-30",
+      "07551-20",
+      "07551-30",
+      "07575-30",
+      "07575-40"
+    ],
     "kind": "pump",
     "capabilities": [
       "pumping"
@@ -371,7 +379,6 @@
     "api_version": "v1",
     "code_slug": "cole_parmer",
     "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "notes": "Models 07522-20, 07522-30, 07551-20, 07551-30, 07575-30 and 07575-40.",
     "oem": "https://corporate.avantorsciences.com/us/en/bioprocess-solutions/fluid-management/masterflex-peristaltic-pumps/ls-series"
   },
   {
@@ -709,6 +716,11 @@
     "id": "inheco-thermoshake",
     "vendor": "Inheco",
     "name": "Thermoshake",
+    "models": [
+      "Thermoshake",
+      "Thermoshake AC",
+      "Thermoshake RM"
+    ],
     "kind": "heater shaker",
     "capabilities": [
       "heating",
@@ -721,43 +733,7 @@
     "code_slug": "inheco",
     "doc_slug": "inheco/thermoshake/hello-world",
     "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.inheco.com/thermoshake-classic.html"
-  },
-  {
-    "id": "inheco-thermoshake-ac",
-    "vendor": "Inheco",
-    "name": "Thermoshake AC",
-    "kind": "heater shaker",
-    "capabilities": [
-      "heating",
-      "active cooling",
-      "shaking"
-    ],
-    "status": "wip",
-    "api": "pylabrobot.inheco.inheco_thermoshake_ac",
-    "api_version": "v1",
-    "code_slug": "inheco",
-    "doc_slug": "inheco/thermoshake/hello-world",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "notes": "Resource definition incomplete, so the model cannot be instantiated yet.",
-    "oem": "https://www.inheco.com/thermoshake-ac.html"
-  },
-  {
-    "id": "inheco-thermoshake-rm",
-    "vendor": "Inheco",
-    "name": "Thermoshake RM",
-    "kind": "heater shaker",
-    "capabilities": [
-      "heating",
-      "shaking"
-    ],
-    "status": "wip",
-    "api": "pylabrobot.inheco.inheco_thermoshake_rm",
-    "api_version": "v1",
-    "code_slug": "inheco",
-    "doc_slug": "inheco/thermoshake/hello-world",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "notes": "Resource definition incomplete, so the model cannot be instantiated yet.",
+    "notes": "The ThermoShake resource is available; the AC and RM resource definitions are incomplete and cannot yet be instantiated.",
     "oem": "https://www.inheco.com/thermoshake-classic.html"
   },
   {
@@ -1321,49 +1297,25 @@
     "oem": "https://lifesciences.tecan.com/multimode-plate-reader"
   },
   {
-    "id": "thermo-fisher-alps-300",
+    "id": "thermo-fisher-alps",
     "vendor": "Thermo Fisher",
-    "name": "ALPS 300",
+    "name": "ALPS",
+    "models": [
+      "ALPS 300",
+      "ALPS 3000",
+      "ALPS 5000"
+    ],
     "kind": "sealer",
     "capabilities": [
       "sealing"
     ],
     "status": "mostly",
-    "api": "pylabrobot.thermo_fisher.alps.ThermoScientificALPS300",
+    "api": "pylabrobot.thermo_fisher.alps",
     "api_version": "v1",
     "code_slug": "thermo_fisher/alps",
-    "doc_slug": "thermo_fisher/alps/alps300/hello-world",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga"
-  },
-  {
-    "id": "thermo-fisher-alps-3000",
-    "vendor": "Thermo Fisher",
-    "name": "ALPS 3000",
-    "kind": "sealer",
-    "capabilities": [
-      "sealing"
-    ],
-    "status": "mostly",
-    "api": "pylabrobot.thermo_fisher.alps.ThermoScientificALPS3000",
-    "api_version": "v1",
-    "code_slug": "thermo_fisher/alps",
-    "doc_slug": "thermo_fisher/alps/alps3000/hello-world",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga"
-  },
-  {
-    "id": "thermo-fisher-alps-5000",
-    "vendor": "Thermo Fisher",
-    "name": "ALPS 5000",
-    "kind": "sealer",
-    "capabilities": [
-      "sealing"
-    ],
-    "status": "mostly",
-    "api": "pylabrobot.thermo_fisher.alps.ThermoScientificALPS5000",
-    "api_version": "v1",
-    "code_slug": "thermo_fisher/alps",
-    "doc_slug": "thermo_fisher/alps/alps5000/hello-world",
+    "doc_slug": "thermo_fisher/alps/index",
     "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
+    "notes": "Each model has its own driver class and hello-world guide.",
     "oem": "https://www.thermofisher.com/order/catalog/product/AB-5000"
   },
   {
@@ -1382,30 +1334,22 @@
     "oem": "https://www.thermofisher.com/us/en/home/life-science/pcr/thermal-cyclers-realtime-instruments/thermal-cyclers/automated-thermal-cycler-atc.html"
   },
   {
-    "id": "thermo-fisher-cytomat-2-c425",
+    "id": "thermo-fisher-cytomat",
     "vendor": "Thermo Fisher",
-    "name": "Cytomat 2 C425",
-    "kind": "storage",
-    "capabilities": [
-      "storage",
-      "heating",
-      "active cooling"
+    "name": "Cytomat",
+    "models": [
+      "Cytomat 2 C425",
+      "Cytomat 2 C450 SHAKE",
+      "Cytomat 2 C_50",
+      "Cytomat 5C",
+      "Cytomat 6000",
+      "Cytomat 6002"
     ],
-    "status": "full",
-    "api": "pylabrobot.legacy.storage.cytomat.CytomatBackend",
-    "api_version": "v0",
-    "code_slug": "legacy/storage/cytomat",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.thermofisher.com/order/catalog/product/51033032"
-  },
-  {
-    "id": "thermo-fisher-cytomat-2-c450-shake",
-    "vendor": "Thermo Fisher",
-    "name": "Cytomat 2 C450 SHAKE",
     "kind": "storage",
     "capabilities": [
       "storage",
       "heating",
+      "active cooling",
       "shaking"
     ],
     "status": "full",
@@ -1413,72 +1357,8 @@
     "api_version": "v0",
     "code_slug": "legacy/storage/cytomat",
     "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.thermofisher.com/order/catalog/product/51033035"
-  },
-  {
-    "id": "thermo-fisher-cytomat-2-c50",
-    "vendor": "Thermo Fisher",
-    "name": "Cytomat 2 C_50",
-    "kind": "storage",
-    "capabilities": [
-      "storage",
-      "heating"
-    ],
-    "status": "wip",
-    "api": "pylabrobot.legacy.storage.cytomat.CytomatBackend",
-    "api_version": "v0",
-    "code_slug": "legacy/storage/cytomat",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "notes": "The driver lists this model but rejects it: constructing one raises NotImplementedError.",
+    "notes": "Capabilities vary by model. The driver lists Cytomat 2 C_50 but rejects it with NotImplementedError.",
     "oem": "https://www.thermofisher.com/us/en/home/life-science/lab-equipment/lab-automation/lab-automation-incubators.html"
-  },
-  {
-    "id": "thermo-fisher-cytomat-5c",
-    "vendor": "Thermo Fisher",
-    "name": "Cytomat 5C",
-    "kind": "storage",
-    "capabilities": [
-      "storage",
-      "heating"
-    ],
-    "status": "full",
-    "api": "pylabrobot.legacy.storage.cytomat.CytomatBackend",
-    "api_version": "v0",
-    "code_slug": "legacy/storage/cytomat",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.thermofisher.com/order/catalog/product/51031526"
-  },
-  {
-    "id": "thermo-fisher-cytomat-6000",
-    "vendor": "Thermo Fisher",
-    "name": "Cytomat 6000",
-    "kind": "storage",
-    "capabilities": [
-      "storage",
-      "heating"
-    ],
-    "status": "full",
-    "api": "pylabrobot.legacy.storage.cytomat.CytomatBackend",
-    "api_version": "v0",
-    "code_slug": "legacy/storage/cytomat",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.thermofisher.com/us/en/home/life-science/lab-equipment/lab-automation/lab-automation-incubators.html"
-  },
-  {
-    "id": "thermo-fisher-cytomat-6002",
-    "vendor": "Thermo Fisher",
-    "name": "Cytomat 6002",
-    "kind": "storage",
-    "capabilities": [
-      "storage",
-      "heating"
-    ],
-    "status": "full",
-    "api": "pylabrobot.legacy.storage.cytomat.CytomatBackend",
-    "api_version": "v0",
-    "code_slug": "legacy/storage/cytomat",
-    "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "oem": "https://www.thermofisher.com/order/catalog/product/50075279"
   },
   {
     "id": "thermo-fisher-heraeus-cytomat",

--- a/docs/_static/devices.json
+++ b/docs/_static/devices.json
@@ -263,8 +263,8 @@
     "vendor": "Brooks",
     "name": "PreciseFlex",
     "models": [
-      "PreciseFlex PF3400",
-      "PreciseFlex PF400"
+      {"name": "PreciseFlex PF3400", "status": "full"},
+      {"name": "PreciseFlex PF400", "status": "full"}
     ],
     "kind": "arm",
     "capabilities": [
@@ -348,12 +348,12 @@
     "vendor": "Cole Parmer",
     "name": "Masterflex L/S",
     "models": [
-      "07522-20",
-      "07522-30",
-      "07551-20",
-      "07551-30",
-      "07575-30",
-      "07575-40"
+      {"name": "07522-20", "status": "full"},
+      {"name": "07522-30", "status": "full"},
+      {"name": "07551-20", "status": "full"},
+      {"name": "07551-30", "status": "full"},
+      {"name": "07575-30", "status": "full"},
+      {"name": "07575-40", "status": "full"}
     ],
     "kind": "pump",
     "capabilities": [
@@ -467,8 +467,8 @@
     "vendor": "Hamilton",
     "name": "STAR",
     "models": [
-      "STAR",
-      "STARlet"
+      {"name": "STAR", "status": "full"},
+      {"name": "STARlet", "status": "full"}
     ],
     "kind": "liquid handler",
     "capabilities": [
@@ -689,9 +689,9 @@
     "vendor": "Inheco",
     "name": "Thermoshake",
     "models": [
-      "Thermoshake",
-      "Thermoshake AC",
-      "Thermoshake RM"
+      {"name": "Thermoshake", "status": "full"},
+      {"name": "Thermoshake AC", "status": "wip"},
+      {"name": "Thermoshake RM", "status": "wip"}
     ],
     "kind": "heater shaker",
     "capabilities": [
@@ -729,9 +729,9 @@
     "vendor": "KBiosystems",
     "name": "Ultraseal",
     "models": [
-      "Ultraseal ePRO",
-      "Ultraseal PRO",
-      "Ultraseal XT PRO"
+      {"name": "Ultraseal ePRO", "status": "mostly"},
+      {"name": "Ultraseal PRO", "status": "mostly"},
+      {"name": "Ultraseal XT PRO", "status": "mostly"}
     ],
     "kind": "sealer",
     "capabilities": [
@@ -972,16 +972,16 @@
     "vendor": "QInstruments",
     "name": "BioShake",
     "models": [
-      "BioShake 3000",
-      "BioShake 3000 elm",
-      "BioShake 3000 elm DWP",
-      "BioShake 3000-T",
-      "BioShake 3000-T elm",
-      "BioShake 5000 elm",
-      "BioShake D30 elm",
-      "BioShake D30-T elm",
-      "BioShake Q1",
-      "BioShake Q2"
+      {"name": "BioShake 3000", "status": "full"},
+      {"name": "BioShake 3000 elm", "status": "full"},
+      {"name": "BioShake 3000 elm DWP", "status": "full"},
+      {"name": "BioShake 3000-T", "status": "wip"},
+      {"name": "BioShake 3000-T elm", "status": "wip"},
+      {"name": "BioShake 5000 elm", "status": "wip"},
+      {"name": "BioShake D30 elm", "status": "wip"},
+      {"name": "BioShake D30-T elm", "status": "wip"},
+      {"name": "BioShake Q1", "status": "full"},
+      {"name": "BioShake Q2", "status": "wip"}
     ],
     "kind": "heater shaker",
     "capabilities": [
@@ -995,7 +995,7 @@
     "code_slug": "qinstruments",
     "doc_slug": "qinstruments/bioshake/hello-world",
     "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-    "notes": "Capabilities and support completeness vary by model; use a model-specific factory function.",
+    "notes": "Capabilities vary by model; use a model-specific factory function.",
     "oem": "https://www.qinstruments.com/"
   },
   {
@@ -1111,9 +1111,9 @@
     "vendor": "Thermo Fisher",
     "name": "ALPS",
     "models": [
-      "ALPS 300",
-      "ALPS 3000",
-      "ALPS 5000"
+      {"name": "ALPS 300", "status": "mostly"},
+      {"name": "ALPS 3000", "status": "mostly"},
+      {"name": "ALPS 5000", "status": "mostly"}
     ],
     "kind": "sealer",
     "capabilities": [
@@ -1148,12 +1148,12 @@
     "vendor": "Thermo Fisher",
     "name": "Cytomat",
     "models": [
-      "Cytomat 2 C425",
-      "Cytomat 2 C450 SHAKE",
-      "Cytomat 2 C_50",
-      "Cytomat 5C",
-      "Cytomat 6000",
-      "Cytomat 6002"
+      {"name": "Cytomat 2 C425", "status": "full"},
+      {"name": "Cytomat 2 C450 SHAKE", "status": "full"},
+      {"name": "Cytomat 2 C_50", "status": "wip"},
+      {"name": "Cytomat 5C", "status": "full"},
+      {"name": "Cytomat 6000", "status": "full"},
+      {"name": "Cytomat 6002", "status": "full"}
     ],
     "kind": "storage",
     "capabilities": [

--- a/docs/_static/plr_devices.css
+++ b/docs/_static/plr_devices.css
@@ -153,6 +153,37 @@ td.plr-device-name {
   font-weight: 600;
 }
 
+tr.plr-device-row[data-has-models="true"] {
+  cursor: pointer;
+}
+
+.plr-device-row-toggle {
+  display: inline-grid;
+  width: 1rem;
+  height: 1rem;
+  margin: 0 0.2rem 0 0;
+  padding: 0;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  color: var(--pst-color-text-muted, #666);
+  cursor: pointer;
+  vertical-align: -0.08rem;
+}
+
+.plr-device-row-toggle:hover,
+.plr-device-row-toggle:focus-visible {
+  color: var(--pst-color-primary, #1a4ed8);
+}
+
+.plr-device-row-toggle span {
+  transition: transform 120ms ease;
+}
+
+.plr-device-row-toggle[aria-expanded="true"] span {
+  transform: rotate(90deg);
+}
+
 table.plr-device-table tr.plr-device-model-row td {
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;

--- a/docs/_static/plr_devices.css
+++ b/docs/_static/plr_devices.css
@@ -31,6 +31,30 @@
   box-shadow: 0 0 0 2px rgba(26, 78, 216, 0.18);
 }
 
+.plr-device-model-toggle {
+  flex: 0 0 auto;
+  padding: 0.5rem 0.85rem;
+  border: 1px solid var(--pst-color-border, #ccc);
+  border-radius: var(--plr-device-radius);
+  background: transparent;
+  color: var(--pst-color-text-base, #222);
+  font-size: 0.85rem;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.plr-device-model-toggle:hover,
+.plr-device-model-toggle:focus-visible {
+  border-color: var(--pst-color-primary, #1a4ed8);
+  color: var(--pst-color-primary, #1a4ed8);
+}
+
+.plr-device-model-toggle[aria-pressed="true"] {
+  background: var(--pst-color-primary, #1a4ed8);
+  border-color: var(--pst-color-primary, #1a4ed8);
+  color: #fff;
+}
+
 /* ---- Filter chips ---- */
 
 .plr-device-filters {
@@ -121,12 +145,42 @@ table.plr-device-table tbody tr[hidden] {
 
 /* Vendor and device names wrap within the same width rather than stretching the table. */
 table.plr-device-table td:first-child,
-td.plr-device-name {
+td.plr-device-name,
+td.plr-device-model-name {
   max-width: 11rem;
 }
 
 td.plr-device-name {
   font-weight: 600;
+}
+
+table.plr-device-table tr.plr-device-model-row td {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  border-bottom-style: dotted;
+  color: var(--pst-color-text-muted, #666);
+  font-size: 0.82rem;
+}
+
+td.plr-device-model-name {
+  padding-left: 0.6rem;
+}
+
+.plr-device-model {
+  display: grid;
+  grid-template-columns: 1rem minmax(0, 1fr);
+  align-items: baseline;
+  gap: 0.25rem;
+  padding-left: 0.25rem;
+}
+
+.plr-device-model__arrow {
+  text-align: center;
+}
+
+.plr-device-model__label {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 td.plr-device-capabilities {

--- a/docs/_static/plr_devices.css
+++ b/docs/_static/plr_devices.css
@@ -145,8 +145,7 @@ table.plr-device-table tbody tr[hidden] {
 
 /* Vendor and device names wrap within the same width rather than stretching the table. */
 table.plr-device-table td:first-child,
-td.plr-device-name,
-td.plr-device-model-name {
+td.plr-device-name {
   max-width: 11rem;
 }
 
@@ -163,7 +162,7 @@ table.plr-device-table tr.plr-device-model-row td {
 }
 
 td.plr-device-model-name {
-  padding-left: 0.6rem;
+  padding-left: 1rem;
 }
 
 .plr-device-model {

--- a/docs/_static/plr_devices.css
+++ b/docs/_static/plr_devices.css
@@ -196,6 +196,10 @@ td.plr-device-model-name {
   padding-left: 1rem;
 }
 
+td.plr-device-model-status {
+  white-space: nowrap;
+}
+
 .plr-device-model {
   display: grid;
   grid-template-columns: 1rem minmax(0, 1fr);

--- a/docs/_static/plr_devices.js
+++ b/docs/_static/plr_devices.js
@@ -1,6 +1,8 @@
 /* Search and chip filtering for device tables rendered by the plr_devices extension. */
 
 (function () {
+  var AUTO_SHOW_MODELS_MAX_DEVICES = 10;
+
   function all(selector, root) {
     return Array.prototype.slice.call((root || document).querySelectorAll(selector));
   }
@@ -24,6 +26,55 @@
     return wanted.indexOf(row.getAttribute("data-" + field)) !== -1;
   }
 
+  function textMatches(row, terms) {
+    var haystack = row.getAttribute("data-search") || "";
+    return terms.every(function (term) {
+      return haystack.indexOf(term) !== -1;
+    });
+  }
+
+  function applyModels(container, terms, visibleDeviceIds, visibleDeviceCount) {
+    var rowsByDevice = Object.create(null);
+
+    all(".plr-device-model-row", container).forEach(function (row) {
+      var deviceId = row.getAttribute("data-device-id");
+      (rowsByDevice[deviceId] = rowsByDevice[deviceId] || []).push(row);
+    });
+
+    var hasVisibleModels = Object.keys(rowsByDevice).some(function (deviceId) {
+      return visibleDeviceIds[deviceId];
+    });
+    var autoShow =
+      terms.length > 0 &&
+      visibleDeviceCount > 0 &&
+      visibleDeviceCount <= AUTO_SHOW_MODELS_MAX_DEVICES &&
+      hasVisibleModels;
+    var override = container._plrModelsOverride;
+    var showModels = override === null ? autoShow : override;
+
+    Object.keys(rowsByDevice).forEach(function (deviceId) {
+      var modelRows = rowsByDevice[deviceId];
+      var matchingRows = terms.length
+        ? modelRows.filter(function (row) {
+            return textMatches(row, terms);
+          })
+        : [];
+      var onlyMatchingModels = matchingRows.length > 0;
+
+      modelRows.forEach(function (row) {
+        var matchesSearch = !onlyMatchingModels || matchingRows.indexOf(row) !== -1;
+        row.hidden = !(showModels && visibleDeviceIds[deviceId] && matchesSearch);
+      });
+    });
+
+    container._plrModelsVisible = showModels;
+    var toggle = container.querySelector(".plr-device-model-toggle");
+    if (toggle) {
+      toggle.setAttribute("aria-pressed", showModels ? "true" : "false");
+      toggle.textContent = showModels ? "Hide models" : "Show models";
+    }
+  }
+
   function apply(container) {
     var input = container.querySelector(".plr-device-search__input");
     var query = (input ? input.value : "").trim().toLowerCase();
@@ -31,32 +82,47 @@
     var filters = activeFilters(container);
     var rows = all(".plr-device-row", container);
     var visible = 0;
+    var visibleDeviceIds = Object.create(null);
 
     rows.forEach(function (row) {
-      var haystack = row.getAttribute("data-search") || "";
-      var textOk = terms.every(function (term) {
-        return haystack.indexOf(term) !== -1;
-      });
+      var textOk = textMatches(row, terms);
       var filterOk = Object.keys(filters).every(function (field) {
         return rowMatches(row, field, filters[field]);
       });
       var show = textOk && filterOk;
       row.hidden = !show;
-      if (show) visible++;
+      if (show) {
+        visible++;
+        visibleDeviceIds[row.getAttribute("data-device-id")] = true;
+      }
     });
+
+    applyModels(container, terms, visibleDeviceIds, visible);
 
     var empty = container.querySelector(".plr-device-empty");
     if (empty) empty.hidden = visible !== 0;
   }
 
   function init(container) {
+    container._plrModelsOverride = null;
+    container._plrModelsVisible = false;
+
     var input = container.querySelector(".plr-device-search__input");
     if (input) {
       input.addEventListener("input", function () {
+        if (container._plrModelsOverride === false) container._plrModelsOverride = null;
         apply(container);
       });
       // A page linked as `...#device-<id>` should not hide that row behind a stale query.
       input.value = "";
+    }
+
+    var modelToggle = container.querySelector(".plr-device-model-toggle");
+    if (modelToggle) {
+      modelToggle.addEventListener("click", function () {
+        container._plrModelsOverride = !container._plrModelsVisible;
+        apply(container);
+      });
     }
 
     all(".plr-device-chip", container).forEach(function (chip) {

--- a/docs/_static/plr_devices.js
+++ b/docs/_static/plr_devices.js
@@ -35,6 +35,11 @@
 
   function applyModels(container, terms, visibleDeviceIds, visibleDeviceCount) {
     var rowsByDevice = Object.create(null);
+    var deviceRowsById = Object.create(null);
+
+    all(".plr-device-row", container).forEach(function (row) {
+      deviceRowsById[row.getAttribute("data-device-id")] = row;
+    });
 
     all(".plr-device-model-row", container).forEach(function (row) {
       var deviceId = row.getAttribute("data-device-id");
@@ -54,6 +59,9 @@
 
     Object.keys(rowsByDevice).forEach(function (deviceId) {
       var modelRows = rowsByDevice[deviceId];
+      var deviceOverride = container._plrModelDeviceOverrides[deviceId];
+      var showDeviceModels =
+        typeof deviceOverride === "boolean" ? deviceOverride : showModels;
       var matchingRows = terms.length
         ? modelRows.filter(function (row) {
             return textMatches(row, terms);
@@ -63,8 +71,23 @@
 
       modelRows.forEach(function (row) {
         var matchesSearch = !onlyMatchingModels || matchingRows.indexOf(row) !== -1;
-        row.hidden = !(showModels && visibleDeviceIds[deviceId] && matchesSearch);
+        row.hidden = !(showDeviceModels && visibleDeviceIds[deviceId] && matchesSearch);
       });
+
+      var deviceRow = deviceRowsById[deviceId];
+      if (deviceRow) {
+        deviceRow._plrModelsVisible = showDeviceModels;
+        var disclosure = deviceRow.querySelector(".plr-device-row-toggle");
+        if (disclosure) {
+          disclosure.setAttribute("aria-expanded", showDeviceModels ? "true" : "false");
+          disclosure.setAttribute(
+            "aria-label",
+            (showDeviceModels ? "Hide" : "Show") +
+              " models for " +
+              disclosure.getAttribute("data-device-label"),
+          );
+        }
+      }
     });
 
     container._plrModelsVisible = showModels;
@@ -106,6 +129,7 @@
   function init(container) {
     container._plrModelsOverride = null;
     container._plrModelsVisible = false;
+    container._plrModelDeviceOverrides = Object.create(null);
 
     var input = container.querySelector(".plr-device-search__input");
     if (input) {
@@ -120,10 +144,20 @@
     var modelToggle = container.querySelector(".plr-device-model-toggle");
     if (modelToggle) {
       modelToggle.addEventListener("click", function () {
+        container._plrModelDeviceOverrides = Object.create(null);
         container._plrModelsOverride = !container._plrModelsVisible;
         apply(container);
       });
     }
+
+    all(".plr-device-row[data-has-models='true']", container).forEach(function (row) {
+      row.addEventListener("click", function (event) {
+        if (event.target.closest("a, .plr-tip")) return;
+        var deviceId = row.getAttribute("data-device-id");
+        container._plrModelDeviceOverrides[deviceId] = !row._plrModelsVisible;
+        apply(container);
+      });
+    });
 
     all(".plr-device-chip", container).forEach(function (chip) {
       chip.addEventListener("click", function () {

--- a/docs/contributor_guide/device-registry.md
+++ b/docs/contributor_guide/device-registry.md
@@ -11,18 +11,25 @@ Append an object to `docs/_static/devices.json`:
 
 ```json
 {
-  "id": "curiox-ht2000",
-  "vendor": "Curiox",
-  "name": "HT2000",
-  "kind": "plate washer",
-  "capabilities": ["plate washing"],
-  "status": "mostly",
-  "api": "pylabrobot.curiox.CurioxHT2000",
+  "id": "cole-parmer-masterflex",
+  "vendor": "Cole Parmer",
+  "name": "Masterflex L/S",
+  "models": [
+    "07522-20",
+    "07522-30",
+    "07551-20",
+    "07551-30",
+    "07575-30",
+    "07575-40"
+  ],
+  "kind": "pump",
+  "capabilities": ["pumping"],
+  "status": "full",
+  "api": "pylabrobot.cole_parmer.Masterflex",
   "api_version": "v1",
-  "code_slug": "curiox",
-  "doc_slug": "curiox/curiox-ht2000/hello-world",
+  "code_slug": "cole_parmer",
   "manager": "https://discuss.pylabrobot.org/u/rickwierenga",
-  "oem": "https://curiox.com/"
+  "oem": "https://corporate.avantorsciences.com/us/en/bioprocess-solutions/fluid-management/masterflex-peristaltic-pumps/ls-series"
 }
 ```
 
@@ -30,7 +37,8 @@ Append an object to `docs/_static/devices.json`:
 |---|---|---|
 | `id` | yes | Unique kebab-case identifier. Used by `device-card` and as the HTML anchor (`#device-<id>`). |
 | `vendor` | yes | Manufacturer, as users would search for it. |
-| `name` | yes | Model name, without the vendor. |
+| `name` | yes | Display name for the device or device family, without the vendor. |
+| `models` | no | Exact model names or numbers when one entry covers several models, e.g. `["07522-20", "07522-30"]`. They render as searchable sub-rows beneath the device. |
 | `kind` | yes | Device type, e.g. `plate reader`, `sealer`, `arm`. Must be one of `KINDS` in `docs/_exts/plr_devices/data.py`. |
 | `status` | yes | One of `wip`, `basic`, `mostly`, `full`. See {doc}`/user_guide/machines` for what each level means. |
 | `capabilities` | no | Core functions, e.g. `["heating", "shaking"]`. Must come from `CAPABILITIES` in `docs/_exts/plr_devices/data.py`. These drive the badges and the capability filter. |
@@ -40,7 +48,7 @@ Append an object to `docs/_static/devices.json`:
 | `code_slug` | no | The driver's module or package, relative to `pylabrobot/`. Builds the **code** link to the source on GitHub; verified at build time. |
 | `manager` | no | Forum profile of whoever looks after this driver, e.g. `https://discuss.pylabrobot.org/u/rickwierenga`. Shown as their handle, and who to ask about the device. |
 | `oem` | no | Manufacturer product page. |
-| `notes` | no | One line about which models the entry covers, or what is missing. |
+| `notes` | no | One line of additional context about the entry, such as functionality that is missing. Use `models` for the hardware models an entry covers. |
 
 The registry is validated when the docs build starts: unknown fields, duplicate ids and unknown
 statuses fail the build, as do `doc_slug` and `code_slug` values that do not point at a real page
@@ -84,7 +92,9 @@ python -m pytest docs/_exts/plr_devices/registry_tests.py
 
 ## Rendering a table
 
-A bare `device-table` renders every device, with a search box and filter chips:
+A bare `device-table` renders every device, with a search box, a **Show models** toggle and filter
+chips. Models render as sub-rows beneath their device. They are initially hidden, but a text search
+always matches them and automatically reveals matching model rows when 10 or fewer devices remain:
 
 ````md
 ```{device-table}
@@ -109,7 +119,7 @@ pre-filtered list on a vendor page.
 
 `device-card` renders one device. It works anywhere MyST is parsed, including markdown cells in the
 notebooks under `docs/user_guide` — put one at the top of a machine's hello-world notebook so the
-page carries the same vendor, support level, capabilities and links as the table.
+page carries the same vendor, models, support level, capabilities and links as the table.
 
 ````md
 ```{device-card} curiox-ht2000

--- a/docs/contributor_guide/device-registry.md
+++ b/docs/contributor_guide/device-registry.md
@@ -15,12 +15,12 @@ Append an object to `docs/_static/devices.json`:
   "vendor": "Cole Parmer",
   "name": "Masterflex L/S",
   "models": [
-    "07522-20",
-    "07522-30",
-    "07551-20",
-    "07551-30",
-    "07575-30",
-    "07575-40"
+    {"name": "07522-20", "status": "full"},
+    {"name": "07522-30", "status": "full"},
+    {"name": "07551-20", "status": "full"},
+    {"name": "07551-30", "status": "full"},
+    {"name": "07575-30", "status": "full"},
+    {"name": "07575-40", "status": "full"}
   ],
   "kind": "pump",
   "capabilities": ["pumping"],
@@ -38,7 +38,7 @@ Append an object to `docs/_static/devices.json`:
 | `id` | yes | Unique kebab-case identifier. Used by `device-card` and as the HTML anchor (`#device-<id>`). |
 | `vendor` | yes | Manufacturer, as users would search for it. |
 | `name` | yes | Display name for the device or device family, without the vendor. |
-| `models` | no | Exact model names or numbers when one entry covers several models, e.g. `["07522-20", "07522-30"]`. They render as searchable sub-rows beneath the device. |
+| `models` | no | Model objects when one entry covers several models. `name` is required; `status` may be `wip`, `basic`, `mostly`, or `full` and defaults to the device status when omitted. Models render as searchable sub-rows with their support status beneath the device. |
 | `kind` | yes | Device type, e.g. `plate reader`, `sealer`, `arm`. Must be one of `KINDS` in `docs/_exts/plr_devices/data.py`. |
 | `status` | yes | One of `wip`, `basic`, `mostly`, `full`. See {doc}`/user_guide/machines` for what each level means. |
 | `capabilities` | no | Core functions, e.g. `["heating", "shaking"]`. Must come from `CAPABILITIES` in `docs/_exts/plr_devices/data.py`. These drive the badges and the capability filter. |
@@ -94,7 +94,8 @@ python -m pytest docs/_exts/plr_devices/registry_tests.py
 
 A bare `device-table` renders every device, with a search box, a **Show models** toggle and filter
 chips. Models render as sub-rows beneath their device. A device row can reveal its own models, and
-the toggle reveals them all. Models are initially hidden, but a text search
+the toggle reveals them all. Each model's support badge is aligned beneath the device support
+column. Models are initially hidden, but a text search
 always matches them and automatically reveals matching model rows when 10 or fewer devices remain:
 
 ````md

--- a/docs/contributor_guide/device-registry.md
+++ b/docs/contributor_guide/device-registry.md
@@ -93,7 +93,8 @@ python -m pytest docs/_exts/plr_devices/registry_tests.py
 ## Rendering a table
 
 A bare `device-table` renders every device, with a search box, a **Show models** toggle and filter
-chips. Models render as sub-rows beneath their device. They are initially hidden, but a text search
+chips. Models render as sub-rows beneath their device. A device row can reveal its own models, and
+the toggle reveals them all. Models are initially hidden, but a text search
 always matches them and automatically reveals matching model rows when 10 or fewer devices remain:
 
 ````md

--- a/docs/user_guide/brooks/precise_flex/hello-world.ipynb
+++ b/docs/user_guide/brooks/precise_flex/hello-world.ipynb
@@ -21,10 +21,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```{device-card} brooks-preciseflex-pf400\n",
-    "```\n",
-    "\n",
-    "```{device-card} brooks-preciseflex-pf3400\n",
+    "```{device-card} brooks-preciseflex\n",
     "```"
    ],
    "id": "device-card"

--- a/docs/user_guide/hamilton/star/index.md
+++ b/docs/user_guide/hamilton/star/index.md
@@ -1,9 +1,6 @@
-# Hamilton STAR
+# Hamilton STAR and STARlet
 
 ```{device-card} hamilton-star
-```
-
-```{device-card} hamilton-starlet
 ```
 
 ```{toctree}

--- a/docs/user_guide/kbiosystems/ultraseal-epro/hello-world.ipynb
+++ b/docs/user_guide/kbiosystems/ultraseal-epro/hello-world.ipynb
@@ -10,7 +10,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```{device-card} kbiosystems-ultraseal-epro\n",
+    "```{device-card} kbiosystems-ultraseal\n",
     "```"
    ],
    "id": "device-card"

--- a/docs/user_guide/kbiosystems/ultraseal-pro/hello-world.ipynb
+++ b/docs/user_guide/kbiosystems/ultraseal-pro/hello-world.ipynb
@@ -10,7 +10,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```{device-card} kbiosystems-ultraseal-pro\n",
+    "```{device-card} kbiosystems-ultraseal\n",
     "```"
    ],
    "id": "device-card"

--- a/docs/user_guide/kbiosystems/ultraseal-xt-pro/hello-world.ipynb
+++ b/docs/user_guide/kbiosystems/ultraseal-xt-pro/hello-world.ipynb
@@ -10,7 +10,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```{device-card} kbiosystems-ultraseal-xt-pro\n",
+    "```{device-card} kbiosystems-ultraseal\n",
     "```"
    ],
    "id": "device-card"

--- a/docs/user_guide/machines.md
+++ b/docs/user_guide/machines.md
@@ -7,8 +7,10 @@ the [forum](https://discuss.pylabrobot.org).
 ```{device-table}
 ```
 
-An asterisk after a device name marks a note about the models that entry covers; hover it to read
-the note.
+Some registry entries cover several hardware models. Select **Show models** to display each model
+as a sub-row beneath its device. Model names are always included in search; when a text search
+leaves 10 or fewer devices, matching model sub-rows appear automatically. An asterisk after a
+device name marks an additional note; hover it to read the note.
 
 ## Reading the table
 

--- a/docs/user_guide/machines.md
+++ b/docs/user_guide/machines.md
@@ -8,9 +8,10 @@ the [forum](https://discuss.pylabrobot.org).
 ```
 
 Some registry entries cover several hardware models. Click one of those device rows to reveal its
-models, or select **Show models** to display all model sub-rows. Model names are always included in search; when a text search
-leaves 10 or fewer devices, matching model sub-rows appear automatically. An asterisk after a
-device name marks an additional note; hover it to read the note.
+models, or select **Show models** to display all model sub-rows. Each model has its own support
+status. Model names are always included in search; when a text search leaves 10 or fewer devices,
+matching model sub-rows appear automatically. An asterisk after a device name marks an additional
+note; hover it to read the note.
 
 ## Reading the table
 

--- a/docs/user_guide/machines.md
+++ b/docs/user_guide/machines.md
@@ -7,8 +7,8 @@ the [forum](https://discuss.pylabrobot.org).
 ```{device-table}
 ```
 
-Some registry entries cover several hardware models. Select **Show models** to display each model
-as a sub-row beneath its device. Model names are always included in search; when a text search
+Some registry entries cover several hardware models. Click one of those device rows to reveal its
+models, or select **Show models** to display all model sub-rows. Model names are always included in search; when a text search
 leaves 10 or fewer devices, matching model sub-rows appear automatically. An asterisk after a
 device name marks an additional note; hover it to read the note.
 

--- a/docs/user_guide/thermo_fisher/alps/alps300/hello-world.ipynb
+++ b/docs/user_guide/thermo_fisher/alps/alps300/hello-world.ipynb
@@ -10,7 +10,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```{device-card} thermo-fisher-alps-300\n",
+    "```{device-card} thermo-fisher-alps\n",
     "```"
    ],
    "id": "device-card"

--- a/docs/user_guide/thermo_fisher/alps/alps3000/hello-world.ipynb
+++ b/docs/user_guide/thermo_fisher/alps/alps3000/hello-world.ipynb
@@ -10,7 +10,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```{device-card} thermo-fisher-alps-3000\n",
+    "```{device-card} thermo-fisher-alps\n",
     "```"
    ],
    "id": "device-card"

--- a/docs/user_guide/thermo_fisher/alps/alps5000/hello-world.ipynb
+++ b/docs/user_guide/thermo_fisher/alps/alps5000/hello-world.ipynb
@@ -10,7 +10,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```{device-card} thermo-fisher-alps-5000\n",
+    "```{device-card} thermo-fisher-alps\n",
     "```"
    ],
    "id": "device-card"


### PR DESCRIPTION
## Summary

- add validated model objects with per-model support statuses to device registry entries
- render searchable model names across the first three table columns, with status badges aligned beneath device support
- let each model-bearing device row reveal its models through a compact chevron, with a bulk Show models toggle
- automatically reveal matching models when search narrows to 10 or fewer device families and count searchable models in the prompt
- consolidate the Masterflex model note and the Thermoshake, ALPS, Cytomat, PreciseFlex, STAR/STARlet, Ultraseal, and BioShake families
- limit the Cytation 1 capability listing to microscopy
- update affected guide cards and document the registry schema and model browsing behavior

## Testing

- `.venv/bin/python -m pytest docs/_exts/plr_devices/registry_tests.py` (29 passed)
- `.venv/bin/python -m ruff check docs/_exts/plr_devices/data.py docs/_exts/plr_devices/html.py docs/_exts/plr_devices/registry_tests.py`
- warning-as-error Sphinx builds of the machine table and all affected guide pages
