### PR TITLE
Route OT-2 fixed-trash disposal by API version

### DIFF
--- a/pylabrobot/legacy/liquid_handling/backends/opentrons_backend.py
+++ b/pylabrobot/legacy/liquid_handling/backends/opentrons_backend.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+import re
 import uuid
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
@@ -45,6 +46,28 @@ except ImportError as e:
 _OT_DECK_IS_ADDRESSABLE_AREA_VERSION = "7.1.0"
 
 logger = logging.getLogger(__name__)
+
+
+def _opentrons_version_components(version: str) -> Tuple[int, int, int]:
+  """Parse the numeric release components from an Opentrons server version.
+
+  Raises:
+    ValueError: If the version does not start with major, minor, and patch numbers.
+  """
+  match = re.match(r"^(\d+)\.(\d+)\.(\d+)", version)
+  if match is None:
+    raise ValueError(
+      f"Opentrons server version must start with major, minor, and patch numbers: {version!r}."
+    )
+  major, minor, patch = match.groups()
+  return int(major), int(minor), int(patch)
+
+
+def _fixed_trash_is_addressable(api_version: str) -> bool:
+  """Return whether fixed trash uses the addressable-area commands."""
+  return _opentrons_version_components(api_version) >= _opentrons_version_components(
+    _OT_DECK_IS_ADDRESSABLE_AREA_VERSION
+  )
 
 
 class _IOLogger:
@@ -377,9 +400,8 @@ class OpentronsOT2Backend(LiquidHandlerBackend):
     pipette_id = self._get_drop_pipette(ops)
     op = ops[0]
 
-    use_fixed_trash = (
-      cast(str, self.ot_api_version) >= _OT_DECK_IS_ADDRESSABLE_AREA_VERSION
-      and op.resource.name == "trash"
+    use_fixed_trash = op.resource.name == "trash" and _fixed_trash_is_addressable(
+      cast(str, self.ot_api_version)
     )
     if use_fixed_trash:
       labware_id = "fixedTrash"

--- a/pylabrobot/legacy/liquid_handling/backends/opentrons_backend_tests.py
+++ b/pylabrobot/legacy/liquid_handling/backends/opentrons_backend_tests.py
@@ -7,8 +7,8 @@ pytest.importorskip("ot_api")
 
 from pylabrobot.legacy.liquid_handling import LiquidHandler
 from pylabrobot.legacy.liquid_handling.backends.opentrons_backend import (
-  _OT_DECK_IS_ADDRESSABLE_AREA_VERSION,
   OpentronsOT2Backend,
+  _fixed_trash_is_addressable,
 )
 from pylabrobot.legacy.liquid_handling.errors import NoChannelError
 from pylabrobot.legacy.liquid_handling.standard import (
@@ -34,6 +34,25 @@ def _mock_health_get():
   return {
     "api_version": "7.0.1",
   }
+
+
+@pytest.mark.parametrize(
+  ("version", "expected"),
+  (
+    ("7.0.1", False),
+    ("7.1.0", True),
+    ("9.1.0-alpha.12", True),
+    ("9.1.0.dev12", True),
+    ("26.6.0", True),
+  ),
+)
+def test_fixed_trash_is_addressable(version: str, expected: bool) -> None:
+  assert _fixed_trash_is_addressable(version) is expected
+
+
+def test_fixed_trash_rejects_invalid_server_version() -> None:
+  with pytest.raises(ValueError, match="must start with major, minor, and patch numbers"):
+    _fixed_trash_is_addressable("development")
 
 
 class OpentronsBackendSetupTests(unittest.IsolatedAsyncioTestCase):
@@ -147,6 +166,7 @@ class OpentronsBackendCommandTests(unittest.IsolatedAsyncioTestCase):
       self.assertEqual(offset_z, offset_z)
 
     mock_drop_tip.side_effect = assert_parameters
+    self.backend.ot_api_version = "development"
 
     await self.test_tip_pick_up()
     await self.lh.drop_tips(self.tip_rack["A1"])
@@ -233,7 +253,7 @@ class OpentronsBackendCommandTests(unittest.IsolatedAsyncioTestCase):
     area (move_to_addressable_area_for_drop_tip + drop_tip_in_place), not drop_tip."""
     mock_define.side_effect = _mock_define
     mock_add.side_effect = _mock_add
-    self.backend.ot_api_version = _OT_DECK_IS_ADDRESSABLE_AREA_VERSION
+    self.backend.ot_api_version = "26.6.0"
 
     await self.lh.pick_up_tips(self.tip_rack["A1"])
     await self.lh.discard_tips()


### PR DESCRIPTION
## Summary

The OT-2 backend selected its fixed-trash command route by comparing server versions as text. A multi-digit version such as `26.6.0` was therefore treated as older than `7.1.0` and entered the tip-rack path.

- Parse the numeric major, minor, and patch components before selecting fixed-trash commands.
- Support server versions with release suffixes.
- Keep ordinary tip returns independent of server-version parsing.
- Reject versions that do not start with numeric major, minor, and patch components.

## Verification

- `python -m pytest pylabrobot/legacy/liquid_handling/backends/opentrons_backend_tests.py pylabrobot/legacy/liquid_handling/backends/opentrons_chatterbox_tests.py -q` — 32 passed.
- Focused Ruff format, lint, and import checks passed.
- Focused MyPy check passed.
- Physical OT-2 with API `26.6.0`: fixed-trash disposal completed with the P20 and P300 pipettes using the numeric route-selection implementation.
- Release-suffix handling was verified in software because the OT-2 was not connected for the final parser revision.

Repository-wide `make lint` and `make format-check` still report existing failures outside this change.