### PR TITLE
Fix ND-1000 on macOS: tolerant clear_halt + lamp-off reset

### DIFF
--- a/pylabrobot/thermo_fisher/nanodrop_1000/nanodrop_1000.py
+++ b/pylabrobot/thermo_fisher/nanodrop_1000/nanodrop_1000.py
@@ -36,9 +36,14 @@ class ThermoFisherNanoDrop1000:
   @classmethod
   def _configure_usb_device(cls, device) -> None:
     device.set_configuration()
-    device.clear_halt(cls.EP_OUT)
-    device.clear_halt(cls.EP_IN_HEAVY)
-    device.clear_halt(cls.EP_IN_COMM)
+    # clear_halt is not universally safe: on macOS libusb raises "Entity not found"
+    # for an endpoint that is not actually halted, and seabreeze (the reference
+    # Ocean Optics stack) does not call it at all. Best-effort per endpoint.
+    for ep in (cls.EP_OUT, cls.EP_IN_HEAVY, cls.EP_IN_COMM):
+      try:
+        device.clear_halt(ep)
+      except Exception:
+        logger.debug("clear_halt(0x%02x) failed; continuing", ep, exc_info=True)
 
   async def setup(self):
     """Initializes the USB connection."""
@@ -62,6 +67,12 @@ class ThermoFisherNanoDrop1000:
         # Ensure lamp and magnet are off before disconnect
         await self.send_command([0x03, 0x00])
         await self.send_command([0x0F, 0x00])
+        # The command-based lamp-off ([0x03, 0x00]) is unreliable on this firmware and
+        # intermittently leaves the lamp on. A USB reset clears the lamp latch
+        # deterministically, as the original driver did. Done at teardown only, so the
+        # re-enumeration a reset triggers is harmless here.
+        if self.io.dev is not None:
+          await asyncio.to_thread(self.io.dev.reset)
       except Exception:
         logger.warning("Failed to power down the NanoDrop cleanly", exc_info=True)
       await self.io.stop()


### PR DESCRIPTION
Tested #1166 on a physical NanoDrop ND-1000 on **macOS** — it drives the device and measures a correct paracetamol UV spectrum (λmax ≈ 243 nm). Two small fixes were needed, both in `pylabrobot/thermo_fisher/nanodrop_1000/nanodrop_1000.py` (+14/-3):

1. **`clear_halt` crash on macOS** — libusb raises `[Errno 2] Entity not found` for an endpoint that isn't actually halted, which crashes `setup()`. Made it best-effort per endpoint. (`python-seabreeze`, the reference Ocean Optics stack, doesn't call `clear_halt` at all.)

2. **Lamp not switching off** — the command-based lamp-off (`[0x03, 0x00]`) is unreliable on this device's firmware and intermittently leaves the lamp on. Restored a USB reset at teardown (as Jordvl's original driver did), which clears the lamp latch reliably. Re-enumeration is harmless at teardown.

Windows setup steps (Zadig / BOS reg key) untested — no Windows machine here.

Full write-up with plots + raw data: https://github.com/vcjdeboer/nanodrop-pylabrobot-demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018b3SXMWSzNMuNe6S48Yk7m