### PR TITLE
fix(resources): center a plate on the adapter hole's y size, not its x size

### DIFF
--- a/pylabrobot/resources/plate_adapter.py
+++ b/pylabrobot/resources/plate_adapter.py
@@ -154,7 +154,7 @@ class PlateAdapter(Resource):
 
     # Calculate adjustment to place center of H1_plate on top of center of H1_adapter
     plate_x_adjustment = self.dx - plate_dx + self.adapter_hole_size_x / 2 - well_size_x / 2
-    plate_y_adjustment = self.dy - plate_dy + self.adapter_hole_size_x / 2 - well_size_y / 2
+    plate_y_adjustment = self.dy - plate_dy + self.adapter_hole_size_y / 2 - well_size_y / 2
     # basic plate_z_adjustment ability
     plate_z_adjustment = self.dz + self.plate_z_offset
     # TODO: create more sophisticated plate_z_adjustment based on

--- a/pylabrobot/resources/plate_adapter_tests.py
+++ b/pylabrobot/resources/plate_adapter_tests.py
@@ -1,6 +1,12 @@
 import unittest
 
-from pylabrobot.resources import PlateAdapter
+from pylabrobot.resources import (
+  Coordinate,
+  Plate,
+  PlateAdapter,
+  Well,
+  create_ordered_items_2d,
+)
 
 _adapter = PlateAdapter(
   name="adapter",
@@ -43,3 +49,48 @@ class TestPlateAdapter(unittest.TestCase):
 
   def test_plate_adapter_deserialization(self):
     assert _adapter == PlateAdapter.deserialize(_adapter.serialize())
+
+
+class TestComputePlateLocation(unittest.TestCase):
+  def test_rectangular_hole_centers_each_axis_on_its_own_size(self):
+    """A hole whose x and y sizes differ centers the well on the hole in both directions."""
+
+    adapter = PlateAdapter(
+      name="rectangular_hole_adapter",
+      size_x=128.0,
+      size_y=86.0,
+      size_z=15.0,
+      dx=10.0,
+      dy=8.0,
+      dz=2.0,
+      adapter_hole_size_x=8.0,
+      adapter_hole_size_y=6.0,
+      adapter_hole_dx=9.0,
+      adapter_hole_dy=9.0,
+    )
+    adapter.location = Coordinate.zero()
+    plate = Plate(
+      name="plate",
+      size_x=127.76,
+      size_y=85.48,
+      size_z=14.0,
+      ordered_items=create_ordered_items_2d(
+        Well,
+        num_items_x=12,
+        num_items_y=8,
+        dx=9.5,
+        dy=6.5,
+        dz=1.0,
+        item_dx=9.0,
+        item_dy=9.0,
+        size_x=6.0,
+        size_y=6.0,
+        size_z=10.0,
+      ),
+    )
+
+    adapter.assign_child_resource(plate)
+
+    well_center = plate.get_well("H1").get_location_wrt(adapter, x="c", y="c", z="b")
+    self.assertAlmostEqual(well_center.x, adapter.dx + adapter.adapter_hole_size_x / 2)
+    self.assertAlmostEqual(well_center.y, adapter.dy + adapter.adapter_hole_size_y / 2)


### PR DESCRIPTION
## Problem

`PlateAdapter.compute_plate_location` works out where a plate has to sit so its well grid lines up with the adapter's hole grid. The y term uses the hole's x size (`pylabrobot/resources/plate_adapter.py:157`):

```python
plate_x_adjustment = self.dx - plate_dx + self.adapter_hole_size_x / 2 - well_size_x / 2
plate_y_adjustment = self.dy - plate_dy + self.adapter_hole_size_x / 2 - well_size_y / 2
```

A hole is described by two sizes, `adapter_hole_size_x` and `adapter_hole_size_y`. When they differ the plate is placed `(adapter_hole_size_x - adapter_hole_size_y) / 2` mm off in y, and every well coordinate read off the plate afterwards carries that offset. `PlateAdapter.assign_child_resource` uses the same value when no location is given, so assigning a plate to an adapter with non-square holes misplaces it without any error.

All four adapters defined in the repo (Hamilton 188182, Sergi 1047, Alpaqua MAGNUM FLX, Thermo MicroAmp base) have square holes, so the two sizes are equal and the bug does not show up on them. It shows up on any adapter with rectangular or slot-shaped holes.

## Fix

Use `adapter_hole_size_y` in the y term, matching the x term on the line above.

## Tests

`TestComputePlateLocation.test_rectangular_hole_centers_each_axis_on_its_own_size` in `plate_adapter_tests.py` builds an adapter with an 8.0 x 6.0 mm hole and a 96 well plate on a 9.0 mm pitch, then asserts the front left well center lands on the front left hole center in both x and y. Against the unfixed `plate_adapter.py` it fails with `AssertionError: 12.0 != 11.0 within 7 places (1.0 difference)`, and it passes with the fix.

## Verification

`python -m pytest pylabrobot/resources` on the branch: 258 passed, 71 subtests passed.

`python -m pytest pylabrobot/resources/plate_adapter_tests.py` with `plate_adapter.py` reverted to main and the new test kept: 1 failed, 2 passed, with the assertion above.

`make lint` and `make format-check` (ruff 0.15.4, the pinned version): "All checks passed!" and "771 files already formatted".

`python -m mypy` (1.18.2, the pinned version) on the two changed files: "Success: no issues found in 2 source files".
