### PR TITLE
fix(resources): stop transposing a tip spot's size_x and size_y

### DIFF
--- a/pylabrobot/resources/tip_rack.py
+++ b/pylabrobot/resources/tip_rack.py
@@ -46,8 +46,8 @@ class TipSpot(Resource):
 
     super().__init__(
       name,
-      size_x=size_y,
-      size_y=size_x,
+      size_x=size_x,
+      size_y=size_y,
       size_z=size_z,
       category=category,
       metadata=metadata,

--- a/pylabrobot/resources/tip_rack_tests.py
+++ b/pylabrobot/resources/tip_rack_tests.py
@@ -48,3 +48,32 @@ class TipRackNamingTests(unittest.TestCase):
     spot = rack.get_item("A1")
     tip = spot.tracker.get_tip()
     self.assertIsNotNone(tip.name)
+
+
+class TipSpotSizeTests(unittest.TestCase):
+  """Tests that a tip spot keeps the footprint it was created with."""
+
+  @staticmethod
+  def _make_tip(name: str) -> Tip:
+    return Tip(
+      name=name,
+      has_filter=False,
+      total_tip_length=50.0,
+      maximal_volume=300.0,
+      fitting_depth=8.0,
+    )
+
+  def test_size_x_and_size_y_are_not_transposed(self):
+    spot = TipSpot(name="spot", size_x=8.0, size_y=5.0, size_z=2.0, make_tip=self._make_tip)
+
+    self.assertEqual(spot.get_size_x(), 8.0)
+    self.assertEqual(spot.get_size_y(), 5.0)
+    self.assertEqual(spot.center(), Coordinate(4.0, 2.5, 0.0))
+
+  def test_serialization_round_trip_preserves_footprint(self):
+    spot = TipSpot(name="spot", size_x=8.0, size_y=5.0, size_z=2.0, make_tip=self._make_tip)
+
+    round_tripped = TipSpot.deserialize(spot.serialize())
+
+    self.assertEqual(round_tripped.get_size_x(), spot.get_size_x())
+    self.assertEqual(round_tripped.get_size_y(), spot.get_size_y())


### PR DESCRIPTION
A `TipSpot` reports the two sizes it was created with swapped. `TipSpot.__init__` passes `size_x=size_y, size_y=size_x` up to `Resource` (`pylabrobot/resources/tip_rack.py:49-50`), so a spot built with `size_x=8.0, size_y=5.0` answers `get_size_x() == 5.0` and `get_size_y() == 8.0`. `center()` then returns `Coordinate(2.5, 4.0, 0)` instead of `Coordinate(4.0, 2.5, 0)`, and `TipSpot.deserialize(spot.serialize())` transposes the sizes a second time rather than reproducing the spot.

The constructor's own docstring settles which is which: "size_x: the size of the tip spot in the x direction", "size_y: the size of the tip spot in the y direction", and `Resource.get_size_x` is documented as the local size in the x direction. No other resource in the repo transposes its sizes, and nothing downstream compensates: the OT-2 driver targets `tip_spot.get_location_wrt(self.robot.deck, "c", "c", "b")` (`pylabrobot/opentrons/ot2/pipette.py:237`) and the STAR and Vantage backends add `tip_spot_a1.center()`, all of which read those two sizes back, so a non-square spot is approached half the difference off center in each axis.

Nothing in the repo trips it because every tip spot defined here is square, so the two sizes are equal. It shows up on a spot whose x and y footprint differ, which is what two separate parameters are for.

The fix passes each size to the axis it names. `TipSpotSizeTests` in `tip_rack_tests.py` builds an 8.0 by 5.0 mm spot and checks the reported sizes, `center()`, and a serialize/deserialize round trip; against the unfixed constructor it fails with `AssertionError: 5.0 != 8.0`.

Verified with `python -m pytest` (whole suite green), `make lint` and `make format-check` ("All checks passed!"), and `make typecheck` clean on the changed files.
