### PR TITLE
Compare OT-2 API versions numerically

### DIFF
--- a/pylabrobot/legacy/liquid_handling/backends/opentrons_backend.py
+++ b/pylabrobot/legacy/liquid_handling/backends/opentrons_backend.py
@@ -47,6 +47,13 @@ _OT_DECK_IS_ADDRESSABLE_AREA_VERSION = "7.1.0"
 logger = logging.getLogger(__name__)
 
 
+def _version_is_at_least(version: str, minimum: str) -> bool:
+  """Compare versions that contain dot-separated integers."""
+  return tuple(int(component) for component in version.split(".")) >= tuple(
+    int(component) for component in minimum.split(".")
+  )
+
+
 class _IOLogger:
   """Transparent proxy over the ``ot_api`` module that logs every call at
   ``LOG_LEVEL_IO``.
@@ -378,7 +385,7 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
     op = ops[0]
 
     use_fixed_trash = (
-      cast(str, self.ot_api_version) >= _OT_DECK_IS_ADDRESSABLE_AREA_VERSION
+      _version_is_at_least(cast(str, self.ot_api_version), _OT_DECK_IS_ADDRESSABLE_AREA_VERSION)
       and op.resource.name == "trash"
     )
     if use_fixed_trash:

--- a/pylabrobot/legacy/liquid_handling/backends/opentrons_backend_tests.py
+++ b/pylabrobot/legacy/liquid_handling/backends/opentrons_backend_tests.py
@@ -8,6 +8,7 @@ pytest.importorskip("ot_api")
 from pylabrobot.legacy.liquid_handling import LiquidHandler
 from pylabrobot.legacy.liquid_handling.backends.opentrons_backend import (
   _OT_DECK_IS_ADDRESSABLE_AREA_VERSION,
+  _version_is_at_least,
   OpentronsOT2Backend,
 )
 from pylabrobot.legacy.liquid_handling.errors import NoChannelError
@@ -34,6 +35,14 @@ def _mock_health_get():
   return {
     "api_version": "7.0.1",
   }
+
+
+@pytest.mark.parametrize(
+  ("version", "expected"),
+  (("7.0.1", False), ("7.1.0", True), ("26.6.0", True)),
+)
+def test_version_is_at_least(version: str, expected: bool) -> None:
+  assert _version_is_at_least(version, _OT_DECK_IS_ADDRESSABLE_AREA_VERSION) is expected
 
 
 class OpentronsBackendSetupTests(unittest.IsolatedAsyncioTestCase):
@@ -233,7 +242,7 @@ class OpentronsBackendCommandTests(unittest.IsolatedAsyncioTestCase):
     area (move_to_addressable_area_for_drop_tip + drop_tip_in_place), not drop_tip."""
     mock_define.side_effect = _mock_define
     mock_add.side_effect = _mock_add
-    self.backend.ot_api_version = _OT_DECK_IS_ADDRESSABLE_AREA_VERSION
+    self.backend.ot_api_version = "26.6.0"
 
     await self.lh.pick_up_tips(self.tip_rack["A1"])
     await self.lh.discard_tips()


### PR DESCRIPTION
## Summary

OT-2 robot server versions can have multi-digit major components. The previous text comparison treated version 26.6.0 as older than 7.1.0. Fixed-trash disposal then entered the tip-rack path and raised an assertion.

- Compare dot-separated numeric components before selecting the fixed-trash route.
- Cover a version below the boundary, the 7.1.0 boundary, and robot version 26.6.0.

## Verification

- Focused Opentrons backend tests: 24 passed.
- Ruff lint and format checks passed.
- Focused MyPy check passed.
- Physical OT-2 with robot API 26.6.0: fixed-trash disposal completed for the P300 and P20 pipettes. A combined two-transfer LabYard run completed once and did not replay after reconstruction.