### PR TITLE
Support eight-channel pipettes in the OT-2 driver

### DIFF
--- a/docs/api/pylabrobot.opentrons.rst
+++ b/docs/api/pylabrobot.opentrons.rst
@@ -8,6 +8,11 @@ pylabrobot.opentrons package
 the robot; ``setup()`` also loads the pipettes into a run and optionally homes.
 Queries return fresh values without changing the driver's session state.
 
+Each mount is an ``OT2SingleChannelPipette`` or ``OT2_8ChannelPipette``, selected
+from the discovered model. Both share motion, command execution, and transactional
+tracking. Single-channel pipettes take one tip spot or container; eight-channel
+pipettes take a complete column in nozzle order, with a shared volume per nozzle.
+
 ``OpentronsAPI`` contains the named HTTP endpoints and response parsing.
 ``OpentronsRun`` provides command primitives and waits for their completion.
 Both use the device's ``pylabrobot.io.HTTP`` transport. Pipette operations own
@@ -19,7 +24,8 @@ resource tracking and retraction to traversal height.
   :recursive:
 
     OT2
-    OT2Pipette
+    OT2SingleChannelPipette
+    OT2_8ChannelPipette
     OpentronsAPI
     OpentronsRun
     RobotInfo

--- a/pylabrobot/opentrons/__init__.py
+++ b/pylabrobot/opentrons/__init__.py
@@ -5,6 +5,6 @@ from .errors import (
   OpentronsError,
   OpentronsProtocolError,
 )
-from .ot2 import OT2, OT2Pipette
+from .ot2 import OT2, OT2_8ChannelPipette, OT2SingleChannelPipette
 from .run import OpentronsRun
 from .types import ModuleInfo, MountedPipette, RobotInfo

--- a/pylabrobot/opentrons/ot2/__init__.py
+++ b/pylabrobot/opentrons/ot2/__init__.py
@@ -1,2 +1,2 @@
 from .ot2 import OT2
-from .pipette import OT2Pipette
+from .pipette import OT2_8ChannelPipette, OT2SingleChannelPipette

--- a/pylabrobot/opentrons/ot2/ot2.py
+++ b/pylabrobot/opentrons/ot2/ot2.py
@@ -3,7 +3,7 @@
 import asyncio
 import math
 import uuid
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 from pylabrobot.io.http import HTTP
 from pylabrobot.opentrons.api import HTTP_API_VERSION, OpentronsAPI
@@ -12,7 +12,11 @@ from pylabrobot.opentrons.labware import (
   build_tip_rack_definition,
   official_tip_rack_identity,
 )
-from pylabrobot.opentrons.ot2.pipette import _PIPETTE_SPECS, OT2Pipette
+from pylabrobot.opentrons.ot2.pipette import (
+  _PIPETTE_SPECS,
+  OT2_8ChannelPipette,
+  OT2SingleChannelPipette,
+)
 from pylabrobot.opentrons.run import OpentronsRun
 from pylabrobot.opentrons.types import (
   LabwareIdentity,
@@ -73,12 +77,12 @@ class OT2:
     self._connected = False
     self._run: Optional[OpentronsRun] = None
     self._labware: Optional[LabwareRegistry] = None
-    self.left_pipette: Optional[OT2Pipette] = None
-    self.right_pipette: Optional[OT2Pipette] = None
+    self.left_pipette: Optional[Union[OT2SingleChannelPipette, OT2_8ChannelPipette]] = None
+    self.right_pipette: Optional[Union[OT2SingleChannelPipette, OT2_8ChannelPipette]] = None
     self._operation_lock = asyncio.Lock()
 
   @property
-  def pipettes(self) -> List[OT2Pipette]:
+  def pipettes(self) -> List[Union[OT2SingleChannelPipette, OT2_8ChannelPipette]]:
     """Mounted pipettes, left first."""
     return [p for p in (self.left_pipette, self.right_pipette) if p is not None]
 
@@ -153,7 +157,11 @@ class OT2:
     run = self._require_run()
     for pipette in mounted:
       pipette_id = await run.load_pipette(pipette.name, pipette.mount)
-      bound = OT2Pipette(self, pipette.mount, pipette.name, pipette_id)
+      bound: Union[OT2SingleChannelPipette, OT2_8ChannelPipette]
+      if _PIPETTE_SPECS[pipette.name].channels == 8:
+        bound = OT2_8ChannelPipette(self, pipette.mount, pipette.name, pipette_id)
+      else:
+        bound = OT2SingleChannelPipette(self, pipette.mount, pipette.name, pipette_id)
       if pipette.mount == "left":
         self.left_pipette = bound
       else:

--- a/pylabrobot/opentrons/ot2/ot2_tests.py
+++ b/pylabrobot/opentrons/ot2/ot2_tests.py
@@ -3,11 +3,17 @@ import unittest
 from typing import Any, Dict, List, Optional, Tuple
 
 from pylabrobot.io.http import HTTP, HTTPError
-from pylabrobot.opentrons import OT2, OpentronsError
+from pylabrobot.opentrons import OT2, OpentronsError, OT2_8ChannelPipette, OT2SingleChannelPipette
+from pylabrobot.opentrons.ot2.pipette import _OT2Pipette
 from pylabrobot.opentrons.types import ModuleInfo
 from pylabrobot.resources import Coordinate, set_tip_tracking, set_volume_tracking
 from pylabrobot.resources.celltreat import celltreat_96_wellplate_350uL_Fb
-from pylabrobot.resources.errors import TooLittleLiquidError, TooLittleVolumeError
+from pylabrobot.resources.errors import (
+  HasTipError,
+  NoTipError,
+  TooLittleLiquidError,
+  TooLittleVolumeError,
+)
 from pylabrobot.resources.opentrons import OTDeck, opentrons_96_filtertiprack_20ul
 
 
@@ -149,7 +155,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_full_single_channel_protocol_updates_trackers_and_commands(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     source = self.plate.get_well("A1")
     destination = self.plate.get_well("B1")
     source.tracker.set_volume(15)
@@ -219,7 +225,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_return_tip_restores_its_origin(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     origin = self.tips.get_item("A1")
 
     await pipette.pick_up_tip(origin)
@@ -234,7 +240,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_pickup_retracts_with_tip_state_committed(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     origin = self.tips.get_item("A1")
 
     await pipette.pick_up_tip(origin)
@@ -251,7 +257,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_failed_retraction_preserves_completed_pickup(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     origin = self.tips.get_item("A1")
     for failed_command in ("savePosition", "moveToCoordinates"):
       with self.subTest(failed_command=failed_command):
@@ -269,7 +275,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_move_to_retracts_without_lowering_an_already_high_tip(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     for z in (10, 150):
       with self.subTest(z=z):
         self.io.saved_position = {"x": 100, "y": 200, "z": z}
@@ -291,7 +297,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_drop_tip_retracts_vertically_from_reported_position(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     await pipette.pick_up_tip(self.tips.get_item("A1"))
     self.tips.set_tip_state({"A12": False})
     self.robot.traversal_height = 140
@@ -312,14 +318,14 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_discard_tip_retracts_for_both_trash_apis(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     for tip_index, version in enumerate(("6.3.0", "7.1.0")):
       with self.subTest(version=version):
         await self.robot.stop()
         self.io.api_version = version
         await self.robot.setup(skip_home=True)
         pipette = self.robot.left_pipette
-        assert pipette is not None
+        assert isinstance(pipette, OT2SingleChannelPipette)
         await pipette.pick_up_tip(self.tips.get_item(tip_index))
 
         await pipette.discard_tip()
@@ -335,7 +341,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_drop_does_not_lower_a_nozzle_above_traversal_height(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     await pipette.pick_up_tip(self.tips.get_item("A1"))
     self.io.saved_position["z"] = self.robot.traversal_height + 10
     command_count = len(self.io.commands)
@@ -350,7 +356,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_failed_drop_preserves_tip_and_does_not_retract(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     await pipette.pick_up_tip(self.tips.get_item("A1"))
     tip = pipette.tip
     self.io.fail_command_type = "dropTip"
@@ -367,7 +373,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_failed_retraction_preserves_completed_tip_drop(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     for tip_index, (operation, failed_command, returned) in enumerate(
       (
         (pipette.return_tip, "savePosition", True),
@@ -395,7 +401,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
     tips = opentrons_96_filtertiprack_20ul(name="official_tips")
     self.deck.assign_child_at_slot(tips, slot=3)
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     definition_request_count = len(
       [
         path
@@ -428,7 +434,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_failed_aspiration_rolls_back_volume_trackers(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     source = self.plate.get_well("A1")
     source.tracker.set_volume(15)
     await pipette.pick_up_tip(self.tips.get_item("A1"))
@@ -443,7 +449,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_liquid_operations_retract_from_reported_position(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     await pipette.pick_up_tip(self.tips.get_item("A1"))
     assert pipette.tip is not None
     well = self.plate.get_well("A1")
@@ -463,7 +469,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_rejected_aspiration_preserves_both_volume_trackers(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     await pipette.pick_up_tip(self.tips.get_item("A1"))
     assert pipette.tip is not None
     pipette.tip.tracker.set_volume(15)
@@ -482,7 +488,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_rejected_dispense_preserves_both_volume_trackers(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     await pipette.pick_up_tip(self.tips.get_item("A1"))
     assert pipette.tip is not None
     pipette.tip.tracker.set_volume(10)
@@ -502,7 +508,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_failed_retraction_preserves_completed_transfer(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     await pipette.pick_up_tip(self.tips.get_item("A1"))
     assert pipette.tip is not None
     well = self.plate.get_well("A1")
@@ -529,7 +535,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_moved_or_unassigned_loaded_rack_is_rejected_before_a_command(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     await pipette.pick_up_tip(self.tips.get_item("A1"))
     await pipette.return_tip()
     self.deck.unassign_child_resource(self.tips)
@@ -547,7 +553,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_drop_into_moved_rack_preserves_tip_state(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     await pipette.pick_up_tip(self.tips.get_item("A1"))
     self.deck.unassign_child_resource(self.tips)
     self.deck.assign_child_at_slot(self.tips, slot=5)
@@ -562,7 +568,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_concurrent_pickups_only_pick_up_one_tip(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     results = await asyncio.wait_for(
       asyncio.gather(
         pipette.pick_up_tip(self.tips.get_item("A1")),
@@ -582,7 +588,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_concurrent_transfer_checks_state_after_preceding_operation(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     await pipette.pick_up_tip(self.tips.get_item("A1"))
     source = self.plate.get_well("A1")
     destination = self.plate.get_well("B1")
@@ -603,7 +609,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_concurrent_return_and_discard_only_drop_once(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     await pipette.pick_up_tip(self.tips.get_item("A1"))
     results = await asyncio.wait_for(
       asyncio.gather(pipette.return_tip(), pipette.discard_tip(), return_exceptions=True),
@@ -622,7 +628,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_mix_rejects_insufficient_liquid_or_tip_capacity_before_moving(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     await pipette.pick_up_tip(self.tips.get_item("A1"))
     assert pipette.tip is not None
     source = self.plate.get_well("A1")
@@ -642,7 +648,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_mix_tracks_each_transfer_when_dispense_fails(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     await pipette.pick_up_tip(self.tips.get_item("A1"))
     source = self.plate.get_well("A1")
     source.tracker.set_volume(15)
@@ -660,7 +666,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_mix_preserves_volume_after_completed_cycles(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     await pipette.pick_up_tip(self.tips.get_item("A1"))
     assert pipette.tip is not None
     source = self.plate.get_well("A1")
@@ -690,7 +696,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_unreachable_move_is_rejected_before_an_http_command(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     command_count = len(self.io.commands)
 
     with self.assertRaisesRegex(ValueError, "reachable"):
@@ -700,7 +706,7 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
   async def test_negative_z_move_is_rejected_before_an_http_command(self) -> None:
     pipette = self.robot.left_pipette
-    assert pipette is not None
+    assert isinstance(pipette, OT2SingleChannelPipette)
     command_count = len(self.io.commands)
 
     with self.assertRaisesRegex(ValueError, "non-negative"):
@@ -761,20 +767,261 @@ class OT2Tests(unittest.IsolatedAsyncioTestCase):
 
 
 class OT2MultiChannelTests(unittest.IsolatedAsyncioTestCase):
-  async def test_multi_channel_is_modeled_but_not_mistracked_as_one_tip(self) -> None:
-    io = FakeHTTP(left_pipette_name="p20_multi_gen2")
-    deck = OTDeck()
-    robot = OT2(host="ot2.local", deck=deck, command_poll_interval=0, io=io)
-    await robot.setup(skip_home=True)
-    tips = opentrons_96_filtertiprack_20ul(name="tips")
-    deck.assign_child_at_slot(tips, slot=1)
-    assert robot.left_pipette is not None
-    self.assertEqual(robot.left_pipette.num_channels, 8)
+  async def asyncSetUp(self) -> None:
+    """Set up a multi and a single on the same robot using only fake HTTP."""
+    set_tip_tracking(True)
+    set_volume_tracking(True)
+    self.io = FakeHTTP(left_pipette_name="p20_multi_gen2", right_pipette_name="p20_single_gen2")
+    self.deck = OTDeck()
+    self.robot = OT2(host="ot2.local", deck=self.deck, command_poll_interval=0, io=self.io)
+    await self.robot.setup(skip_home=True)
+    assert isinstance(self.robot.left_pipette, OT2_8ChannelPipette)
+    self.pipette = self.robot.left_pipette
+    self.tips = opentrons_96_filtertiprack_20ul(name="tips")
+    self.tips.model = None
+    self.deck.assign_child_at_slot(self.tips, slot=1)
+    self.plate = celltreat_96_wellplate_350uL_Fb(name="plate")
+    self.deck.assign_child_at_slot(self.plate, slot=2)
+    self.column = self.tips["A1:H1"]
+    self.sources = self.plate["A1:H1"]
+    self.destinations = self.plate["A2:H2"]
+    for well in self.sources:
+      well.tracker.set_volume(15)
 
-    with self.assertRaisesRegex(NotImplementedError, "Multi-channel"):
-      await robot.left_pipette.pick_up_tip(tips.get_item("A1"))
+  async def asyncTearDown(self) -> None:
+    """Close the fake run and restore global tracking switches."""
+    await self.robot.stop()
+    set_tip_tracking(False)
+    set_volume_tracking(False)
 
-    await robot.stop()
+  async def test_setup_selects_the_concrete_class_on_either_mount(self) -> None:
+    """Discovery selects a class from the pipette model, independently of its mount."""
+    self.assertIsInstance(self.pipette, _OT2Pipette)
+    for model in ("p10_multi", "p20_multi_gen2", "p50_multi", "p300_multi", "p300_multi_gen2"):
+      with self.subTest(model=model):
+        await self.robot.stop()
+        self.io.left_pipette_name = "p20_single_gen2"
+        self.io.right_pipette_name = model
+        await self.robot.setup(skip_home=True)
+        self.assertIsInstance(self.robot.left_pipette, OT2SingleChannelPipette)
+        self.assertIsInstance(self.robot.right_pipette, OT2_8ChannelPipette)
+        self.assertEqual([p.num_channels for p in self.robot.pipettes], [1, 8])
+
+  def test_constructors_reject_models_with_the_wrong_channel_count(self) -> None:
+    """A concrete class cannot bind a model whose nozzle count contradicts its API."""
+    with self.assertRaisesRegex(ValueError, "8-channel"):
+      OT2SingleChannelPipette(self.robot, "left", "p20_multi_gen2", "left-pipette-id")
+    with self.assertRaisesRegex(ValueError, "1-channel"):
+      OT2_8ChannelPipette(self.robot, "right", "p20_single_gen2", "right-pipette-id")
+
+  async def test_full_column_uses_one_command_and_tracks_each_nozzle(self) -> None:
+    """One physical stroke transfers the requested volume separately in eight wells."""
+    original_tips = [spot.get_tip() for spot in self.column]
+    await self.pipette.pick_up_tips(self.column)
+    self.assertEqual(self.pipette.num_channels, 8)
+    self.assertEqual(len(self.pipette.tips), 8)
+    for actual, original in zip(self.pipette.tips, original_tips):
+      self.assertIs(actual, original)
+    await self.pipette.aspirate(self.sources, volume=10)
+    self.assertEqual([tip.tracker.volume for tip in self.pipette.tips], [10] * 8)
+    await self.pipette.dispense(self.destinations, volume=10, flow_rate=6)
+    await self.pipette.return_tips()
+
+    for spot, original in zip(self.column, original_tips):
+      self.assertIs(spot.get_tip(), original)
+      self.assertEqual(original.tracker.volume, 0)
+    self.assertFalse(self.pipette.has_tip)
+    self.assertEqual(self.pipette.tips, ())
+    self.assertEqual([well.tracker.volume for well in self.sources], [5] * 8)
+    self.assertEqual([well.tracker.volume for well in self.destinations], [10] * 8)
+    commands = self.io.commands
+    for kind in ("pickUpTip", "aspirateInPlace", "dispenseInPlace", "dropTip"):
+      selected = [command for command in commands if command["commandType"] == kind]
+      self.assertEqual(len(selected), 1)
+      params = selected[0]["params"]
+      self.assertEqual(params["pipetteId"], "left-pipette-id")
+      if kind in ("pickUpTip", "dropTip"):
+        self.assertEqual(params["wellName"], "A1")
+      else:
+        self.assertEqual(params["volume"], 10)
+        self.assertEqual(params["flowRate"], 7.6 if kind == "aspirateInPlace" else 6)
+    # Two liquid moves plus four vertical retractions; the liquid moves anchor at row A.
+    moves = [c["params"] for c in commands if c["commandType"] == "moveToCoordinates"]
+    self.assertEqual(len(moves), 6)
+    anchor = self.sources[0].get_location_wrt(self.deck, "c", "c", "cavity_bottom")
+    anchor -= self.deck.slot_locations[0]
+    self.assertEqual(moves[1]["coordinates"], {"x": anchor.x, "y": anchor.y, "z": anchor.z})
+
+  async def test_single_mount_and_multi_mount_keep_independent_tips(self) -> None:
+    """A multi on one mount does not change the other mount's single-channel API."""
+    single = self.robot.right_pipette
+    assert isinstance(single, OT2SingleChannelPipette)
+    self.assertEqual(single.num_channels, 1)
+    await asyncio.gather(
+      self.pipette.pick_up_tips(self.column), single.pick_up_tip(self.tips.get_item("A3"))
+    )
+    await self.pipette.discard_tips()
+    self.assertTrue(single.has_tip)
+    self.assertIsNotNone(single.tip)
+    await single.return_tip()
+    self.assertTrue(self.tips.get_item("A3").has_tip())
+    self.assertTrue(all(not spot.has_tip() for spot in self.column))
+    pickups = [c["params"] for c in self.io.commands if c["commandType"] == "pickUpTip"]
+    self.assertEqual([p["pipetteId"] for p in pickups], ["left-pipette-id", "right-pipette-id"])
+
+  async def test_incomplete_or_misaligned_pickups_send_nothing(self) -> None:
+    """Reject partial, repeated, mixed-column, and reversed targets before loading labware."""
+    before = len(self.io.calls)
+    for spots in (
+      [],
+      self.column[:7],
+      [self.column[0]] * 8,
+      list(reversed(self.column)),
+      self.column[:7] + [self.tips.get_item("H2")],
+    ):
+      with self.subTest(spots=spots), self.assertRaises(ValueError):
+        await self.pipette.pick_up_tips(spots)
+    self.assertEqual(len(self.io.calls), before)
+    self.assertTrue(all(spot.has_tip() for spot in self.column))
+
+  async def test_missing_last_tip_and_failed_pickup_preserve_the_rack(self) -> None:
+    """A missing eighth tip or failed command must not consume the first seven tips."""
+    last_tip = self.column[-1].get_tip()
+    self.column[-1].tracker.remove_tip(commit=True)
+    before = len(self.io.calls)
+    with self.assertRaises(NoTipError):
+      await self.pipette.pick_up_tips(self.column)
+    self.assertEqual(len(self.io.calls), before)
+    self.assertTrue(all(spot.has_tip() for spot in self.column[:-1]))
+    self.column[-1].tracker.add_tip(last_tip)
+    self.io.fail_command_type = "pickUpTip"
+    with self.assertRaises(OpentronsError):
+      await self.pipette.pick_up_tips(self.column)
+    self.assertTrue(all(spot.has_tip() for spot in self.column))
+    self.assertFalse(self.pipette.has_tip)
+
+  async def test_drop_preflight_and_command_failure_roll_back_every_spot(self) -> None:
+    """A late occupied destination or command failure preserves all mounted tips."""
+    await self.pipette.pick_up_tips(self.column)
+    mounted = self.pipette.tips
+    destinations = self.tips["A2:H2"]
+    for spot in destinations[:-1]:
+      spot.tracker.remove_tip(commit=True)
+    before = len(self.io.calls)
+    with self.assertRaises(HasTipError):
+      await self.pipette.drop_tips(destinations)
+    self.assertEqual(len(self.io.calls), before)
+    self.assertTrue(all(not spot.has_tip() for spot in destinations[:-1]))
+    self.io.fail_command_type = "dropTip"
+    with self.assertRaises(OpentronsError):
+      await self.pipette.return_tips()
+    self.assertTrue(all(not spot.has_tip() for spot in self.column))
+    self.assertIs(self.pipette.tips, mounted)
+    self.io.fail_command_type = None
+    destinations[-1].tracker.remove_tip(commit=True)
+    await self.pipette.drop_tips(destinations)
+    for spot, tip in zip(destinations, mounted):
+      self.assertIs(spot.get_tip(), tip)
+
+  async def test_last_well_or_tip_capacity_failure_rolls_back_the_whole_transfer(self) -> None:
+    """Every nozzle is validated before motion, with earlier staged updates undone."""
+    await self.pipette.pick_up_tips(self.column)
+    self.sources[-1].tracker.set_volume(0)
+    before = len(self.io.calls)
+    with self.assertRaises(TooLittleLiquidError):
+      await self.pipette.aspirate(self.sources, volume=10)
+    self.assertEqual([w.tracker.get_used_volume() for w in self.sources], [15] * 7 + [0])
+    self.assertEqual([tip.tracker.get_used_volume() for tip in self.pipette.tips], [0] * 8)
+    self.sources[-1].tracker.set_volume(15)
+    self.pipette.tips[-1].tracker.set_volume(20)
+    with self.assertRaises(TooLittleVolumeError):
+      await self.pipette.aspirate(self.sources, volume=10)
+    self.assertEqual([w.tracker.get_used_volume() for w in self.sources], [15] * 8)
+    self.assertEqual([tip.tracker.get_used_volume() for tip in self.pipette.tips], [0] * 7 + [20])
+    self.assertEqual(len(self.io.calls), before)
+
+  async def test_liquid_command_failures_preserve_all_volumes(self) -> None:
+    """A rejected aspiration or dispense rolls back the entire column."""
+    await self.pipette.pick_up_tips(self.column)
+    for operation, kind, tip_volume in (
+      (self.pipette.aspirate, "aspirateInPlace", 0),
+      (self.pipette.dispense, "dispenseInPlace", 10),
+    ):
+      with self.subTest(kind=kind):
+        for tip in self.pipette.tips:
+          tip.tracker.set_volume(tip_volume)
+        self.io.fail_command_type = kind
+        with self.assertRaises(OpentronsError):
+          await operation(self.sources, volume=10)
+        self.assertEqual([w.tracker.get_used_volume() for w in self.sources], [15] * 8)
+        self.assertEqual(
+          [tip.tracker.get_used_volume() for tip in self.pipette.tips], [tip_volume] * 8
+        )
+
+  async def test_liquid_targets_must_match_the_rigid_head(self) -> None:
+    """A partial column or row cannot silently command an eight-nozzle stroke."""
+    await self.pipette.pick_up_tips(self.column)
+    before = len(self.io.calls)
+    for targets in (self.sources[:7], self.plate["A1:A8"]):
+      with self.subTest(targets=targets), self.assertRaises(ValueError):
+        await self.pipette.aspirate(targets, volume=10)
+    self.assertEqual(len(self.io.calls), before)
+
+  async def test_mix_commits_each_completed_stroke(self) -> None:
+    """A later failed mix stroke retains the liquid moved by earlier completed strokes."""
+    await self.pipette.pick_up_tips(self.column)
+    await self.pipette.mix(self.sources, volume=5, repetitions=2)
+    self.assertEqual([w.tracker.volume for w in self.sources], [15] * 8)
+    self.io.fail_command_type = "dispenseInPlace"
+    with self.assertRaises(OpentronsError):
+      await self.pipette.mix(self.sources, volume=5, repetitions=1)
+    self.assertEqual([w.tracker.volume for w in self.sources], [10] * 8)
+    self.assertEqual([tip.tracker.volume for tip in self.pipette.tips], [5] * 8)
+
+  async def test_retraction_failure_keeps_completed_tip_and_liquid_state(self) -> None:
+    """A retraction failure must not undo the successful operation preceding it."""
+    self.io.fail_command_type = "savePosition"
+    with self.assertRaises(OpentronsError):
+      await self.pipette.pick_up_tips(self.column)
+    self.assertEqual(len(self.pipette.tips), 8)
+    self.assertTrue(all(not spot.has_tip() for spot in self.column))
+    with self.assertRaises(OpentronsError):
+      await self.pipette.aspirate(self.sources, volume=10)
+    self.assertEqual([w.tracker.volume for w in self.sources], [5] * 8)
+    self.assertEqual([tip.tracker.volume for tip in self.pipette.tips], [10] * 8)
+    with self.assertRaises(OpentronsError):
+      await self.pipette.return_tips(allow_nonzero_volume=True)
+    self.assertFalse(self.pipette.has_tip)
+    self.assertTrue(all(spot.has_tip() for spot in self.column))
+
+  async def test_discard_checks_every_tip_and_retains_tips_on_failure(self) -> None:
+    """Liquid in the last tip blocks disposal; a failed drop keeps tip ownership."""
+    await self.pipette.pick_up_tips(self.column)
+    self.pipette.tips[-1].tracker.set_volume(1)
+    before = len(self.io.calls)
+    with self.assertRaisesRegex(ValueError, "contains liquid"):
+      await self.pipette.discard_tips()
+    self.assertEqual(len(self.io.calls), before)
+    self.io.fail_command_type = "dropTipInPlace"
+    with self.assertRaises(OpentronsError):
+      await self.pipette.discard_tips(allow_nonzero_volume=True)
+    self.assertEqual(len(self.pipette.tips), 8)
+    self.io.fail_command_type = None
+    await self.pipette.discard_tips(allow_nonzero_volume=True)
+    self.assertFalse(self.pipette.has_tip)
+
+  async def test_disabled_tracking_still_owns_and_operates_all_tips(self) -> None:
+    """Global tracking switches do not change the physical command grouping."""
+    set_tip_tracking(False)
+    set_volume_tracking(False)
+    await self.pipette.pick_up_tips(self.column)
+    await self.pipette.aspirate(self.sources, volume=10)
+    await self.pipette.dispense(self.destinations, volume=10)
+    self.assertEqual(len(self.pipette.tips), 8)
+    self.assertTrue(all(spot.has_tip() for spot in self.column))
+    self.assertEqual([w.tracker.volume for w in self.sources], [15] * 8)
+    self.assertEqual([w.tracker.volume for w in self.destinations], [0] * 8)
+    await self.pipette.discard_tips()
 
 
 class OT2ArchitectureTests(unittest.IsolatedAsyncioTestCase):

--- a/pylabrobot/opentrons/ot2/pipette.py
+++ b/pylabrobot/opentrons/ot2/pipette.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import math
+from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, Iterator, Optional
+from typing import TYPE_CHECKING, Dict, Iterator, Optional, Sequence, Tuple
 
 from pylabrobot.opentrons.types import Mount
 from pylabrobot.resources.container import Container
 from pylabrobot.resources.coordinate import Coordinate
+from pylabrobot.resources.resource import Resource
 from pylabrobot.resources.tip import Tip
 from pylabrobot.resources.tip_rack import TipRack, TipSpot
 from pylabrobot.resources.tip_tracker import does_tip_tracking
@@ -58,19 +60,20 @@ def _require_finite_coordinate(name: str, coordinate: Coordinate) -> None:
 
 @contextmanager
 def _track_liquid_transfer(
-  source: VolumeTracker, destination: VolumeTracker, volume: float
+  sources: Sequence[VolumeTracker], destinations: Sequence[VolumeTracker], volume: float
 ) -> Iterator[None]:
-  """Track one liquid transfer, committing when its command succeeds."""
+  """Stage all nozzle transfers and commit together when their command succeeds."""
   trackers = [
     tracker
-    for tracker in (source, destination)
+    for tracker in (*sources, *destinations)
     if does_volume_tracking() and not tracker.is_disabled
   ]
   try:
-    if source in trackers:
-      source.remove_liquid(volume)
-    if destination in trackers:
-      destination.add_liquid(volume)
+    for source, destination in zip(sources, destinations):
+      if source in trackers:
+        source.remove_liquid(volume)
+      if destination in trackers:
+        destination.add_liquid(volume)
     yield
   except BaseException:
     for tracker in trackers:
@@ -81,14 +84,8 @@ def _track_liquid_transfer(
       tracker.commit()
 
 
-class OT2Pipette:
-  """A pipette mounted on an OT-2 carriage.
-
-  Instances are discovered and created by :meth:`OT2.setup`. Single-channel
-  pipettes expose tip, liquid, and motion operations. Multi-channel pipettes are represented
-  accurately, but their liquid operations are rejected until all eight tip and volume trackers
-  can be updated atomically.
-  """
+class _OT2Pipette(ABC):
+  """Shared motion, command sequencing, and transactional tracking for mounted OT-2 pipettes."""
 
   def __init__(
     self,
@@ -102,14 +99,17 @@ class OT2Pipette:
     except KeyError as error:
       raise ValueError(f"Unsupported OT-2 pipette {name!r}") from error
 
+    if spec.channels != self.num_channels:
+      raise ValueError(f"{name} requires a {spec.channels}-channel pipette class")
+
     self.robot = robot
     self._run = robot._require_run()
     self.mount = mount
     self.name = name
     self.pipette_id = pipette_id
     self._spec = spec
-    self._tip: Optional[Tip] = None
-    self._tip_origin: Optional[TipSpot] = None
+    self._tips: Tuple[Tip, ...] = ()
+    self._tip_origins: Tuple[TipSpot, ...] = ()
 
   @property
   def minimum_volume(self) -> float:
@@ -122,35 +122,43 @@ class OT2Pipette:
     return self._spec.maximum_volume
 
   @property
+  @abstractmethod
   def num_channels(self) -> int:
-    """Number of nozzles on the pipette."""
-    return self._spec.channels
+    """Number of nozzles exposed by this pipette class."""
+    ...
 
   @property
   def has_tip(self) -> bool:
     """Whether the pipette holds a tip according to commands issued by this object."""
-    return self._tip is not None
-
-  @property
-  def tip(self) -> Optional[Tip]:
-    """The mounted tip, or ``None`` when no tip is mounted."""
-    return self._tip
+    return bool(self._tips)
 
   def _require_active(self) -> None:
     if self.robot._require_run() is not self._run:
       raise RuntimeError("This pipette belongs to an earlier OT-2 run; use the current pipette")
 
-  def _require_single_channel(self) -> None:
-    if self.num_channels != 1:
-      raise NotImplementedError(
-        f"{self.name} has {self.num_channels} channels. Multi-channel liquid operations are not "
-        "implemented yet."
-      )
-
-  def _require_tip(self) -> Tip:
-    if self._tip is None:
+  def _require_tips(self) -> Tuple[Tip, ...]:
+    """Return the mounted tips, requiring a tip on every nozzle."""
+    if not self._tips:
       raise RuntimeError(f"The {self.mount} pipette does not have a tip")
-    return self._tip
+    return self._tips
+
+  def _validate_targets(self, targets: Sequence[Resource]) -> None:
+    """Require one target per nozzle."""
+    if len(targets) != self.num_channels:
+      raise ValueError(f"{self.name} requires {self.num_channels} targets in nozzle order")
+
+  def _validate_nozzle_positions(self, positions: Sequence[Coordinate]) -> None:
+    """Require finite target coordinates."""
+    for position in positions:
+      _require_finite_coordinate("target", position)
+
+  def _tip_rack(self, tip_spots: Sequence[TipSpot]) -> TipRack:
+    """Validate tip spots and return its rack."""
+    self._validate_targets(tip_spots)
+    rack = tip_spots[0].parent
+    if not isinstance(rack, TipRack):
+      raise ValueError("tip spots must be assigned to a tip rack")
+    return rack
 
   def _validate_volume(self, volume: float) -> float:
     volume = float(volume)
@@ -213,98 +221,105 @@ class OT2Pipette:
       )
       await self._retract_to_traversal_height()
 
-  async def pick_up_tip(
+  async def _pick_up_tips(
     self,
-    tip_spot: TipSpot,
+    tip_spots: Sequence[TipSpot],
     offset: Optional[Coordinate] = None,
   ) -> None:
-    """Pick up one tip from a tip rack and retract to at least traversal height."""
+    """Pick up one tip per nozzle with one command, then retract to traversal height."""
     async with self.robot._operation_lock:
       self._require_active()
-      self._require_single_channel()
-      if self._tip is not None:
+      if self.has_tip:
         raise RuntimeError(f"The {self.mount} pipette already has a tip")
-      if not isinstance(tip_spot.parent, TipRack):
-        raise ValueError("tip_spot must be assigned to a tip rack")
-
-      tip = tip_spot.get_tip()
+      tip_spots = tuple(tip_spots)
+      rack = self._tip_rack(tip_spots)
+      tips = tuple(spot.get_tip() for spot in tip_spots)
+      tip = tips[0]
       if not self.can_use_tip(tip):
         raise ValueError(f"{self.name} cannot use a {tip.maximal_volume:g} µL-capacity tip")
+      if any(other != tip for other in tips):
+        raise ValueError("All nozzles must use the same tip type")
       offset = offset or Coordinate.zero()
       _require_finite_coordinate("offset", offset)
-      tracked = does_tip_tracking() and not tip_spot.tracker.is_disabled
-      if tracked:
-        tip_spot.tracker.remove_tip(commit=False)
-
+      tracked = [
+        spot.tracker for spot in tip_spots if does_tip_tracking() and not spot.tracker.is_disabled
+      ]
       try:
-        await self.robot._load_tip_rack(tip_spot.parent, tip)
-        binding = self.robot._require_labware().get(tip_spot.parent)
+        for tracker in tracked:
+          tracker.remove_tip(commit=False)
+        await self.robot._load_tip_rack(rack, tip)
+        binding = self.robot._require_labware().get(rack)
         await self._run.pick_up_tip(
           self.pipette_id,
           binding.labware_id,
-          tip_spot.parent.get_child_identifier(tip_spot),
+          rack.get_child_identifier(tip_spots[0]),
           offset + Coordinate(z=tip.total_tip_length),
         )
-      except Exception:
-        if tracked:
-          tip_spot.tracker.rollback()
+      except BaseException:
+        for tracker in tracked:
+          tracker.rollback()
         raise
 
-      if tracked:
-        tip_spot.tracker.commit()
-      self._tip = tip
-      self._tip_origin = tip_spot
+      for tracker in tracked:
+        tracker.commit()
+      self._tips = tips
+      self._tip_origins = tip_spots
       await self._retract_to_traversal_height()
 
-  async def drop_tip(
+  async def _drop_tips(
     self,
-    tip_spot: TipSpot,
+    tip_spots: Sequence[TipSpot],
     offset: Optional[Coordinate] = None,
     allow_nonzero_volume: bool = False,
   ) -> None:
-    """Drop into a tip-rack position and retract vertically to at least traversal height."""
+    """Drop all mounted tips into a rack with one command, then retract."""
     async with self.robot._operation_lock:
       self._require_active()
-      await self._drop_tip(tip_spot, offset, allow_nonzero_volume)
+      await self._drop_tips_locked(tuple(tip_spots), offset, allow_nonzero_volume)
 
-  async def _drop_tip(
+  def _check_tip_volumes(self, allow_nonzero_volume: bool) -> None:
+    """Require mounted tips and reject disposal of liquid unless explicitly allowed."""
+    tips = self._require_tips()
+    if does_volume_tracking() and not allow_nonzero_volume:
+      if any(tip.tracker.get_used_volume() > 0 for tip in tips):
+        raise ValueError("A mounted tip still contains liquid")
+
+  async def _drop_tips_locked(
     self,
-    tip_spot: TipSpot,
+    tip_spots: Sequence[TipSpot],
     offset: Optional[Coordinate] = None,
     allow_nonzero_volume: bool = False,
   ) -> None:
-    """Drop a tip while the robot's operation lock is held."""
-    self._require_single_channel()
-    tip = self._require_tip()
-    if not isinstance(tip_spot.parent, TipRack):
-      raise ValueError("tip_spot must be assigned to a tip rack")
-    if does_volume_tracking() and tip.tracker.get_used_volume() > 0 and not allow_nonzero_volume:
-      raise ValueError("The mounted tip still contains liquid")
-
+    """Drop tips while the robot's operation lock is held."""
+    self._check_tip_volumes(allow_nonzero_volume)
+    rack = self._tip_rack(tip_spots)
+    tip = self._tips[0]
     offset = offset or Coordinate.zero()
     _require_finite_coordinate("offset", offset)
-    tracked = does_tip_tracking() and not tip_spot.tracker.is_disabled
-    if tracked:
-      tip_spot.tracker.add_tip(tip, origin=tip_spot, commit=False)
-
+    tracked = [
+      spot.tracker for spot in tip_spots if does_tip_tracking() and not spot.tracker.is_disabled
+    ]
     try:
-      await self.robot._load_tip_rack(tip_spot.parent, tip)
-      binding = self.robot._require_labware().get(tip_spot.parent)
+      for spot, mounted_tip in zip(tip_spots, self._tips):
+        if spot.tracker in tracked:
+          spot.tracker.add_tip(mounted_tip, origin=spot, commit=False)
+      await self.robot._load_tip_rack(rack, tip)
+      binding = self.robot._require_labware().get(rack)
       await self._run.drop_tip(
         self.pipette_id,
         binding.labware_id,
-        tip_spot.parent.get_child_identifier(tip_spot),
+        rack.get_child_identifier(tip_spots[0]),
         offset + Coordinate(z=10),
       )
-    except Exception:
-      if tracked:
-        tip_spot.tracker.rollback()
+    except BaseException:
+      for tracker in tracked:
+        tracker.rollback()
       raise
 
-    if tracked:
-      tip_spot.tracker.commit()
-    self._tip = None
-    self._tip_origin = None
+    for tracker in tracked:
+      tracker.commit()
+    self._tips = ()
+    self._tip_origins = ()
     await self._retract_to_traversal_height()
 
   async def _retract_to_traversal_height(self) -> None:
@@ -317,41 +332,32 @@ class OT2Pipette:
         force_direct=True,
       )
 
-  async def return_tip(
+  async def _return_tips(
     self,
     offset: Optional[Coordinate] = None,
     allow_nonzero_volume: bool = False,
   ) -> None:
-    """Return the mounted tip to its pickup position and retract to at least traversal height."""
+    """Return all mounted tips to their pickup positions, then retract."""
     async with self.robot._operation_lock:
       self._require_active()
-      if self._tip_origin is None:
+      if not self._tip_origins:
         raise RuntimeError("The mounted tip's origin is unknown")
-      await self._drop_tip(
-        self._tip_origin,
-        offset=offset,
-        allow_nonzero_volume=allow_nonzero_volume,
-      )
+      await self._drop_tips_locked(self._tip_origins, offset, allow_nonzero_volume)
 
-  async def discard_tip(
+  async def _discard_tips(
     self,
     offset: Optional[Coordinate] = None,
     allow_nonzero_volume: bool = False,
   ) -> None:
-    """Discard into fixed trash and retract vertically to at least traversal height."""
+    """Discard all mounted tips into fixed trash and retract to traversal height."""
     async with self.robot._operation_lock:
       self._require_active()
-      self._require_single_channel()
-      tip = self._require_tip()
-      if does_volume_tracking() and tip.tracker.get_used_volume() > 0 and not allow_nonzero_volume:
-        raise ValueError("The mounted tip still contains liquid")
+      self._check_tip_volumes(allow_nonzero_volume)
       offset = offset or Coordinate.zero()
       _require_finite_coordinate("offset", offset)
-
       await self._run.discard_tip_in_fixed_trash(self.pipette_id, offset + Coordinate(z=10))
-
-      self._tip = None
-      self._tip_origin = None
+      self._tips = ()
+      self._tip_origins = ()
       await self._retract_to_traversal_height()
 
   def _liquid_location(
@@ -371,27 +377,39 @@ class OT2Pipette:
     )
     return self.robot._deck_to_robot_frame(location + offset + Coordinate(z=liquid_height))
 
-  async def aspirate(
+  def _liquid_targets(
     self,
-    container: Container,
+    containers: Sequence[Container],
+    offset: Coordinate,
+    liquid_height: float,
+  ) -> Tuple[Tuple[VolumeTracker, ...], Coordinate]:
+    """Resolve one container per nozzle and the reference nozzle's liquid position."""
+    self._validate_targets(containers)
+    locations = [self._liquid_location(c, offset, liquid_height) for c in containers]
+    self._validate_nozzle_positions(locations)
+    return tuple(c.tracker for c in containers), locations[0]
+
+  async def _aspirate(
+    self,
+    containers: Sequence[Container],
     volume: float,
     flow_rate: Optional[float] = None,
     liquid_height: float = 0,
     offset: Optional[Coordinate] = None,
   ) -> None:
-    """Aspirate liquid from a container and return to traversal height."""
+    """Aspirate ``volume`` per nozzle from one container or a full column, then retract."""
     async with self.robot._operation_lock:
       self._require_active()
-      self._require_single_channel()
-      tip = self._require_tip()
+      tips = self._require_tips()
+      tip_trackers = tuple(tip.tracker for tip in tips)
       volume = self._validate_volume(volume)
       flow_rate = self._spec.default_aspiration_flow_rate if flow_rate is None else float(flow_rate)
       if not math.isfinite(flow_rate) or flow_rate <= 0:
         raise ValueError("flow_rate must be finite and greater than zero")
       offset = offset or Coordinate.zero()
-      location = self._liquid_location(container, offset, liquid_height)
+      container_trackers, location = self._liquid_targets(containers, offset, liquid_height)
 
-      with _track_liquid_transfer(container.tracker, tip.tracker, volume):
+      with _track_liquid_transfer(container_trackers, tip_trackers, volume):
         await self._move_to(
           location,
           minimum_z_height=self.robot.traversal_height,
@@ -399,27 +417,27 @@ class OT2Pipette:
         await self._run.aspirate_in_place(self.pipette_id, volume, flow_rate)
       await self._retract_to_traversal_height()
 
-  async def dispense(
+  async def _dispense(
     self,
-    container: Container,
+    containers: Sequence[Container],
     volume: float,
     flow_rate: Optional[float] = None,
     liquid_height: float = 0,
     offset: Optional[Coordinate] = None,
   ) -> None:
-    """Dispense liquid into a container and return to traversal height."""
+    """Dispense ``volume`` per nozzle into one container or a full column, then retract."""
     async with self.robot._operation_lock:
       self._require_active()
-      self._require_single_channel()
-      tip = self._require_tip()
+      tips = self._require_tips()
+      tip_trackers = tuple(tip.tracker for tip in tips)
       volume = self._validate_volume(volume)
       flow_rate = self._spec.default_dispense_flow_rate if flow_rate is None else float(flow_rate)
       if not math.isfinite(flow_rate) or flow_rate <= 0:
         raise ValueError("flow_rate must be finite and greater than zero")
       offset = offset or Coordinate.zero()
-      location = self._liquid_location(container, offset, liquid_height)
+      container_trackers, location = self._liquid_targets(containers, offset, liquid_height)
 
-      with _track_liquid_transfer(tip.tracker, container.tracker, volume):
+      with _track_liquid_transfer(tip_trackers, container_trackers, volume):
         await self._move_to(
           location,
           minimum_z_height=self.robot.traversal_height,
@@ -427,9 +445,9 @@ class OT2Pipette:
         await self._run.dispense_in_place(self.pipette_id, volume, flow_rate)
       await self._retract_to_traversal_height()
 
-  async def mix(
+  async def _mix(
     self,
-    container: Container,
+    containers: Sequence[Container],
     volume: float,
     repetitions: int,
     aspiration_flow_rate: Optional[float] = None,
@@ -437,11 +455,11 @@ class OT2Pipette:
     liquid_height: float = 0,
     offset: Optional[Coordinate] = None,
   ) -> None:
-    """Mix in place using aspiration and dispense cycles, then retract to traversal height."""
+    """Mix ``volume`` per nozzle in one container or a full column, then retract."""
     async with self.robot._operation_lock:
       self._require_active()
-      self._require_single_channel()
-      tip = self._require_tip()
+      tips = self._require_tips()
+      tip_trackers = tuple(tip.tracker for tip in tips)
       volume = self._validate_volume(volume)
       if repetitions < 1:
         raise ValueError("repetitions must be at least 1")
@@ -464,12 +482,226 @@ class OT2Pipette:
         raise ValueError("flow rates must be finite and greater than zero")
 
       offset = offset or Coordinate.zero()
-      location = self._liquid_location(container, offset, liquid_height)
+      container_trackers, location = self._liquid_targets(containers, offset, liquid_height)
       for repetition in range(repetitions):
-        with _track_liquid_transfer(container.tracker, tip.tracker, volume):
+        with _track_liquid_transfer(container_trackers, tip_trackers, volume):
           if repetition == 0:
             await self._move_to(location, minimum_z_height=self.robot.traversal_height)
           await self._run.aspirate_in_place(self.pipette_id, volume, aspiration_flow_rate)
-        with _track_liquid_transfer(tip.tracker, container.tracker, volume):
+        with _track_liquid_transfer(tip_trackers, container_trackers, volume):
           await self._run.dispense_in_place(self.pipette_id, volume, dispense_flow_rate)
       await self._retract_to_traversal_height()
+
+
+class OT2SingleChannelPipette(_OT2Pipette):
+  """A single-channel OT-2 pipette, discovered and created by :meth:`OT2.setup`."""
+
+  @property
+  def num_channels(self) -> int:
+    """One independently addressed nozzle."""
+    return 1
+
+  @property
+  def tip(self) -> Optional[Tip]:
+    """The single-channel mounted tip, or ``None`` when no tip is mounted."""
+    return self._tips[0] if self._tips else None
+
+  async def pick_up_tip(
+    self,
+    tip_spot: TipSpot,
+    offset: Optional[Coordinate] = None,
+  ) -> None:
+    """Pick up one tip from a tip rack and retract to at least traversal height."""
+    await self._pick_up_tips([tip_spot], offset)
+
+  async def drop_tip(
+    self,
+    tip_spot: TipSpot,
+    offset: Optional[Coordinate] = None,
+    allow_nonzero_volume: bool = False,
+  ) -> None:
+    """Drop into a tip-rack position and retract vertically to at least traversal height."""
+    await self._drop_tips([tip_spot], offset, allow_nonzero_volume)
+
+  async def return_tip(
+    self,
+    offset: Optional[Coordinate] = None,
+    allow_nonzero_volume: bool = False,
+  ) -> None:
+    """Return the mounted single tip to its pickup position, then retract."""
+    await self._return_tips(offset, allow_nonzero_volume)
+
+  async def discard_tip(
+    self,
+    offset: Optional[Coordinate] = None,
+    allow_nonzero_volume: bool = False,
+  ) -> None:
+    """Discard a single tip into fixed trash and retract to traversal height."""
+    await self._discard_tips(offset, allow_nonzero_volume)
+
+  async def aspirate(
+    self,
+    container: Container,
+    volume: float,
+    flow_rate: Optional[float] = None,
+    liquid_height: float = 0,
+    offset: Optional[Coordinate] = None,
+  ) -> None:
+    """Aspirate ``volume`` from a container, then retract."""
+    await self._aspirate([container], volume, flow_rate, liquid_height, offset)
+
+  async def dispense(
+    self,
+    container: Container,
+    volume: float,
+    flow_rate: Optional[float] = None,
+    liquid_height: float = 0,
+    offset: Optional[Coordinate] = None,
+  ) -> None:
+    """Dispense ``volume`` into a container, then retract."""
+    await self._dispense([container], volume, flow_rate, liquid_height, offset)
+
+  async def mix(
+    self,
+    container: Container,
+    volume: float,
+    repetitions: int,
+    aspiration_flow_rate: Optional[float] = None,
+    dispense_flow_rate: Optional[float] = None,
+    liquid_height: float = 0,
+    offset: Optional[Coordinate] = None,
+  ) -> None:
+    """Mix ``volume`` in a container, then retract."""
+    await self._mix(
+      [container],
+      volume,
+      repetitions,
+      aspiration_flow_rate,
+      dispense_flow_rate,
+      liquid_height,
+      offset,
+    )
+
+
+class OT2_8ChannelPipette(_OT2Pipette):
+  """An eight-channel OT-2 pipette with a rigid, full-column nozzle layout.
+
+  Instances are discovered and created by :meth:`OT2.setup`. Targets run from the
+  back nozzle to the front (rows A-H). Volume, flow rate, liquid height, and offset
+  apply equally to every nozzle. Partial columns are not supported.
+  """
+
+  @property
+  def num_channels(self) -> int:
+    """Eight nozzles at 9 mm pitch."""
+    return 8
+
+  @property
+  def tips(self) -> Tuple[Tip, ...]:
+    """Mounted tips in nozzle order, or an empty tuple when no tips are mounted."""
+    return self._tips
+
+  def _validate_targets(self, targets: Sequence[Resource]) -> None:
+    """Require one distinct target per nozzle on the same resource."""
+    super()._validate_targets(targets)
+    if len({id(target) for target in targets}) != len(targets):
+      raise ValueError("Each nozzle must address a distinct target")
+    if any(target.parent is not targets[0].parent for target in targets):
+      raise ValueError("All targets must belong to the same resource")
+
+  def _validate_nozzle_positions(self, positions: Sequence[Coordinate]) -> None:
+    """Require targets to align with the rigid head's 9 mm back-to-front pitch."""
+    super()._validate_nozzle_positions(positions)
+    for nozzle, position in enumerate(positions):
+      expected = positions[0] + Coordinate(y=-9 * nozzle)
+      if any(abs(actual - target) > 0.01 for actual, target in zip(position, expected)):
+        raise ValueError("Targets must align in nozzle order at 9 mm pitch and equal height")
+
+  def _tip_rack(self, tip_spots: Sequence[TipSpot]) -> TipRack:
+    """Validate a complete A-H column and return its rack."""
+    rack = super()._tip_rack(tip_spots)
+    column = rack.get_child_identifier(tip_spots[0])[1:]
+    if rack.num_items_y != 8 or [rack.get_child_identifier(spot) for spot in tip_spots] != [
+      f"{row}{column}" for row in "ABCDEFGH"
+    ]:
+      raise ValueError("Eight-channel tip operations require a full A-H rack column")
+    self._validate_nozzle_positions(
+      [spot.get_location_wrt(self.robot.deck, "c", "c", "b") for spot in tip_spots]
+    )
+    return rack
+
+  async def pick_up_tips(
+    self,
+    tip_spots: Sequence[TipSpot],
+    offset: Optional[Coordinate] = None,
+  ) -> None:
+    """Pick up one tip per nozzle with one command, then retract to traversal height."""
+    await self._pick_up_tips(tip_spots, offset)
+
+  async def drop_tips(
+    self,
+    tip_spots: Sequence[TipSpot],
+    offset: Optional[Coordinate] = None,
+    allow_nonzero_volume: bool = False,
+  ) -> None:
+    """Drop all mounted tips into a rack with one command, then retract."""
+    await self._drop_tips(tip_spots, offset, allow_nonzero_volume)
+
+  async def return_tips(
+    self,
+    offset: Optional[Coordinate] = None,
+    allow_nonzero_volume: bool = False,
+  ) -> None:
+    """Return all mounted tips to their pickup positions, then retract."""
+    await self._return_tips(offset, allow_nonzero_volume)
+
+  async def discard_tips(
+    self,
+    offset: Optional[Coordinate] = None,
+    allow_nonzero_volume: bool = False,
+  ) -> None:
+    """Discard all mounted tips into fixed trash and retract to traversal height."""
+    await self._discard_tips(offset, allow_nonzero_volume)
+
+  async def aspirate(
+    self,
+    containers: Sequence[Container],
+    volume: float,
+    flow_rate: Optional[float] = None,
+    liquid_height: float = 0,
+    offset: Optional[Coordinate] = None,
+  ) -> None:
+    """Aspirate ``volume`` per nozzle from a full column, then retract."""
+    await self._aspirate(tuple(containers), volume, flow_rate, liquid_height, offset)
+
+  async def dispense(
+    self,
+    containers: Sequence[Container],
+    volume: float,
+    flow_rate: Optional[float] = None,
+    liquid_height: float = 0,
+    offset: Optional[Coordinate] = None,
+  ) -> None:
+    """Dispense ``volume`` per nozzle into a full column, then retract."""
+    await self._dispense(tuple(containers), volume, flow_rate, liquid_height, offset)
+
+  async def mix(
+    self,
+    containers: Sequence[Container],
+    volume: float,
+    repetitions: int,
+    aspiration_flow_rate: Optional[float] = None,
+    dispense_flow_rate: Optional[float] = None,
+    liquid_height: float = 0,
+    offset: Optional[Coordinate] = None,
+  ) -> None:
+    """Mix ``volume`` per nozzle in a full column, then retract."""
+    await self._mix(
+      tuple(containers),
+      volume,
+      repetitions,
+      aspiration_flow_rate,
+      dispense_flow_rate,
+      liquid_height,
+      offset,
+    )


### PR DESCRIPTION
The OT-2 driver discovers eight-channel pipettes but rejects their tip and liquid operations. This adds full-column pickup, drop, return, disposal, aspiration, dispensing, and mixing.

- Split mounted pipettes into `OT2SingleChannelPipette` and `OT2_8ChannelPipette`, sharing command execution, locking, tracking, and retraction through `_OT2Pipette`.
- Send one pipetting command per column, with shared volume and flow rate.
- Track all eight tips and wells together, rolling back failed operations while preserving completed operations if retraction fails.
- Require complete, aligned columns; partial pickup and surrounding-labware collision detection remain outside this change.

Implements the full-column behavior proposed in [#1135](https://github.com/PyLabRobot/pylabrobot/pull/1135) in the current architecture.

Validation: 90 related tests pass, including single-channel regression coverage. Ruff, formatting, MyPy, and the OT-2 API documentation build pass. Eight-channel operations have not been tested on hardware.
