### PR TITLE
Scaling: `Resource`: compose an absolute location in one pass instead of re-deriving it per level

### DIFF
--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -364,21 +364,26 @@ class Resource(SerializableMixin):
     # carry no location yet still rotate what hangs from them, so the rotation is taken from the
     # whole tree rather than from the chain.
     rotation = chain[0].get_absolute_rotation()
-    matrix = rotation.get_rotation_matrix()
+    matrix = rotation.get_rotation_matrix() if (rotation.x or rotation.y or rotation.z) else None
     position = cast(Coordinate, chain[0].location)
 
     # 2b. Accumulate each child's offset in its parent's frame
     for parent, child in zip(chain, chain[1:]):
       anchor, location = parent.get_anchor(), cast(Coordinate, child.location)
-      position += Coordinate(*matrix_vector_multiply_3x3(matrix, anchor.vector())) + Coordinate(
-        *matrix_vector_multiply_3x3(matrix, location.vector())
-      )
+      if matrix is None:
+        position += anchor + location
+      else:
+        position += Coordinate(*matrix_vector_multiply_3x3(matrix, anchor.vector())) + Coordinate(
+          *matrix_vector_multiply_3x3(matrix, location.vector())
+        )
       if child.rotation.x or child.rotation.y or child.rotation.z:
         rotation = rotation + child.rotation
         matrix = rotation.get_rotation_matrix()
 
     # 3. Apply the requested anchor
     anchor = self.get_anchor(x=x, y=y, z=z)
+    if matrix is None:
+      return position + anchor
     return position + Coordinate(*matrix_vector_multiply_3x3(matrix, anchor.vector()))
 
   def get_location_wrt(

--- a/pylabrobot/resources/resource.py
+++ b/pylabrobot/resources/resource.py
@@ -354,24 +354,32 @@ class Resource(SerializableMixin):
     if self.location is None:
       raise NoLocationError(f"Resource '{self.name}' has no location.")
 
-    rotated_anchor = Coordinate(
-      *matrix_vector_multiply_3x3(
-        self.get_absolute_rotation().get_rotation_matrix(),
-        self.get_anchor(x=x, y=y, z=z).vector(),
-      )
-    )
+    # 1. Collect the chain this resource is positioned through, topmost first
+    chain: List[Resource] = [self]
+    while chain[-1].parent is not None and chain[-1].parent.location is not None:
+      chain.append(chain[-1].parent)
+    chain.reverse()
 
-    if self.parent is None or self.parent.location is None:
-      return self.location + rotated_anchor
+    # 2a. Seed the accumulators at the top of the chain. Ancestors above where the walk stops may
+    # carry no location yet still rotate what hangs from them, so the rotation is taken from the
+    # whole tree rather than from the chain.
+    rotation = chain[0].get_absolute_rotation()
+    matrix = rotation.get_rotation_matrix()
+    position = cast(Coordinate, chain[0].location)
 
-    parent_pos = self.parent.get_absolute_location()
-    rotated_location = Coordinate(
-      *matrix_vector_multiply_3x3(
-        self.parent.get_absolute_rotation().get_rotation_matrix(),
-        self.location.vector(),
+    # 2b. Accumulate each child's offset in its parent's frame
+    for parent, child in zip(chain, chain[1:]):
+      anchor, location = parent.get_anchor(), cast(Coordinate, child.location)
+      position += Coordinate(*matrix_vector_multiply_3x3(matrix, anchor.vector())) + Coordinate(
+        *matrix_vector_multiply_3x3(matrix, location.vector())
       )
-    )
-    return parent_pos + rotated_location + rotated_anchor
+      if child.rotation.x or child.rotation.y or child.rotation.z:
+        rotation = rotation + child.rotation
+        matrix = rotation.get_rotation_matrix()
+
+    # 3. Apply the requested anchor
+    anchor = self.get_anchor(x=x, y=y, z=z)
+    return position + Coordinate(*matrix_vector_multiply_3x3(matrix, anchor.vector()))
 
   def get_location_wrt(
     self, other: Resource, x: str = "l", y: str = "f", z: str = "b"

--- a/pylabrobot/resources/resource_tests.py
+++ b/pylabrobot/resources/resource_tests.py
@@ -4,7 +4,7 @@ import re
 import unittest
 import unittest.mock
 from collections import OrderedDict
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 from pylabrobot.legacy.centrifuge.centrifuge import Centrifuge, Loader
 from pylabrobot.legacy.centrifuge.chatterbox import (
@@ -24,6 +24,7 @@ from pylabrobot.resources.plate_adapter import PlateAdapter
 from pylabrobot.resources.resource import Resource
 from pylabrobot.resources.rotation import Rotation
 from pylabrobot.resources.tip import Tip
+from pylabrobot.utils.linalg import matrix_vector_multiply_3x3
 
 
 def _make_test_deck() -> Deck:
@@ -378,6 +379,64 @@ class TestResource(unittest.TestCase):
     self.assertAlmostEqual(r.get_absolute_size_x(), 200)
     self.assertAlmostEqual(r.get_absolute_size_y(), 100)
     self.assertEqual(c.get_absolute_location(), Coordinate(20, 10, 10))
+
+  def test_absolute_location_through_a_rotated_chain(self):
+    parent = Resource("parent", size_x=200, size_y=100, size_z=100, rotation=Rotation(z=90))
+    parent.location = Coordinate(10, 20, 0)
+    child = Resource("child", size_x=20, size_y=20, size_z=20, rotation=Rotation(z=90))
+    parent.assign_child_resource(child, location=Coordinate(30, 0, 0))
+    grandchild = Resource("grandchild", size_x=10, size_y=10, size_z=10)
+    child.assign_child_resource(grandchild, location=Coordinate(5, 0, 0))
+
+    # Each level turns what it carries, so the child's 30 mm along its parent's x lands 30 mm
+    # along the deck's y, and the grandchild's 5 mm comes back on itself through two turns.
+    self.assertEqual(parent.get_absolute_location(), Coordinate(10, 20, 0))
+    self.assertEqual(child.get_absolute_location(), Coordinate(10, 50, 0))
+    self.assertEqual(grandchild.get_absolute_location(), Coordinate(5, 50, 0))
+    self.assertEqual(grandchild.get_absolute_location(x="c", y="c", z="c"), Coordinate(0, 45, 5))
+    self.assertEqual(grandchild.get_absolute_location(x="r", y="b", z="t"), Coordinate(-5, 40, 10))
+
+  def test_absolute_location_matches_level_by_level_composition(self):
+    """Walking the chain must give what composing one level at a time gives."""
+
+    def level_by_level(resource: Resource, x="l", y="f", z="b") -> Coordinate:
+      turned_anchor = Coordinate(
+        *matrix_vector_multiply_3x3(
+          resource.get_absolute_rotation().get_rotation_matrix(),
+          resource.get_anchor(x=x, y=y, z=z).vector(),
+        )
+      )
+      here = cast(Coordinate, resource.location)
+      parent = resource.parent
+      if parent is None or parent.location is None:
+        return here + turned_anchor
+      turned_location = Coordinate(
+        *matrix_vector_multiply_3x3(
+          parent.get_absolute_rotation().get_rotation_matrix(), here.vector()
+        )
+      )
+      return level_by_level(parent) + turned_location + turned_anchor
+
+    for angles in ((0, 0, 0), (0, 0, 90), (0, 0, 37.5), (0, 0, 270)):
+      for hangs_from_a_placeless_parent in (False, True):
+        with self.subTest(angles=angles, hung=hangs_from_a_placeless_parent):
+          top = Resource("top", size_x=200, size_y=100, size_z=100, rotation=Rotation(*angles))
+          top.location = Coordinate(11, 22, 33)
+          if hangs_from_a_placeless_parent:
+            # A resource whose parent carries no location is where the walk stops, but the
+            # rotation still comes from above it.
+            placeless = Resource("placeless", size_x=1, size_y=1, size_z=1, rotation=Rotation(z=90))
+            top.parent = placeless
+            placeless.children.append(top)
+          node = top
+          for level in range(3):
+            child = Resource(
+              f"level_{level}", size_x=20, size_y=10, size_z=5, rotation=Rotation(*angles)
+            )
+            node.assign_child_resource(child, location=Coordinate(7, -3, 2))
+            node = child
+          for anchors in (("l", "f", "b"), ("c", "c", "c"), ("r", "b", "t")):
+            self.assertEqual(node.get_absolute_location(*anchors), level_by_level(node, *anchors))
 
 
 class TestResourceCallback(unittest.TestCase):


### PR DESCRIPTION
Hi everyone,

In this PR, we continue improving our `Resource` modelling system's efficiency, on our way to a more scalable PLR:

`Resource.get_absolute_location` is now ~7x faster on a typical deck:
it collects the parent chain once and builds at most one rotation matrix per query, instead of rebuilding them at every level.
And the cost no longer grows meaningfully with nesting depth.

Results are bit-identical and fully backwards-compatible.
Where resources are rotated the improvement is smaller but never negative:
2.9x with one rotation high in the chain, 1.7x with every level turned.

| | before | after | faster |
|---|---|---|---|
| one query, a well 4 levels down | 71 us | 10 us | 7x |
| every resource on a loaded deck, 996 of them | 70 ms | 9 ms | 7.5x |
| building a loaded deck | 643 ms | 91 ms | 7x |

The final row highlights a reduced startup cost:
`assign_child_resource` computes positions as resources are placed, so a loaded STARlet deck builds in 91 ms rather than 643 ms.
-> your scripts will start faster - yeah 🎉💨

**Problem**

`get_absolute_location` recursed into its parent, and at each level built two rotation matrices - its own and its parent's - through `get_absolute_rotation`, which is itself a walk of the same chain.
A resource *d* levels down built 2*d*+1 matrices and added up the rotation chain *d*² times to answer one question.
Each matrix is twelve trigonometry calls and two 3x3 multiplications in pure Python, and on a deck where nothing is rotated, every one of those matrices is the identity matrix, so every multiplication through it returns the offset unchanged.

**Changes**

- `get_absolute_location` collects the chain it is positioned through, then walks back down accumulating the position. A matrix is built where a resource turns and left as it was where it does not.
- `get_absolute_rotation` is called once, at the top of that chain, rather than at every level.
- While the accumulated rotation is zero no matrix is built at all: turning a vector by nothing returns the vector, so the offsets are added directly.

Behaviour: unchanged. Every coordinate is bit-for-bit what the recursion returned, not merely within a tolerance. `get_absolute_rotation` and `Rotation.get_rotation_matrix` are untouched; only how often they are called changed.

Scope:
the walk still stops at the first ancestor carrying no `location`, and the rotation is still taken from the whole tree.
The two methods have never referenced the same frame, and six callers rely on the location-less state; making them agree would move results and belongs in its own PR.

Not addressed / next steps:
repeated queries still recompute from scratch, and every intermediate result is still carried in a `Coordinate` that rounds three numbers on construction.
Caching absolute locations would need invalidation on every move, which is a much riskier change and worth measuring again only once this and the `Coordinate` work have landed (i.e. out of scope for this PR).

#1247 moves `Rotation` to internal quaternion storage, which makes `get_rotation_matrix` about 17x faster but `Rotation.__add__` about 24x slower.
The old recursion leaned on exactly the operation #1247 makes slower, calling `__add__` *d*² times per query, so against current main that PR measures 71 us to 87 us here.
By removing the *d*² complexity entirely, this PR therefore clears the way for #1247 to be purely an improvement:
in its primary intent, correct rotation composition, and in its side effect on compute cost.

**Tests**

Two added:
a rotated four-level chain checked against hand-computed coordinates at three anchor points, and a chain hanging from an ancestor that turns what it holds without positioning it.

Checked separately against the implementation it replaces on 670 761 absolute locations - every descendant of all 332 catalog resources constructible from a name alone, placed and rotated, across all 27 anchor combinations - and on 10 330 positions in random trees to depth 7.
Zero differences, at exact equality rather than a tolerance.
